### PR TITLE
feat: OCM, propagate events for notification, direct to event.Publish

### DIFF
--- a/internal/grpc/services/ocmcore/ocmcore.go
+++ b/internal/grpc/services/ocmcore/ocmcore.go
@@ -176,12 +176,12 @@ func (s *service) CreateOCMCoreShare(ctx context.Context, req *ocmcore.CreateOCM
 	if s.eventStream != nil {
 		if err := events.Publish(ctx, s.eventStream, events.OCMCoreShareCreated{
 			ShareID:       share.Id.OpaqueId,
-			Executant:     req.GetSender(),
-			Sharer:        req.GetSender(),
-			GranteeUserID: req.GetShareWith(),
-			ItemID:        req.GetResourceId(),
-			ResourceName:  req.GetName(),
-			CTime:         now,
+			Executant:     share.Creator,
+			Sharer:        share.Creator,
+			GranteeUserID: share.Grantee.GetUserId(),
+			ItemID:        share.RemoteShareId,
+			ResourceName:  share.Name,
+			CTime:         share.Ctime,
 			Permissions:   permissions,
 		}); err != nil {
 			s.log.Error().Err(err).

--- a/internal/grpc/services/ocmcore/ocmcore.go
+++ b/internal/grpc/services/ocmcore/ocmcore.go
@@ -48,6 +48,7 @@ func init() {
 	rgrpc.Register("ocmcore", New)
 }
 
+// EventOptions are the configurable options for events
 type EventOptions struct {
 	Endpoint             string `mapstructure:"natsaddress"`
 	Cluster              string `mapstructure:"natsclusterid"`

--- a/pkg/events/ocmcore.go
+++ b/pkg/events/ocmcore.go
@@ -44,3 +44,19 @@ func (OCMCoreShareCreated) Unmarshal(v []byte) (interface{}, error) {
 	err := json.Unmarshal(v, &e)
 	return e, err
 }
+
+// OCMCoreShareDelete is emitted when an ocm share is requested for delete
+type OCMCoreShareDelete struct {
+	ShareID      string
+	Sharer       *user.UserId
+	Grantee      *user.UserId
+	ResourceName string
+	CTime        *types.Timestamp
+}
+
+// Unmarshal to fulfill umarshaller interface
+func (OCMCoreShareDelete) Unmarshal(v []byte) (interface{}, error) {
+	e := OCMCoreShareDelete{}
+	err := json.Unmarshal(v, &e)
+	return e, err
+}


### PR DESCRIPTION
oCIS dependency for enabling OCM Notifications
https://github.com/owncloud/ocis/issues/11042

Same functionality as https://github.com/owncloud/reva/pull/255 but with direct event.Publish() from ocmcore