### PR TITLE
[OCISDEV-249] Use []string for auth levels

### DIFF
--- a/changelog/unreleased/mfa-capability.md
+++ b/changelog/unreleased/mfa-capability.md
@@ -1,5 +1,6 @@
 Enhancement: Add MFA Capability
 
-Adds a capability to signal web there is MFA support.
+Adds a capability to signal web there is MFA support. Reworked to use []string
 
 https://github.com/owncloud/reva/pull/385
+https://github.com/owncloud/reva/pull/391

--- a/pkg/owncloud/ocs/capabilities.go
+++ b/pkg/owncloud/ocs/capabilities.go
@@ -100,8 +100,8 @@ type CapabilitiesAuth struct {
 
 // CapabilitiesMFA holds mfa capabilities
 type CapabilitiesMFA struct {
-	Enabled   bool   `json:"enabled,omitempty" xml:"enabled,omitempty" mapstructure:"enabled"`
-	LevelName string `json:"levelname,omitempty" xml:"levelname,omitempty" mapstructure:"levelname"`
+	Enabled    bool     `json:"enabled,omitempty" xml:"enabled,omitempty" mapstructure:"enabled"`
+	LevelNames []string `json:"levelnames,omitempty" xml:"levelnames,omitempty" mapstructure:"levelnames"`
 }
 
 // Spaces lets a service configure its advertised options related to Storage Spaces.


### PR DESCRIPTION
Use a []string to be able to accept multiple auth levels
