### PR TITLE
fix: [OCISDEV-330] add dav/public-files into unprotected routes

### DIFF
--- a/changelog/unreleased/fix-add-dav-public-files-into-unprotected-routes.md
+++ b/changelog/unreleased/fix-add-dav-public-files-into-unprotected-routes.md
@@ -1,0 +1,5 @@
+Bugfix: Add `dav/public-files` into unprotected routes
+
+Added `dav/public-files` into unprotected routes to support calling public files without the `remote.php` prefix.
+
+https://github.com/owncloud/reva/pull/390

--- a/internal/http/services/owncloud/ocdav/ocdav.go
+++ b/internal/http/services/owncloud/ocdav/ocdav.go
@@ -158,7 +158,7 @@ func (s *svc) Close() error {
 }
 
 func (s *svc) Unprotected() []string {
-	return []string{"/status.php", "/status", "/remote.php/dav/public-files/", "/apps/files/", "/index.php/f/", "/index.php/s/", "/remote.php/dav/ocm/", "/dav/ocm/"}
+	return []string{"/status.php", "/status", "/remote.php/dav/public-files/", "/dav/public-files/", "/apps/files/", "/index.php/f/", "/index.php/s/", "/remote.php/dav/ocm/", "/dav/ocm/"}
 }
 
 func (s *svc) Handler() http.Handler {


### PR DESCRIPTION
Added `dav/public-files` into unprotected routes to support calling public files without the `remote.php` prefix.