### PR TITLE
[tests-only][full-ci] Bump latest ocis commit id on main branch

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,4 +1,4 @@
 # The test runner source for API tests
-APITESTS_COMMITID=202cc8bc4cfebeaa701c30da776774c99a59ab14
+APITESTS_COMMITID=231e87e7e49040b7c4aa847f75d5004ae9e58341
 APITESTS_BRANCH=master
 APITESTS_REPO_GIT_URL=https://github.com/owncloud/ocis.git


### PR DESCRIPTION
## Description
Bump latest ocis `master` branch commit id.

Part of: https://github.com/owncloud/QA/issues/894