### PR TITLE
[tests-only][full-ci] Bump latest ocis commit id on `main` branch

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,4 +1,4 @@
 # The test runner source for API tests
-APITESTS_COMMITID=a46cd29cc9feccc1c9ac9ad3043fe110de9f84be
+APITESTS_COMMITID=8abef52e47bbfffc70926f6fcd9817ab2c94d92b
 APITESTS_BRANCH=master
 APITESTS_REPO_GIT_URL=https://github.com/owncloud/ocis.git


### PR DESCRIPTION
## Description

Bump latest ocis `master` branch commit id.

Part of: https://github.com/owncloud/QA/issues/892