### PR TITLE
limited the length of tags

### DIFF
--- a/changelog/unreleased/add-tags-validation.md
+++ b/changelog/unreleased/add-tags-validation.md
@@ -1,0 +1,5 @@
+Enhancement: Limit length of tags
+
+We limited the length of tags to avoid DOS attacks against the ocis server.
+
+https://github.com/owncloud/reva/pull/261

--- a/pkg/owncloud/ocs/capabilities.go
+++ b/pkg/owncloud/ocs/capabilities.go
@@ -114,6 +114,7 @@ type CapabilitiesCore struct {
 type CapabilitiesGraph struct {
 	PersonalDataExport ocsBool                `json:"personal-data-export" xml:"personal-data-export" mapstructure:"personal_data_export"`
 	Users              CapabilitiesGraphUsers `json:"users" xml:"users" mapstructure:"users"`
+	Tags               CapabilitiesGraphTags  `json:"tags" xml:"tags" mapstructure:"tags"`
 }
 
 // CapabilitiesPasswordPolicy hold the password policy capabilities
@@ -133,6 +134,11 @@ type CapabilitiesGraphUsers struct {
 	CreateDisabled             ocsBool  `json:"create_disabled" xml:"create_disabled" mapstructure:"create_disabled"`
 	DeleteDisabled             ocsBool  `json:"delete_disabled" xml:"delete_disabled" mapstructure:"delete_disabled"`
 	ChangePasswordSelfDisabled ocsBool  `json:"change_password_self_disabled" xml:"change_password_self_disabled" mapstructure:"change_password_self_disabled"`
+}
+
+// CapabilitiesGraphTags holds the graph tags capabilities
+type CapabilitiesGraphTags struct {
+	MaxTagLength int `json:"max_tag_length" xml:"max_tag_length" mapstructure:"max_tag_length"`
 }
 
 // Status holds basic status information

--- a/pkg/tags/tags.go
+++ b/pkg/tags/tags.go
@@ -19,7 +19,9 @@
 package tags
 
 import (
+	"fmt"
 	"strings"
+	"unicode/utf8"
 )
 
 var (
@@ -42,35 +44,45 @@ type Tags struct {
 // New creates a Tag struct from a slice of tags, e.g. ["tag1", "tag2"] or a list of tags, e.g. "tag1,tag2"
 func New(ts ...string) *Tags {
 	t := &Tags{sep: _tagsep, maxtags: _maxtags, exists: make(map[string]bool), t: make([]string, 0)}
-	t.addTags(ts)
+	t.addTags(t.normalize(ts))
 	return t
 }
 
 // Add appends a list of new tags and returns true if at least one was appended
 func (t *Tags) Add(ts ...string) bool {
-	return len(t.addTags(ts)) > 0
+	return len(t.addTags(t.normalize(ts))) > 0
+}
+
+// AddValidated appends a list of new tags and validates them using the provided validator function
+// It returns true if at least one was appended and an error if the validation failed
+func (t *Tags) AddValidated(validator func([]string) error, ts ...string) (bool, error) {
+	newTags := t.normalize(ts)
+	err := validator(newTags)
+	if err != nil {
+		return false, err
+	}
+	return len(t.addTags(newTags)) > 0, nil
 }
 
 // Remove removes a list of tags and returns true if at least one was removed
 func (t *Tags) Remove(s ...string) bool {
 	var removed bool
+	tags := t.normalize(s)
 
-	for _, tt := range s {
-		for _, tag := range strings.Split(tt, t.sep) {
-			if !t.exists[tag] {
-				continue
-			}
-
-			for i, tt := range t.t {
-				if tt == tag {
-					t.t = append(t.t[:i], t.t[i+1:]...)
-					break
-				}
-			}
-
-			delete(t.exists, tag)
-			removed = true
+	for _, tag := range tags {
+		if !t.exists[tag] {
+			continue
 		}
+
+		for i, tt := range t.t {
+			if tt == tag {
+				t.t = append(t.t[:i], t.t[i+1:]...)
+				break
+			}
+		}
+
+		delete(t.exists, tag)
+		removed = true
 	}
 	return removed
 }
@@ -86,31 +98,70 @@ func (t *Tags) AsSlice() []string {
 }
 
 // adds the tags and returns a list of added tags
+// the function receiving a normalized slice of tags, e.g.["tag1", "tag2"]
 func (t *Tags) addTags(s []string) []string {
-	added := make([]string, 0)
-	for _, tt := range s {
-		for _, tag := range strings.Split(tt, t.sep) {
-			if tag == "" {
-				// ignore empty tags
-				continue
-			}
-
-			if t.exists[tag] {
-				// tag is already existing
-				continue
-			}
-
-			if t.numtags >= t.maxtags {
-				// max number of tags reached. We return silently without warning anyone
-				break
-			}
-
-			added = append(added, tag)
-			t.exists[tag] = true
-			t.numtags++
+	added := make([]string, 0, len(t.t)+len(s))
+	for _, tag := range s {
+		if tag == "" {
+			// ignore empty tags
+			continue
 		}
+
+		if t.exists[tag] {
+			// tag is already existing
+			continue
+		}
+
+		if t.numtags >= t.maxtags {
+			// max number of tags reached. We return silently without warning anyone
+			break
+		}
+
+		added = append(added, tag)
+		t.exists[tag] = true
+		t.numtags++
 	}
 
 	t.t = append(added, t.t...)
 	return added
+}
+
+// normalize splits the tags and removes empty tags
+// the function receiving a slice of tags, e.g.["tag1", "tag2"] or a list of tags, e.g."tag1,tag2" or mixed.
+func (t *Tags) normalize(s []string) []string {
+	res := make([]string, 0, t.maxtags/2)
+	for _, tt := range s {
+		for _, tag := range strings.Split(tt, t.sep) {
+			ttr := strings.TrimSpace(tag)
+			if ttr == "" {
+				// ignore empty tags
+				continue
+			}
+			res = append(res, ttr)
+		}
+	}
+	return res
+}
+
+// MaxLengthValidator returns a function that validates the length of each tag in a slice
+func MaxLengthValidator(maxTagLength int) func([]string) error {
+	if maxTagLength <= 0 {
+		return func(tags []string) error { return nil }
+	}
+	return func(tags []string) error {
+		t := make([]string, 0, maxTagLength)
+		for _, tag := range tags {
+			if !utf8.ValidString(tag) {
+				return fmt.Errorf("tag [%s] contains invalid characters", tag)
+			}
+			if utf8.RuneCount([]byte(tag)) > maxTagLength {
+				t = append(t, tag)
+				continue
+			}
+		}
+		if len(t) > 0 {
+			return fmt.Errorf("tag [%s] too long, max length is %d", strings.Join(t, ", "), maxTagLength)
+		}
+		return nil
+	}
 }


### PR DESCRIPTION
We limited the length of tags to avoid DOS attacks against the ocis server.
Related [PR https://github.com/owncloud/ocis/pull/11231](https://github.com/owncloud/ocis/pull/11231)
