### PR TITLE
Improve Appauth Performance

### DIFF
--- a/internal/grpc/services/applicationauth/applicationauth.go
+++ b/internal/grpc/services/applicationauth/applicationauth.go
@@ -147,7 +147,7 @@ func (s *service) InvalidateAppPassword(ctx context.Context, req *appauthpb.Inva
 }
 
 func (s *service) GetAppPassword(ctx context.Context, req *appauthpb.GetAppPasswordRequest) (*appauthpb.GetAppPasswordResponse, error) {
-	pwd, err := s.am.GetAppPassword(ctx, req.User, req.Password)
+	pwd, err := s.am.GetAppPassword(ctx, req.User, req.Password, utils.ReadPlainFromOpaque(req.Opaque, "hash"))
 	if err != nil {
 		return &appauthpb.GetAppPasswordResponse{
 			Status: status.NewInternal(ctx, "error getting app password via username/password"),

--- a/internal/grpc/services/applicationauth/applicationauth.go
+++ b/internal/grpc/services/applicationauth/applicationauth.go
@@ -22,12 +22,13 @@ import (
 	"context"
 
 	appauthpb "github.com/cs3org/go-cs3apis/cs3/auth/applications/v1beta1"
+	"github.com/mitchellh/mapstructure"
 	"github.com/owncloud/reva/v2/pkg/appauth"
 	"github.com/owncloud/reva/v2/pkg/appauth/manager/registry"
 	"github.com/owncloud/reva/v2/pkg/errtypes"
 	"github.com/owncloud/reva/v2/pkg/rgrpc"
 	"github.com/owncloud/reva/v2/pkg/rgrpc/status"
-	"github.com/mitchellh/mapstructure"
+	"github.com/owncloud/reva/v2/pkg/utils"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"google.golang.org/grpc"
@@ -113,7 +114,8 @@ func (s *service) GenerateAppPassword(ctx context.Context, req *appauthpb.Genera
 
 	return &appauthpb.GenerateAppPasswordResponse{
 		Status:      status.NewOK(ctx),
-		AppPassword: pwd,
+		Opaque:      utils.AppendPlainToOpaque(nil, "hash", pwd.Hash),
+		AppPassword: pwd.AppPassword,
 	}, nil
 }
 

--- a/internal/grpc/services/authprovider/authprovider.go
+++ b/internal/grpc/services/authprovider/authprovider.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 
 	provider "github.com/cs3org/go-cs3apis/cs3/auth/provider/v1beta1"
+	"github.com/mitchellh/mapstructure"
 	"github.com/owncloud/reva/v2/pkg/appctx"
 	"github.com/owncloud/reva/v2/pkg/auth"
 	"github.com/owncloud/reva/v2/pkg/auth/manager/registry"
@@ -31,7 +32,7 @@ import (
 	"github.com/owncloud/reva/v2/pkg/plugin"
 	"github.com/owncloud/reva/v2/pkg/rgrpc"
 	"github.com/owncloud/reva/v2/pkg/rgrpc/status"
-	"github.com/mitchellh/mapstructure"
+	"github.com/owncloud/reva/v2/pkg/utils"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"google.golang.org/grpc"
@@ -136,6 +137,7 @@ func (s *service) Authenticate(ctx context.Context, req *provider.AuthenticateRe
 	username := req.ClientId
 	password := req.ClientSecret
 
+	ctx = context.WithValue(ctx, "hash", utils.ReadPlainFromOpaque(req.Opaque, "hash"))
 	u, scope, err := s.authmgr.Authenticate(ctx, username, password)
 	if err != nil {
 		log.Debug().Str("client_id", username).Err(err).Msg("authsvc: error in Authenticate")

--- a/internal/grpc/services/gateway/authprovider.go
+++ b/internal/grpc/services/gateway/authprovider.go
@@ -52,6 +52,7 @@ func (s *svc) Authenticate(ctx context.Context, req *gateway.AuthenticateRequest
 	}
 
 	authProviderReq := &authpb.AuthenticateRequest{
+		Opaque:       req.Opaque,
 		ClientId:     req.ClientId,
 		ClientSecret: req.ClientSecret,
 	}

--- a/pkg/appauth/appauth.go
+++ b/pkg/appauth/appauth.go
@@ -42,7 +42,7 @@ type Manager interface {
 	// ListAppPasswords lists the application passwords created by a user.
 	ListAppPasswords(ctx context.Context) ([]*apppb.AppPassword, error)
 	// InvalidateAppPassword invalidates a generated password.
-	InvalidateAppPassword(ctx context.Context, secret string) error
+	InvalidateAppPassword(ctx context.Context, hash string) error
 	// GetAppPassword retrieves the password information by the combination of username and password.
-	GetAppPassword(ctx context.Context, user *userpb.UserId, secret string) (*apppb.AppPassword, error)
+	GetAppPassword(ctx context.Context, user *userpb.UserId, secret string, hash string) (*apppb.AppPassword, error)
 }

--- a/pkg/appauth/appauth.go
+++ b/pkg/appauth/appauth.go
@@ -27,11 +27,18 @@ import (
 	typespb "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
 )
 
+// ExtendedAppPassword extends the CS3 AppPassword to return additional information
+// Returned when creating a new AppPassword
+type ExtendedAppPassword struct {
+	AppPassword *apppb.AppPassword
+	Hash        string
+}
+
 // Manager is the interface that manages application authentication mechanisms.
 type Manager interface {
 	// GenerateAppPassword creates a password with specified scope to be used by
 	// third-party applications.
-	GenerateAppPassword(ctx context.Context, scope map[string]*authpb.Scope, label string, expiration *typespb.Timestamp) (*apppb.AppPassword, error)
+	GenerateAppPassword(ctx context.Context, scope map[string]*authpb.Scope, label string, expiration *typespb.Timestamp) (*ExtendedAppPassword, error)
 	// ListAppPasswords lists the application passwords created by a user.
 	ListAppPasswords(ctx context.Context) ([]*apppb.AppPassword, error)
 	// InvalidateAppPassword invalidates a generated password.

--- a/pkg/appauth/manager/json/json.go
+++ b/pkg/appauth/manager/json/json.go
@@ -199,41 +199,25 @@ func (mgr *jsonManager) InvalidateAppPassword(ctx context.Context, password stri
 	if _, ok := appPasswords[password]; !ok {
 		return errtypes.NotFound("password not found")
 	}
-	delete(mgr.passwords[userID.String()], password)
 
-	// if user has 0 passwords, delete user key from state map
-	if len(mgr.passwords[userID.String()]) == 0 {
-		delete(mgr.passwords, userID.String())
-	}
-
+	mgr.remove(userID.String(), password)
 	return mgr.save()
 }
 
-func (mgr *jsonManager) GetAppPassword(ctx context.Context, userID *userpb.UserId, password string) (*apppb.AppPassword, error) {
+func (mgr *jsonManager) GetAppPassword(ctx context.Context, userID *userpb.UserId, password string, hash string) (*apppb.AppPassword, error) {
 	mgr.Lock()
 	defer mgr.Unlock()
 
-	appPassword, ok := mgr.passwords[userID.String()]
+	appPasswords, ok := mgr.passwords[userID.String()]
 	if !ok {
-		return nil, errtypes.NotFound("password not found")
+		return nil, errtypes.NotFound("user has no tokens")
 	}
 
-	for hash, pw := range appPassword {
-		err := bcrypt.CompareHashAndPassword([]byte(hash), []byte(password))
-		if err == nil {
-			// password found
-			if pw.Expiration != nil && pw.Expiration.Seconds != 0 && uint64(time.Now().Unix()) > pw.Expiration.Seconds {
-				// password expired
-				return nil, errtypes.NotFound("password not found")
-			}
-			// password not expired
-			// update last used time
-			pw.Utime = now()
-			if err := mgr.save(); err != nil {
-				return nil, errors.Wrap(err, "error saving file")
-			}
-
-			return pw, nil
+	pw, ok := appPasswords[hash]
+	if !ok {
+		pw, ok = mgr.findPassword(appPasswords, password)
+		if !ok {
+			return nil, errtypes.NotFound("password not found")
 		}
 	} else {
 		// hash found - double check password
@@ -242,11 +226,32 @@ func (mgr *jsonManager) GetAppPassword(ctx context.Context, userID *userpb.UserI
 		}
 	}
 
-	return nil, errtypes.NotFound("password not found")
+	if pw.Expiration != nil && pw.Expiration.Seconds != 0 && uint64(time.Now().Unix()) > pw.Expiration.Seconds {
+		// password expired
+		mgr.remove(userID.String(), pw.Password)
+		return nil, errtypes.NotFound("password not found")
+	}
+	// password not expired
+	// update last used time
+	pw.Utime = now()
+	if err := mgr.save(); err != nil {
+		return nil, errors.Wrap(err, "error saving file")
+	}
+
+	return pw, nil
 }
 
 func now() *typespb.Timestamp {
 	return &typespb.Timestamp{Seconds: uint64(time.Now().Unix())}
+}
+
+func (mgr *jsonManager) remove(userid string, pw string) {
+	delete(mgr.passwords[userid], pw)
+
+	// if user has 0 passwords, delete user key from state map
+	if len(mgr.passwords[userid]) == 0 {
+		delete(mgr.passwords, userid)
+	}
 }
 
 func (mgr *jsonManager) save() error {
@@ -260,4 +265,15 @@ func (mgr *jsonManager) save() error {
 	}
 
 	return nil
+}
+
+// NOTE: this is inefficient as it needs to rehash the password on every iteration.
+// can be omitted by sending the hash with the GetAppPassword request.
+func (mgr *jsonManager) findPassword(appPasswords map[string]*apppb.AppPassword, password string) (*apppb.AppPassword, bool) {
+	for hash, pw := range appPasswords {
+		if err := bcrypt.CompareHashAndPassword([]byte(hash), []byte(password)); err == nil {
+			return pw, true
+		}
+	}
+	return nil, false
 }

--- a/pkg/auth/manager/appauth/appauth.go
+++ b/pkg/auth/manager/appauth/appauth.go
@@ -25,11 +25,12 @@ import (
 	authpb "github.com/cs3org/go-cs3apis/cs3/auth/provider/v1beta1"
 	user "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	rpcv1beta1 "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
+	"github.com/mitchellh/mapstructure"
 	"github.com/owncloud/reva/v2/pkg/auth"
 	"github.com/owncloud/reva/v2/pkg/auth/manager/registry"
 	"github.com/owncloud/reva/v2/pkg/errtypes"
 	"github.com/owncloud/reva/v2/pkg/rgrpc/todo/pool"
-	"github.com/mitchellh/mapstructure"
+	"github.com/owncloud/reva/v2/pkg/utils"
 	"github.com/pkg/errors"
 )
 
@@ -82,6 +83,7 @@ func (m *manager) Authenticate(ctx context.Context, username, password string) (
 
 	// get the app password associated with the user and password
 	appAuthResponse, err := gtw.GetAppPassword(ctx, &appauthpb.GetAppPasswordRequest{
+		Opaque:   utils.AppendPlainToOpaque(nil, "hash", ctx.Value("hash").(string)),
 		User:     userResponse.GetUser().Id,
 		Password: password,
 	})


### PR DESCRIPTION
Improves performance of the Appauth service by returning the hash with the create response. If the hash is send during GetAuthToken, it will directly fetch the correct pw and not loop over all passwords.

This also fixes the InvalidateAuthToken handler as it required the hash anyways.
