### PR TITLE
fix: public space list errors, avoid 5xx on already exists

### DIFF
--- a/internal/grpc/services/publicshareprovider/publicshareprovider.go
+++ b/internal/grpc/services/publicshareprovider/publicshareprovider.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
@@ -451,10 +452,10 @@ func (s *service) ListPublicShares(ctx context.Context, req *link.ListPublicShar
 	user, _ := ctxpkg.ContextGetUser(ctx)
 
 	shares, err := s.sm.ListPublicShares(ctx, user, req.Filters, req.GetSign())
-	if err != nil {
-		log.Err(err).Msg("error listing shares")
+	if err != nil && !strings.Contains(err.Error(), errtypes.ERR_ALREADY_EXISTS) {
+		log.Err(err).Str("user", user.GetId().GetOpaqueId()).Msg("error listing shares")
 		return &link.ListPublicSharesResponse{
-			Status: status.NewInternal(ctx, "error listing public shares"),
+			Status: status.NewInternal(ctx, err.Error()),
 		}, nil
 	}
 

--- a/pkg/errtypes/errtypes.go
+++ b/pkg/errtypes/errtypes.go
@@ -99,7 +99,9 @@ func (e PreconditionFailed) IsPreconditionFailed() {}
 // AlreadyExists is the error to use when a resource something is not found.
 type AlreadyExists string
 
-func (e AlreadyExists) Error() string { return "error: already exists: " + string(e) }
+const ERR_ALREADY_EXISTS = "error: already exists:"
+
+func (e AlreadyExists) Error() string { return ERR_ALREADY_EXISTS + string(e) }
 
 // IsAlreadyExists implements the IsAlreadyExists interface.
 func (e AlreadyExists) IsAlreadyExists() {}


### PR DESCRIPTION
Changes to allow detect the AlreadyExist error on ocis side gracefully and not block whole members list with an error (5XX).

oCIS PR: https://github.com/owncloud/ocis/pull/11245
