### PR TITLE
Fix the parent-id for the share-jail root

### DIFF
--- a/changelog/unreleased/fix-parent-id-for-shares.md
+++ b/changelog/unreleased/fix-parent-id-for-shares.md
@@ -1,0 +1,5 @@
+Bugfix: Fix the parent-id for the share-jail root
+
+Fix the parent-id for the share-jail root.
+
+https://github.com/owncloud/ocis/issues/9933

--- a/internal/grpc/services/sharesstorageprovider/sharesstorageprovider.go
+++ b/internal/grpc/services/sharesstorageprovider/sharesstorageprovider.go
@@ -748,11 +748,11 @@ func (s *service) Stat(ctx context.Context, req *provider.StatRequest) (*provide
 					SpaceId:   utils.ShareStorageSpaceID,
 					OpaqueId:  utils.ShareStorageSpaceID,
 				},
-				Type:          provider.ResourceType_RESOURCE_TYPE_CONTAINER,
-				Mtime:         mtime,
-				Path:          "/",
-				MimeType:      "httpd/unix-directory",
-				Size:          0,
+				Type:     provider.ResourceType_RESOURCE_TYPE_CONTAINER,
+				Mtime:    mtime,
+				Path:     "/",
+				MimeType: "httpd/unix-directory",
+				Size:     0,
 				PermissionSet: &provider.ResourcePermissions{
 					// TODO
 				},
@@ -866,6 +866,12 @@ func (s *service) ListContainer(ctx context.Context, req *provider.ListContainer
 				StorageId: utils.ShareStorageProviderID,
 				SpaceId:   utils.ShareStorageSpaceID,
 				OpaqueId:  share.GetShare().GetId().GetOpaqueId(),
+			}
+			// overwrite parent id with the share jail root
+			info.ParentId = &provider.ResourceId{
+				StorageId: utils.ShareStorageProviderID,
+				SpaceId:   utils.ShareStorageSpaceID,
+				OpaqueId:  utils.ShareStorageSpaceID,
 			}
 			info.Path = filepath.Base(share.MountPoint.Path)
 			info.Name = info.Path


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fix the parent-id for the share-jail root.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes [#10917](https://github.com/owncloud/ocis/issues/10917)