### PR TITLE
Fix the graceful shutdown

### DIFF
--- a/changelog/unreleased/fix-graceful-shutdown.md
+++ b/changelog/unreleased/fix-graceful-shutdown.md
@@ -1,0 +1,6 @@
+Bugfix: Fix the graceful shutdown
+
+Fix the graceful shutdown.
+
+https://github.com/owncloud/reva/pull/272
+https://github.com/owncloud/ocis/issues/11170

--- a/cmd/revad/runtime/drivenserver.go
+++ b/cmd/revad/runtime/drivenserver.go
@@ -2,10 +2,10 @@ package runtime
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"os"
-	"sync"
 	"time"
 
 	"github.com/owncloud/reva/v2/pkg/registry"
@@ -14,30 +14,201 @@ import (
 	"github.com/rs/zerolog"
 )
 
-type drivenServer struct {
-	rhttpServer             *rhttp.Server
-	rgrpcServer             *rgrpc.Server
-	gracefulShutdownTimeout int
-	pidFile                 string
-	log                     *zerolog.Logger
-}
+const (
+	HTTP = iota
+	GRPC
+)
 
-// RevaDrivenServer is an interface that defines the methods for starting and stopping reva services.
+// RevaDrivenServer is an interface that defines the methods for starting and stopping reva HTTP/GRPC services.
 type RevaDrivenServer interface {
 	Start() error
 	Stop() error
 }
 
-// RunDrivenServerWithOptions runs a revad server w/o watcher with the given config file, pid file and options.
+// NewDrivenHTTPServerWithOptions runs a revad server w/o watcher with the given config file and options.
 // Use it in cases where you want to run a revad server without the need for a watcher and the os signal handling as a part of another runtime.
