### PR TITLE
fix: [OCISDEV-176] Tolerating the empty request body for WebDAV operations

### DIFF
--- a/changelog/unreleased/fix-webdav.md
+++ b/changelog/unreleased/fix-webdav.md
@@ -1,0 +1,5 @@
+Bugfix: Tolerating the empty request body for WebDAV
+
+Tolerating the empty request body for WebDAV operations like MKCOL, DELETE, MOVE, COPY.
+
+https://github.com/owncloud/reva/pull/323

--- a/internal/http/services/owncloud/ocdav/copy.go
+++ b/internal/http/services/owncloud/ocdav/copy.go
@@ -56,7 +56,7 @@ func (s *svc) handlePathCopy(w http.ResponseWriter, r *http.Request, ns string) 
 	ctx, span := appctx.GetTracerProvider(r.Context()).Tracer(tracerName).Start(r.Context(), "copy")
 	defer span.End()
 
-	if r.Body != http.NoBody {
+	if !isBodyEmpty(r) {
 		w.WriteHeader(http.StatusUnsupportedMediaType)
 		b, err := errors.Marshal(http.StatusUnsupportedMediaType, "body must be empty", "", "")
 		errors.HandleWebdavError(appctx.GetLogger(ctx), w, b, err)
@@ -331,7 +331,7 @@ func (s *svc) handleSpacesCopy(w http.ResponseWriter, r *http.Request, spaceID s
 	ctx, span := appctx.GetTracerProvider(r.Context()).Tracer(tracerName).Start(r.Context(), "spaces_copy")
 	defer span.End()
 
-	if r.Body != http.NoBody {
+	if !isBodyEmpty(r) {
 		w.WriteHeader(http.StatusUnsupportedMediaType)
 		b, err := errors.Marshal(http.StatusUnsupportedMediaType, "body must be empty", "", "")
 		errors.HandleWebdavError(appctx.GetLogger(ctx), w, b, err)

--- a/internal/http/services/owncloud/ocdav/delete.go
+++ b/internal/http/services/owncloud/ocdav/delete.go
@@ -39,7 +39,7 @@ func (s *svc) handlePathDelete(w http.ResponseWriter, r *http.Request, ns string
 	ctx, span := appctx.GetTracerProvider(r.Context()).Tracer(tracerName).Start(ctx, "path_delete")
 	defer span.End()
 
-	if r.Body != http.NoBody {
+	if !isBodyEmpty(r) {
 		return http.StatusUnsupportedMediaType, errors.New("body must be empty")
 	}
 
@@ -126,7 +126,7 @@ func (s *svc) handleSpacesDelete(w http.ResponseWriter, r *http.Request, spaceID
 	ctx, span := appctx.GetTracerProvider(r.Context()).Tracer(tracerName).Start(ctx, "spaces_delete")
 	defer span.End()
 
-	if r.Body != http.NoBody {
+	if !isBodyEmpty(r) {
 		return http.StatusUnsupportedMediaType, errors.New("body must be empty")
 	}
 

--- a/internal/http/services/owncloud/ocdav/mkcol.go
+++ b/internal/http/services/owncloud/ocdav/mkcol.go
@@ -107,9 +107,7 @@ func (s *svc) handleSpacesMkCol(w http.ResponseWriter, r *http.Request, spaceID 
 }
 
 func (s *svc) handleMkcol(ctx context.Context, w http.ResponseWriter, r *http.Request, parentRef, childRef *provider.Reference, log zerolog.Logger) (status int, err error) {
-	if r.Body != http.NoBody {
-		// We currently do not support extended mkcol https://datatracker.ietf.org/doc/rfc5689/
-		// TODO let clients send a body with properties to set on the new resource
+	if !isBodyEmpty(r) {
 		return http.StatusUnsupportedMediaType, fmt.Errorf("extended-mkcol not supported")
 	}
 

--- a/internal/http/services/owncloud/ocdav/move.go
+++ b/internal/http/services/owncloud/ocdav/move.go
@@ -42,7 +42,7 @@ func (s *svc) handlePathMove(w http.ResponseWriter, r *http.Request, ns string) 
 	ctx, span := appctx.GetTracerProvider(r.Context()).Tracer(tracerName).Start(r.Context(), "move")
 	defer span.End()
 
-	if r.Body != http.NoBody {
+	if !isBodyEmpty(r) {
 		w.WriteHeader(http.StatusUnsupportedMediaType)
 		b, err := errors.Marshal(http.StatusUnsupportedMediaType, "body must be empty", "", "")
 		errors.HandleWebdavError(appctx.GetLogger(ctx), w, b, err)
@@ -106,7 +106,7 @@ func (s *svc) handleSpacesMove(w http.ResponseWriter, r *http.Request, srcSpaceI
 	ctx, span := appctx.GetTracerProvider(r.Context()).Tracer(tracerName).Start(r.Context(), "spaces_move")
 	defer span.End()
 
-	if r.Body != http.NoBody {
+	if !isBodyEmpty(r) {
 		w.WriteHeader(http.StatusUnsupportedMediaType)
 		b, err := errors.Marshal(http.StatusUnsupportedMediaType, "body must be empty", "", "")
 		errors.HandleWebdavError(appctx.GetLogger(ctx), w, b, err)


### PR DESCRIPTION
fix: [OCISDEV-176] Tolerating the empty request body for WebDAV operations
related issue https://github.com/owncloud/ocis/issues/1080