### PR TITLE
Tusupload log errors

### DIFF
--- a/pkg/storage/utils/decomposedfs/upload/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload/upload.go
@@ -112,6 +112,13 @@ func (session *OcisSession) GetReader(ctx context.Context) (io.ReadCloser, error
 func (session *OcisSession) FinishUpload(ctx context.Context) error {
 	err := session.FinishUploadDecomposed(ctx)
 
+	if err != nil {
+		// this is part of the tusd integration and we might be able to
+		// log the error in another place
+		log := appctx.GetLogger(ctx)
+		log.Error().Err(err).Msg("failed to finish upload")
+	}
+
 	//  we need to return a tusd error here to make the tusd handler return the correct status code
 	switch err.(type) {
 	case errtypes.AlreadyExists:

--- a/pkg/storage/utils/decomposedfs/upload/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload/upload.go
@@ -66,7 +66,10 @@ func (session *OcisSession) WriteChunk(ctx context.Context, offset int64, src io
 	_, subspan := tracer.Start(ctx, "os.OpenFile")
 	file, err := os.OpenFile(session.binPath(), os.O_WRONLY|os.O_APPEND, defaultFilePerm)
 	subspan.End()
+
+	log := appctx.GetLogger(ctx)
 	if err != nil {
+		log.Error().Err(err).Msg("WriteChunk: error opening upload file")
 		return 0, err
 	}
 	defer file.Close()
@@ -84,6 +87,7 @@ func (session *OcisSession) WriteChunk(ctx context.Context, offset int64, src io
 	// However, for the ocis driver it's not important whether the stream has ended
 	// on purpose or accidentally.
 	if err != nil && err != io.ErrUnexpectedEOF {
+		log.Error().Err(err).Msg("WriteChunk: error copying data to upload file")
 		return n, err
 	}
 


### PR DESCRIPTION
**JIRA:** [#OCISDEV-39](https://kiteworks.atlassian.net/browse/OCISDEV-39)

Related to https://github.com/owncloud/enterprise/issues/7014#issuecomment-2847132493 .

Add more logs in order to identify the issue.

This seems to affect mainly to the tusd integration. Simple uploads report the error properly in the logs.
Note that this PR won't solve the issue, but it will make it visible in the logs instead of hide it in a generic "Internal server error" coming from tus.

Expected error message:
```
{"level":"error","service":"storage-users","pkg":"rhttp","datatx":"tus","uploadid":"/f7e2cead-7b41-4b50-95d3-9eabf09f41b7","request-id":"30e9bcb8a391/rtHRbX0SKm-000128","error":"Decomposedfs: could not write metadata: open /root/.ocis/storage/users/spaces/fa/07b66c-d3ec-4311-8977-bb4d0ca17420/nodes/56/6a/74/b8/-336b-45d5-9981-f8b703dd42a0.mpk: too many open files","time":"2025-05-07T16:09:12Z","line":"/home/juan/src/ocis/ocis/vendor/github.com/owncloud/reva/v2/pkg/storage/utils/decomposedfs/upload/upload.go:123","message":"failed to finish upload"}
```