### PR TITLE
[tests-only][full-ci] Bump latest ocis commit id on main branch

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,4 +1,4 @@
 # The test runner source for API tests
-APITESTS_COMMITID=f01627339d83a77856f345d8bcffeb8e7ebcfea3
+APITESTS_COMMITID=bc3dbfc7f53759fa76efc48b7982b052312ef05a
 APITESTS_BRANCH=master
 APITESTS_REPO_GIT_URL=https://github.com/owncloud/ocis.git


### PR DESCRIPTION
## Description
Bump latest ocis `master` branch commit id.

Part of: https://github.com/owncloud/QA/issues/895