-func RunDrivenServerWithOptions(mainConf map[string]interface{}, pidFile string, opts ...Option) RevaDrivenServer {
+// Returns nil if no http server is configured in the config file.
+// Throws a fatal error if the http server cannot be created.
+func NewDrivenHTTPServerWithOptions(mainConf map[string]interface{}, opts ...Option) RevaDrivenServer {
+	if !isEnabledHTTP(mainConf) {
+		return nil
+	}
 	options := newOptions(opts...)
+	if srv := newServer(HTTP, mainConf, options); srv != nil {
+		return srv
+	}
+	options.Logger.Fatal().Msg("nothing to do, no http enabled_services declared in config")
+	return nil
+}
+
+// NewDrivenGRPCServerWithOptions runs a revad server w/o watcher with the given config file and options.
+// Use it in cases where you want to run a revad server without the need for a watcher and the os signal handling as a part of another runtime.
+// Returns nil if no grpc server is configured in the config file.
+// Throws a fatal error if the grpc server cannot be created.
+func NewDrivenGRPCServerWithOptions(mainConf map[string]interface{}, opts ...Option) RevaDrivenServer {
+	if !isEnabledGRPC(mainConf) {
+		return nil
+	}
+	options := newOptions(opts...)
+	if srv := newServer(GRPC, mainConf, options); srv != nil {
+		return srv
+	}
+	options.Logger.Fatal().Msg("nothing to do, no grpc enabled_services declared in config")
+	return nil
+}
+
+// drivenHTTPServer represents an HTTP server that implements the RevaDrivenServer interface.
+type drivenHTTPServer struct {
+	rhttpServer             *rhttp.Server
+	log                     *zerolog.Logger
+	gracefulShutdownTimeout int
+}
+
+// Start runs the revad HTTP drivenServer with the given config file.
+func (s *drivenHTTPServer) Start() error {
+	if s.rhttpServer == nil {
+		err := fmt.Errorf("rhttp server not initialized")
+		s.log.Fatal().Err(err).Send()
+		return err
+	}
+	ln, err := net.Listen(s.rhttpServer.Network(), s.rhttpServer.Address())
+	if err != nil {
+		s.log.Fatal().Err(err).Send()
+		return err
+	}
+	if err = s.rhttpServer.Start(ln); err != nil {
+		if !errors.Is(err, http.ErrServerClosed) {
+			s.log.Error().Err(err).Msg("http server error")
+		}
+		return err
+	}
+	return nil
+}
+
+// Stop gracefully stops the revad drivenServer.
+func (s *drivenHTTPServer) Stop() error {
+	if s.rhttpServer == nil {
+		return nil
+	}
+	done := make(chan struct{})
+	go func() {
+		s.gracefulStopHTTPServer()
+		close(done)
+	}()
+
+	select {
+	case <-time.After(time.Duration(s.gracefulShutdownTimeout) * time.Second):
+		s.log.Info().Msg("graceful shutdown timeout reached. running hard shutdown")
+		s.stopHTTPServer()
+		return nil
+	case <-done:
+		s.log.Info().Msg("all revad services gracefully stopped")
+		return nil
+	}
+}
+
+func (s *drivenHTTPServer) stopHTTPServer() {
+	if s.rhttpServer == nil {
+		return
+	}
+	s.log.Info().Msgf("fd to %s:%s abruptly closing", s.rhttpServer.Network(), s.rhttpServer.Address())
+	err := s.rhttpServer.Stop()
+	if err != nil {
+		s.log.Error().Err(err).Msg("error stopping server")
+	}
+}
+
+func (s *drivenHTTPServer) gracefulStopHTTPServer() {
+	if s.rhttpServer != nil {
+		s.log.Info().Msgf("fd to %s:%s gracefully closing", s.rhttpServer.Network(), s.rhttpServer.Address())
+		if err := s.rhttpServer.GracefulStop(); err != nil {
+			s.log.Error().Err(err).Msg("error gracefully stopping server")
+			s.rhttpServer.Stop()
+		}
+	}
+}
+
+// drivenGRPCServer represents a GRPC server that implements the RevaDrivenServer interface.
+type drivenGRPCServer struct {
+	rgrpcServer             *rgrpc.Server
+	log                     *zerolog.Logger
+	gracefulShutdownTimeout int
+}
+
+// Start runs the revad GRPC drivenServer with the given config file.
+func (s *drivenGRPCServer) Start() error {
+	if s.rgrpcServer == nil {
+		err := fmt.Errorf("rgrpc server not initialized")
+		s.log.Fatal().Err(err).Send()
+		return err
+	}
+	ln, err := net.Listen(s.rgrpcServer.Network(), s.rgrpcServer.Address())
+	if err != nil {
+		s.log.Fatal().Err(err).Send()
+		return err
+	}
+	if err = s.rgrpcServer.Start(ln); err != nil {
+		if !errors.Is(err, http.ErrServerClosed) {
+			s.log.Error().Err(err).Msg("grpc server error")
+		}
+		return err
+	}
+	return nil
+}
+
+// Stop gracefully stops the revad drivenServer.
+func (s *drivenGRPCServer) Stop() error {
+	if s.rgrpcServer == nil {
+		return nil
+	}
+
+	done := make(chan struct{})
+	go func() {
+		s.gracefulStopGRPCServer()
+		close(done)
+	}()
+
+	select {
+	case <-time.After(time.Duration(s.gracefulShutdownTimeout) * time.Second):
+		s.log.Info().Msg("graceful shutdown timeout reached. running hard shutdown")
+		s.stopGRPCServer()
+		return nil
+	case <-done:
+		s.log.Info().Msg("all revad services gracefully stopped")
+		return nil
+	}
+}
+
+func (s *drivenGRPCServer) gracefulStopGRPCServer() {
+	if s.rgrpcServer != nil {
+		s.log.Info().Msgf("fd to %s:%s gracefully closing", s.rgrpcServer.Network(), s.rgrpcServer.Address())
+		if err := s.rgrpcServer.GracefulStop(); err != nil {
+			s.log.Error().Err(err).Msg("error gracefully stopping server")
+			s.rgrpcServer.Stop()
+		}
+	}
+}
+
+func (s *drivenGRPCServer) stopGRPCServer() {
+	if s.rgrpcServer == nil {
+		return
+	}
+	s.log.Info().Msgf("fd to %s:%s abruptly closing", s.rgrpcServer.Network(), s.rgrpcServer.Address())
+	err := s.rgrpcServer.Stop()
+	if err != nil {
+		s.log.Error().Err(err).Msg("error stopping server")
+	}
+}
+
+// newServer runs a revad server w/o watcher with the given config file and options.
+func newServer(kind int, mainConf map[string]interface{}, options Options) RevaDrivenServer {
 	parseSharedConfOrDie(mainConf["shared"])
 	coreConf := parseCoreConfOrDie(mainConf["core"])
 	log := options.Logger
 
 	if err := registry.Init(options.Registry); err != nil {
 		log.Fatal().Err(err).Msg("failed to initialize registry client")
+		return nil
 	}
 
 	host, _ := os.Hostname()
@@ -50,187 +221,41 @@ func RunDrivenServerWithOptions(mainConf map[string]interface{}, pidFile string,
 	}
 	initCPUCount(coreConf, log)
 
-	server := &drivenServer{
-		rhttpServer: initHTTPServer(mainConf, &options),
-		rgrpcServer: initGRPCServer(mainConf, &options),
-		log:         log,
-		pidFile:     pidFile,
-	}
-	server.gracefulShutdownTimeout = 30
+	gracefulShutdownTimeout := 20
 	if coreConf.GracefulShutdownTimeout > 0 {
-		server.gracefulShutdownTimeout = coreConf.GracefulShutdownTimeout
+		gracefulShutdownTimeout = coreConf.GracefulShutdownTimeout
 	}
-
-	if server.rhttpServer == nil && server.rgrpcServer == nil {
-		log.Fatal().Msg("nothing to do, no grpc/http enabled_services declared in config")
+	switch kind {
+	case HTTP:
+		return initHTTPServer(mainConf, &options, gracefulShutdownTimeout)
+	case GRPC:
+		return initGRPCServer(mainConf, &options, gracefulShutdownTimeout)
 	}
-	return server
+	return nil
 }
 
-// Start runs the revad drivenServer with the given config file and pid file.
-func (s *drivenServer) Start() error {
-	errCh := make(chan error, 2)
-	done := make(chan struct{}, 1)
-	wg := &sync.WaitGroup{}
-
-	if s.rhttpServer != nil {
-		wg.Add(1)
-		go func() {
-			errCh <- s.startHTTPServer()
-			wg.Done()
-		}()
-	}
-	if s.rgrpcServer != nil {
-		wg.Add(1)
-		go func() {
-			errCh <- s.startGRPCServer()
-			wg.Done()
-		}()
-	}
-
-	go func() {
-		wg.Wait()
-		close(done)
-	}()
-	for {
-		select {
-		case err := <-errCh:
-			if err != nil && !errors.Is(err, http.ErrServerClosed) {
-				return err
-			}
-		case <-done:
-			return nil
-		}
-	}
-}
-
-// Stop gracefully stops the revad drivenServer.
-func (s *drivenServer) Stop() error {
-	wg := &sync.WaitGroup{}
-
-	s.gracefulStopHTTPServer(wg)
-	s.gracefulStopGRPCServer(wg)
-
-	done := make(chan struct{})
-	go func() {
-		wg.Wait()
-		close(done)
-	}()
-
-	select {
-	case <-time.After(time.Duration(s.gracefulShutdownTimeout) * time.Second):
-		s.log.Info().Msg("graceful shutdown timeout reached. running hard shutdown")
-		s.stopHTTPServer()
-		s.stopGRPCServer()
-		return nil
-	case <-done:
-		s.log.Info().Msg("all revad services gracefully stopped")
+func initHTTPServer(mainConf map[string]interface{}, options *Options, timeout int) RevaDrivenServer {
+	s, err := getHTTPServer(mainConf["http"], options.Logger, options.TraceProvider)
+	if err != nil {
+		options.Logger.Fatal().Err(err).Msg("error creating http server")
 		return nil
 	}
+	return &drivenHTTPServer{
+		rhttpServer:             s,
+		log:                     options.Logger,
+		gracefulShutdownTimeout: timeout,
+	}
 }
 
-func (s *drivenServer) startHTTPServer() error {
-	if s.rhttpServer == nil {
-		s.log.Fatal().Msg("http server not initialized")
-	}
-	ln, err := net.Listen(s.rhttpServer.Network(), s.rhttpServer.Address())
+func initGRPCServer(mainConf map[string]interface{}, options *Options, timeout int) RevaDrivenServer {
+	s, err := getGRPCServer(mainConf["grpc"], options.Logger, options.TraceProvider)
 	if err != nil {
-		s.log.Fatal().Err(err).Send()
+		options.Logger.Fatal().Err(err).Msg("error creating grpc server")
+		return nil
 	}
-	if err = s.rhttpServer.Start(ln); err != nil {
-		if !errors.Is(err, http.ErrServerClosed) {
-			s.log.Error().Err(err).Msg("http server error")
-		}
-		return err
+	return &drivenGRPCServer{
+		rgrpcServer:             s,
+		gracefulShutdownTimeout: timeout,
+		log:                     options.Logger,
 	}
-	return nil
-}
-
-func (s *drivenServer) startGRPCServer() error {
-	if s.rgrpcServer == nil {
-		s.log.Fatal().Msg("grcp server not initialized")
-	}
-	ln, err := net.Listen(s.rgrpcServer.Network(), s.rgrpcServer.Address())
-	if err != nil {
-		s.log.Fatal().Err(err).Send()
-	}
-	if err = s.rgrpcServer.Start(ln); err != nil {
-		if !errors.Is(err, http.ErrServerClosed) {
-			s.log.Error().Err(err).Msg("grpc server error")
-		}
-		return err
-	}
-	return nil
-}
-
-func (s *drivenServer) gracefulStopHTTPServer(wg *sync.WaitGroup) {
-	if s.rhttpServer != nil {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			s.log.Info().Msgf("fd to %s:%s gracefully closing", s.rhttpServer.Network(), s.rhttpServer.Address())
-			if err := s.rhttpServer.GracefulStop(); err != nil {
-				s.log.Error().Err(err).Msg("error gracefully stopping server")
-				s.rhttpServer.Stop()
-			}
-		}()
-	}
-}
-
-func (s *drivenServer) gracefulStopGRPCServer(wg *sync.WaitGroup) {
-	if s.rgrpcServer != nil {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			s.log.Info().Msgf("fd to %s:%s gracefully closing", s.rgrpcServer.Network(), s.rgrpcServer.Address())
-			if err := s.rgrpcServer.GracefulStop(); err != nil {
-				s.log.Error().Err(err).Msg("error gracefully stopping server")
-				s.rgrpcServer.Stop()
-			}
-		}()
-	}
-}
-
-func (s *drivenServer) stopHTTPServer() {
-	if s.rhttpServer == nil {
-		return
-	}
-	s.log.Info().Msgf("fd to %s:%s abruptly closing", s.rhttpServer.Network(), s.rhttpServer.Address())
-	err := s.rhttpServer.Stop()
-	if err != nil {
-		s.log.Error().Err(err).Msg("error stopping server")
-	}
-}
-
-func (s *drivenServer) stopGRPCServer() {
-	if s.rgrpcServer == nil {
-		return
-	}
-	s.log.Info().Msgf("fd to %s:%s abruptly closing", s.rgrpcServer.Network(), s.rgrpcServer.Address())
-	err := s.rgrpcServer.Stop()
-	if err != nil {
-		s.log.Error().Err(err).Msg("error stopping server")
-	}
-}
-
-func initHTTPServer(mainConf map[string]interface{}, options *Options) *rhttp.Server {
-	if isEnabledHTTP(mainConf) {
-		s, err := getHTTPServer(mainConf["http"], options.Logger, options.TraceProvider)
-		if err != nil {
-			options.Logger.Fatal().Err(err).Msg("error creating http server")
-		}
-		return s
-	}
-	return nil
-}
-
-func initGRPCServer(mainConf map[string]interface{}, options *Options) *rgrpc.Server {
-	if isEnabledGRPC(mainConf) {
-		s, err := getGRPCServer(mainConf["grpc"], options.Logger, options.TraceProvider)
-		if err != nil {
-			options.Logger.Fatal().Err(err).Msg("error creating grpc server")
-		}
-		return s
-	}
-	return nil
 }

--- a/cmd/revad/runtime/drivenserver.go
+++ b/cmd/revad/runtime/drivenserver.go
@@ -9,8 +9,6 @@ import (
 	"time"
 
 	"github.com/owncloud/reva/v2/pkg/registry"
-	"github.com/owncloud/reva/v2/pkg/rgrpc"
-	"github.com/owncloud/reva/v2/pkg/rhttp"
 	"github.com/rs/zerolog"
 )
 
@@ -25,10 +23,28 @@ type RevaDrivenServer interface {
 	Stop() error
 }
 
+// revaServer is an interface that defines the methods for starting and stopping a reva server.
+type revaServer interface {
+	Start(ln net.Listener) error
+	Stop() error
+	GracefulStop() error
+	Network() string
+	Address() string
+}
+
+// sever represents a generic reva server that implements the RevaDrivenServer interface.
+type server struct {
+	srv                     revaServer
+	log                     *zerolog.Logger
+	gracefulShutdownTimeout time.Duration
+	protocol                string
+}
+
 // NewDrivenHTTPServerWithOptions runs a revad server w/o watcher with the given config file and options.
 // Use it in cases where you want to run a revad server without the need for a watcher and the os signal handling as a part of another runtime.
 // Returns nil if no http server is configured in the config file.
-// Throws a fatal error if the http server cannot be created.
+// The GracefulShutdownTimeout set to default 20 seconds and can be overridden in the core config.
+// Logging a fatal error and exit with code 1 if the http server cannot be created.
 func NewDrivenHTTPServerWithOptions(mainConf map[string]interface{}, opts ...Option) RevaDrivenServer {
 	if !isEnabledHTTP(mainConf) {
 		return nil
@@ -44,7 +60,8 @@ func NewDrivenHTTPServerWithOptions(mainConf map[string]interface{}, opts ...Opt
 // NewDrivenGRPCServerWithOptions runs a revad server w/o watcher with the given config file and options.
 // Use it in cases where you want to run a revad server without the need for a watcher and the os signal handling as a part of another runtime.
 // Returns nil if no grpc server is configured in the config file.
-// Throws a fatal error if the grpc server cannot be created.
+// The GracefulShutdownTimeout set to default 20 seconds and can be overridden in the core config.
+// Logging a fatal error and exit with code 1 if the grpc server cannot be created.
 func NewDrivenGRPCServerWithOptions(mainConf map[string]interface{}, opts ...Option) RevaDrivenServer {
 	if !isEnabledGRPC(mainConf) {
 		return nil
@@ -57,151 +74,58 @@ func NewDrivenGRPCServerWithOptions(mainConf map[string]interface{}, opts ...Opt
 	return nil
 }
 
-// drivenHTTPServer represents an HTTP server that implements the RevaDrivenServer interface.
-type drivenHTTPServer struct {
-	rhttpServer             *rhttp.Server
-	log                     *zerolog.Logger
-	gracefulShutdownTimeout int
-}
-
-// Start runs the revad HTTP drivenServer with the given config file.
-func (s *drivenHTTPServer) Start() error {
-	if s.rhttpServer == nil {
-		err := fmt.Errorf("rhttp server not initialized")
+// Start starts the reva server, listening on the configured address and network.
+func (s *server) Start() error {
+	if s.srv == nil {
+		err := fmt.Errorf("reva %s server not initialized", s.protocol)
 		s.log.Fatal().Err(err).Send()
 		return err
 	}
-	ln, err := net.Listen(s.rhttpServer.Network(), s.rhttpServer.Address())
+	ln, err := net.Listen(s.srv.Network(), s.srv.Address())
 	if err != nil {
 		s.log.Fatal().Err(err).Send()
 		return err
 	}
-	if err = s.rhttpServer.Start(ln); err != nil {
+	if err = s.srv.Start(ln); err != nil {
 		if !errors.Is(err, http.ErrServerClosed) {
-			s.log.Error().Err(err).Msg("http server error")
+			s.log.Error().Err(err).Msgf("reva %s server error", s.protocol)
 		}
 		return err
 	}
 	return nil
 }
 
-// Stop gracefully stops the revad drivenServer.
-func (s *drivenHTTPServer) Stop() error {
-	if s.rhttpServer == nil {
+// Stop gracefully stops the reva server, waiting for the graceful shutdown timeout.
+func (s *server) Stop() error {
+	if s.srv == nil {
 		return nil
 	}
 	done := make(chan struct{})
 	go func() {
-		s.gracefulStopHTTPServer()
+		s.log.Info().Msgf("gracefully stopping %s:%s reva %s server", s.srv.Network(), s.srv.Address(), s.protocol)
+		if err := s.srv.GracefulStop(); err != nil {
+			s.log.Error().Err(err).Msgf("error gracefully stopping reva %s server", s.protocol)
+			s.srv.Stop()
+		}
 		close(done)
 	}()
 
 	select {
-	case <-time.After(time.Duration(s.gracefulShutdownTimeout) * time.Second):
+	case <-time.After(s.gracefulShutdownTimeout):
 		s.log.Info().Msg("graceful shutdown timeout reached. running hard shutdown")
-		s.stopHTTPServer()
+		err := s.srv.Stop()
+		if err != nil {
+			s.log.Error().Err(err).Msgf("error stopping reva %s server", s.protocol)
+		}
 		return nil
 	case <-done:
-		s.log.Info().Msg("all revad services gracefully stopped")
+		s.log.Info().Msgf("reva %s server gracefully stopped", s.protocol)
 		return nil
-	}
-}
-
-func (s *drivenHTTPServer) stopHTTPServer() {
-	if s.rhttpServer == nil {
-		return
-	}
-	s.log.Info().Msgf("fd to %s:%s abruptly closing", s.rhttpServer.Network(), s.rhttpServer.Address())
-	err := s.rhttpServer.Stop()
-	if err != nil {
-		s.log.Error().Err(err).Msg("error stopping server")
-	}
-}
-
-func (s *drivenHTTPServer) gracefulStopHTTPServer() {
-	if s.rhttpServer != nil {
-		s.log.Info().Msgf("fd to %s:%s gracefully closing", s.rhttpServer.Network(), s.rhttpServer.Address())
-		if err := s.rhttpServer.GracefulStop(); err != nil {
-			s.log.Error().Err(err).Msg("error gracefully stopping server")
-			s.rhttpServer.Stop()
-		}
-	}
-}
-
-// drivenGRPCServer represents a GRPC server that implements the RevaDrivenServer interface.
-type drivenGRPCServer struct {
-	rgrpcServer             *rgrpc.Server
-	log                     *zerolog.Logger
-	gracefulShutdownTimeout int
-}
-
-// Start runs the revad GRPC drivenServer with the given config file.
-func (s *drivenGRPCServer) Start() error {
-	if s.rgrpcServer == nil {
-		err := fmt.Errorf("rgrpc server not initialized")
-		s.log.Fatal().Err(err).Send()
-		return err
-	}
-	ln, err := net.Listen(s.rgrpcServer.Network(), s.rgrpcServer.Address())
-	if err != nil {
-		s.log.Fatal().Err(err).Send()
-		return err
-	}
-	if err = s.rgrpcServer.Start(ln); err != nil {
-		if !errors.Is(err, http.ErrServerClosed) {
-			s.log.Error().Err(err).Msg("grpc server error")
-		}
-		return err
-	}
-	return nil
-}
-
-// Stop gracefully stops the revad drivenServer.
-func (s *drivenGRPCServer) Stop() error {
-	if s.rgrpcServer == nil {
-		return nil
-	}
-
-	done := make(chan struct{})
-	go func() {
-		s.gracefulStopGRPCServer()
-		close(done)
-	}()
-
-	select {
-	case <-time.After(time.Duration(s.gracefulShutdownTimeout) * time.Second):
-		s.log.Info().Msg("graceful shutdown timeout reached. running hard shutdown")
-		s.stopGRPCServer()
-		return nil
-	case <-done:
-		s.log.Info().Msg("all revad services gracefully stopped")
-		return nil
-	}
-}
-
-func (s *drivenGRPCServer) gracefulStopGRPCServer() {
-	if s.rgrpcServer != nil {
-		s.log.Info().Msgf("fd to %s:%s gracefully closing", s.rgrpcServer.Network(), s.rgrpcServer.Address())
-		if err := s.rgrpcServer.GracefulStop(); err != nil {
-			s.log.Error().Err(err).Msg("error gracefully stopping server")
-			s.rgrpcServer.Stop()
-		}
-	}
-}
-
-func (s *drivenGRPCServer) stopGRPCServer() {
-	if s.rgrpcServer == nil {
-		return
-	}
-	s.log.Info().Msgf("fd to %s:%s abruptly closing", s.rgrpcServer.Network(), s.rgrpcServer.Address())
-	err := s.rgrpcServer.Stop()
-	if err != nil {
-		s.log.Error().Err(err).Msg("error stopping server")
 	}
 }
 
 // newServer runs a revad server w/o watcher with the given config file and options.
-func newServer(kind int, mainConf map[string]interface{}, options Options) RevaDrivenServer {
+func newServer(protocol int, mainConf map[string]interface{}, options Options) RevaDrivenServer {
 	parseSharedConfOrDie(mainConf["shared"])
 	coreConf := parseCoreConfOrDie(mainConf["core"])
 	log := options.Logger
@@ -221,41 +145,34 @@ func newServer(kind int, mainConf map[string]interface{}, options Options) RevaD
 	}
 	initCPUCount(coreConf, log)
 
-	gracefulShutdownTimeout := 20
+	gracefulShutdownTimeout := 20 * time.Second
 	if coreConf.GracefulShutdownTimeout > 0 {
-		gracefulShutdownTimeout = coreConf.GracefulShutdownTimeout
+		gracefulShutdownTimeout = time.Duration(coreConf.GracefulShutdownTimeout) * time.Second
 	}
-	switch kind {
+
+	srv := &server{
+		log:                     options.Logger,
+		gracefulShutdownTimeout: gracefulShutdownTimeout,
+	}
+	switch protocol {
 	case HTTP:
-		return initHTTPServer(mainConf, &options, gracefulShutdownTimeout)
+		s, err := getHTTPServer(mainConf["http"], options.Logger, options.TraceProvider)
+		if err != nil {
+			options.Logger.Fatal().Err(err).Msg("error creating http server")
+			return nil
+		}
+		srv.srv = s
+		srv.protocol = "http"
+		return srv
 	case GRPC:
-		return initGRPCServer(mainConf, &options, gracefulShutdownTimeout)
+		s, err := getGRPCServer(mainConf["grpc"], options.Logger, options.TraceProvider)
+		if err != nil {
+			options.Logger.Fatal().Err(err).Msg("error creating grpc server")
+			return nil
+		}
+		srv.srv = s
+		srv.protocol = "grpc"
+		return srv
 	}
 	return nil
-}
-
-func initHTTPServer(mainConf map[string]interface{}, options *Options, timeout int) RevaDrivenServer {
-	s, err := getHTTPServer(mainConf["http"], options.Logger, options.TraceProvider)
-	if err != nil {
-		options.Logger.Fatal().Err(err).Msg("error creating http server")
-		return nil
-	}
-	return &drivenHTTPServer{
-		rhttpServer:             s,
-		log:                     options.Logger,
-		gracefulShutdownTimeout: timeout,
-	}
-}
-
-func initGRPCServer(mainConf map[string]interface{}, options *Options, timeout int) RevaDrivenServer {
-	s, err := getGRPCServer(mainConf["grpc"], options.Logger, options.TraceProvider)
-	if err != nil {
-		options.Logger.Fatal().Err(err).Msg("error creating grpc server")
-		return nil
-	}
-	return &drivenGRPCServer{
-		rgrpcServer:             s,
-		gracefulShutdownTimeout: timeout,
-		log:                     options.Logger,
-	}
 }

--- a/cmd/revad/runtime/drivenserver.go
+++ b/cmd/revad/runtime/drivenserver.go
@@ -1,0 +1,230 @@
+package runtime
+
+import (
+	"errors"
+	"net"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/owncloud/reva/v2/pkg/registry"
+	"github.com/owncloud/reva/v2/pkg/rgrpc"
+	"github.com/owncloud/reva/v2/pkg/rhttp"
+	"github.com/rs/zerolog"
+)
+
+type drivenServer struct {
+	rhttpServer             *rhttp.Server
+	rgrpcServer             *rgrpc.Server
+	gracefulShutdownTimeout int
+	pidFile                 string
+	log                     *zerolog.Logger
+}
+
+// RevaDrivenServer is an interface that defines the methods for starting and stopping reva services.
+type RevaDrivenServer interface {
+	Start() error
+	Stop() error
+}
+
+// RunDrivenServerWithOptions runs a revad server w/o watcher with the given config file, pid file and options.
+// Use it in cases where you want to run a revad server without the need for a watcher and the os signal handling as a part of another runtime.
+func RunDrivenServerWithOptions(mainConf map[string]interface{}, pidFile string, opts ...Option) RevaDrivenServer {
+	options := newOptions(opts...)
+	parseSharedConfOrDie(mainConf["shared"])
+	coreConf := parseCoreConfOrDie(mainConf["core"])
+	log := options.Logger
+
+	if err := registry.Init(options.Registry); err != nil {
+		log.Fatal().Err(err).Msg("failed to initialize registry client")
+	}
+
+	host, _ := os.Hostname()
+	log.Info().Msgf("host info: %s", host)
+
+	// Only initialize tracing if we didn't get a tracer provider.
+	if options.TraceProvider == nil {
+		log.Debug().Msg("no pre-existing tracer given, initializing tracing")
+		options.TraceProvider = initTracing(coreConf)
+	}
+	initCPUCount(coreConf, log)
+
+	server := &drivenServer{
+		rhttpServer: initHTTPServer(mainConf, &options),
+		rgrpcServer: initGRPCServer(mainConf, &options),
+		log:         log,
+		pidFile:     pidFile,
+	}
+	server.gracefulShutdownTimeout = 30
+	if coreConf.GracefulShutdownTimeout > 0 {
+		server.gracefulShutdownTimeout = coreConf.GracefulShutdownTimeout
+	}
+
+	if server.rhttpServer == nil && server.rgrpcServer == nil {
+		log.Fatal().Msg("nothing to do, no grpc/http enabled_services declared in config")
+	}
+	return server
+}
+
+// Start runs the revad drivenServer with the given config file and pid file.
+func (s *drivenServer) Start() error {
+	errCh := make(chan error, 2)
+	wg := &sync.WaitGroup{}
+
+	if s.rhttpServer != nil {
+		wg.Add(1)
+		go func() {
+			errCh <- s.startHTTPServer()
+			wg.Done()
+		}()
+	}
+	if s.rgrpcServer != nil {
+		wg.Add(1)
+		go func() {
+			errCh <- s.startGRPCServer()
+			wg.Done()
+		}()
+	}
+
+	go func() {
+		wg.Wait()
+		close(errCh)
+	}()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			s.log.Error().Err(err).Msg("error starting revad service")
+			return err
+		}
+		return nil
+	}
+}
+
+// Stop gracefully stops the revad drivenServer.
+func (s *drivenServer) Stop() error {
+	wg := &sync.WaitGroup{}
+
+	s.gracefulStopHTTPServer(wg)
+	s.gracefulStopGRPCServer(wg)
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-time.After(time.Duration(s.gracefulShutdownTimeout) * time.Second):
+		s.log.Info().Msg("graceful shutdown timeout reached. running hard shutdown")
+		s.stopHTTPServer()
+		s.stopGRPCServer()
+		return nil
+	case <-done:
+		s.log.Info().Msg("all revad services gracefully stopped")
+		return nil
+	}
+}
+
+func (s *drivenServer) startHTTPServer() error {
+	if s.rhttpServer == nil {
+		s.log.Fatal().Msg("http server not initialized")
+	}
+	ln, err := net.Listen(s.rhttpServer.Network(), s.rhttpServer.Address())
+	if err != nil {
+		s.log.Fatal().Err(err).Send()
+	}
+	if err = s.rhttpServer.Start(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		s.log.Error().Err(err).Msg("http server error")
+		return err
+	}
+	return nil
+}
+
+func (s *drivenServer) startGRPCServer() error {
+	if s.rgrpcServer == nil {
+		s.log.Fatal().Msg("grcp server not initialized")
+	}
+	ln, err := net.Listen(s.rgrpcServer.Network(), s.rgrpcServer.Address())
+	if err != nil {
+		s.log.Fatal().Err(err).Send()
+	}
+	if err = s.rgrpcServer.Start(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		s.log.Error().Err(err).Msg("grpc server error")
+		return err
+	}
+	return nil
+}
+
+func (s *drivenServer) gracefulStopHTTPServer(wg *sync.WaitGroup) {
+	if s.rhttpServer != nil {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			s.log.Info().Msgf("fd to %s:%s gracefully closing", s.rhttpServer.Network(), s.rhttpServer.Address())
+			if err := s.rhttpServer.GracefulStop(); err != nil {
+				s.log.Error().Err(err).Msg("error stopping server")
+				s.rhttpServer.Stop()
+			}
+		}()
+	}
+}
+
+func (s *drivenServer) gracefulStopGRPCServer(wg *sync.WaitGroup) {
+	if s.rgrpcServer != nil {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			s.log.Info().Msgf("fd to %s:%s gracefully closing", s.rgrpcServer.Network(), s.rgrpcServer.Address())
+			if err := s.rgrpcServer.GracefulStop(); err != nil {
+				s.log.Error().Err(err).Msg("error gracefully stopping server")
+				s.rgrpcServer.Stop()
+			}
+		}()
+	}
+}
+
+func (s *drivenServer) stopHTTPServer() {
+	if s.rhttpServer == nil {
+		return
+	}
+	s.log.Info().Msgf("fd to %s:%s abruptly closing", s.rhttpServer.Network(), s.rhttpServer.Address())
+	err := s.rhttpServer.Stop()
+	if err != nil {
+		s.log.Error().Err(err).Msg("error stopping server")
+	}
+}
+
+func (s *drivenServer) stopGRPCServer() {
+	if s.rgrpcServer == nil {
+		return
+	}
+	s.log.Info().Msgf("fd to %s:%s abruptly closing", s.rgrpcServer.Network(), s.rgrpcServer.Address())
+	err := s.rgrpcServer.Stop()
+	if err != nil {
+		s.log.Error().Err(err).Msg("error stopping server")
+	}
+}
+
+func initHTTPServer(mainConf map[string]interface{}, options *Options) *rhttp.Server {
+	if isEnabledHTTP(mainConf) {
+		s, err := getHTTPServer(mainConf["http"], options.Logger, options.TraceProvider)
+		if err != nil {
+			options.Logger.Fatal().Err(err).Msg("error creating http server")
+		}
+		return s
+	}
+	return nil
+}
+
+func initGRPCServer(mainConf map[string]interface{}, options *Options) *rgrpc.Server {
+	if isEnabledGRPC(mainConf) {
+		s, err := getGRPCServer(mainConf["grpc"], options.Logger, options.TraceProvider)
+		if err != nil {
+			options.Logger.Fatal().Err(err).Msg("error creating grpc server")
+		}
+		return s
+	}
+	return nil
+}

--- a/cmd/revad/runtime/runtime.go
+++ b/cmd/revad/runtime/runtime.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/mitchellh/mapstructure"
 	"github.com/owncloud/reva/v2/cmd/revad/internal/grace"
 	"github.com/owncloud/reva/v2/pkg/logger"
 	"github.com/owncloud/reva/v2/pkg/registry"
@@ -34,7 +35,6 @@ import (
 	"github.com/owncloud/reva/v2/pkg/rhttp"
 	"github.com/owncloud/reva/v2/pkg/sharedconf"
 	rtrace "github.com/owncloud/reva/v2/pkg/trace"
-	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel/trace"
@@ -53,7 +53,7 @@ func RunWithOptions(mainConf map[string]interface{}, pidFile string, opts ...Opt
 	coreConf := parseCoreConfOrDie(mainConf["core"])
 
 	if err := registry.Init(options.Registry); err != nil {
-		panic(err)
+		options.Logger.Fatal().Err(err).Msg("failed to initialize registry client")
 	}
 
 	run(mainConf, coreConf, options.Logger, options.TraceProvider, pidFile)

--- a/cmd/revad/runtime/runtime.go
+++ b/cmd/revad/runtime/runtime.go
@@ -54,6 +54,7 @@ func RunWithOptions(mainConf map[string]interface{}, pidFile string, opts ...Opt
 
 	if err := registry.Init(options.Registry); err != nil {
 		options.Logger.Fatal().Err(err).Msg("failed to initialize registry client")
+		return
 	}
 
 	run(mainConf, coreConf, options.Logger, options.TraceProvider, pidFile)

--- a/pkg/rgrpc/rgrpc.go
+++ b/pkg/rgrpc/rgrpc.go
@@ -25,6 +25,8 @@ import (
 	"net"
 	"sort"
 
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
+	"github.com/mitchellh/mapstructure"
 	"github.com/owncloud/reva/v2/internal/grpc/interceptors/appctx"
 	"github.com/owncloud/reva/v2/internal/grpc/interceptors/auth"
 	"github.com/owncloud/reva/v2/internal/grpc/interceptors/log"
@@ -33,8 +35,6 @@ import (
 	"github.com/owncloud/reva/v2/internal/grpc/interceptors/useragent"
 	"github.com/owncloud/reva/v2/pkg/sharedconf"
 	rtrace "github.com/owncloud/reva/v2/pkg/trace"
-	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
-	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	mtls "go-micro.dev/v4/util/tls"
@@ -279,15 +279,15 @@ func (s *Server) cleanupServices() {
 
 // Stop stops the server.
 func (s *Server) Stop() error {
-	s.cleanupServices()
 	s.s.Stop()
+	s.cleanupServices()
 	return nil
 }
 
 // GracefulStop gracefully stops the server.
 func (s *Server) GracefulStop() error {
-	s.cleanupServices()
 	s.s.GracefulStop()
+	s.cleanupServices()
 	return nil
 }
 

--- a/pkg/rhttp/rhttp.go
+++ b/pkg/rhttp/rhttp.go
@@ -27,6 +27,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/mitchellh/mapstructure"
 	"github.com/owncloud/reva/v2/internal/http/interceptors/appctx"
 	"github.com/owncloud/reva/v2/internal/http/interceptors/auth"
 	"github.com/owncloud/reva/v2/internal/http/interceptors/log"
@@ -34,7 +35,6 @@ import (
 	"github.com/owncloud/reva/v2/pkg/rhttp/global"
 	"github.com/owncloud/reva/v2/pkg/rhttp/router"
 	rtrace "github.com/owncloud/reva/v2/pkg/trace"
-	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel/propagation"
@@ -132,10 +132,10 @@ func (s *Server) Start(ln net.Listener) error {
 
 // Stop stops the server.
 func (s *Server) Stop() error {
-	s.closeServices()
 	// TODO(labkode): set ctx deadline to zero
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
+	defer s.closeServices()
 	return s.httpServer.Shutdown(ctx)
 }
 
@@ -164,7 +164,7 @@ func (s *Server) Address() string {
 
 // GracefulStop gracefully stops the server.
 func (s *Server) GracefulStop() error {
-	s.closeServices()
+	defer s.closeServices()
 	return s.httpServer.Shutdown(context.Background())
 }
 


### PR DESCRIPTION
Added the reva HTTP/GRPC servers constructor w/o the watcher and the os signal handling to make it driven by the ocis runtime.

https://github.com/owncloud/ocis/issues/11170