### PR TITLE
Bump the latest `ocis` commit ID in `drone.env`

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,4 +1,4 @@
 # The test runner source for API tests
-APITESTS_COMMITID=941f192f790049a4d132cfd8c8056d1c8f24e4d3
+APITESTS_COMMITID=2d821eb9902952f2e927d288a49a59420a1e69e8
 APITESTS_BRANCH=master
 APITESTS_REPO_GIT_URL=https://github.com/owncloud/ocis.git


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR only bumps the `drone.env` file to use the latest commit id from `ocis` `master` branch.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Related to: https://github.com/owncloud/QA/issues/881