### PR TITLE
fix: fixed the OCM WebDAV protocol entity mismatch

### DIFF
--- a/changelog/unreleased/fix-ocm-weddav.md
+++ b/changelog/unreleased/fix-ocm-weddav.md
@@ -1,0 +1,5 @@
+Bugfix: Fix the OCM WebDAV protocol entity mismatch
+
+Fixed the OCM WebDAV protocol entity mismatch
+
+https://github.com/owncloud/reva/pull/425

--- a/internal/grpc/services/ocmshareprovider/ocmshareprovider.go
+++ b/internal/grpc/services/ocmshareprovider/ocmshareprovider.go
@@ -187,7 +187,7 @@ func (s *service) getWebdavProtocol(ctx context.Context, share *ocm.Share, m *oc
 
 	return &ocmd.WebDAV{
 		Permissions:  perms,
-		URL:          s.webdavURL(ctx, share),
+		URI:          s.webdavURL(ctx, share),
 		SharedSecret: share.Token,
 	}
 }

--- a/internal/http/services/ocmd/protocols_test.go
+++ b/internal/http/services/ocmd/protocols_test.go
@@ -49,12 +49,22 @@ func TestUnmarshalProtocol(t *testing.T) {
 			err: "protocol unsupported not recognised",
 		},
 		{
+			raw: `{"name":"multi","options":{},"webdav":{"sharedSecret":"secret","permissions":["read","write"],"uri":"http://example.org"}}`,
+			expected: []Protocol{
+				&WebDAV{
+					SharedSecret: "secret",
+					Permissions:  []string{"read", "write"},
+					URI:          "http://example.org",
+				},
+			},
+		},
+		{
 			raw: `{"name":"multi","options":{},"webdav":{"sharedSecret":"secret","permissions":["read","write"],"url":"http://example.org"}}`,
 			expected: []Protocol{
 				&WebDAV{
 					SharedSecret: "secret",
 					Permissions:  []string{"read", "write"},
-					URL:          "http://example.org",
+					URI:          "http://example.org",
 				},
 			},
 		},
@@ -82,7 +92,25 @@ func TestUnmarshalProtocol(t *testing.T) {
 				&WebDAV{
 					SharedSecret: "secret",
 					Permissions:  []string{"read", "write"},
-					URL:          "http://example.org",
+					URI:          "http://example.org",
+				},
+				&Webapp{
+					URITemplate: "http://example.org/{test}",
+				},
+				&Datatx{
+					SharedSecret: "secret",
+					SourceURI:    "http://example.org",
+					Size:         10,
+				},
+			},
+		},
+		{
+			raw: `{"name":"multi","options":{},"webdav":{"sharedSecret":"secret","permissions":["read","write"],"uri":"http://example.org"},"webapp":{"uriTemplate":"http://example.org/{test}"},"datatx":{"sharedSecret":"secret","srcUri":"http://example.org","size":10}}`,
+			expected: []Protocol{
+				&WebDAV{
+					SharedSecret: "secret",
+					Permissions:  []string{"read", "write"},
+					URI:          "http://example.org",
 				},
 				&Webapp{
 					URITemplate: "http://example.org/{test}",
@@ -145,7 +173,7 @@ func TestMarshalProtocol(t *testing.T) {
 				&WebDAV{
 					SharedSecret: "secret",
 					Permissions:  []string{"read"},
-					URL:          "http://example.org",
+					URI:          "http://example.org",
 				},
 			},
 			expected: map[string]any{
@@ -154,7 +182,7 @@ func TestMarshalProtocol(t *testing.T) {
 				"webdav": map[string]any{
 					"sharedSecret": "secret",
 					"permissions":  []any{"read"},
-					"url":          "http://example.org",
+					"uri":          "http://example.org",
 				},
 			},
 		},
@@ -197,7 +225,7 @@ func TestMarshalProtocol(t *testing.T) {
 				&WebDAV{
 					SharedSecret: "secret",
 					Permissions:  []string{"read"},
-					URL:          "http://example.org",
+					URI:          "http://example.org",
 				},
 				&Webapp{
 					URITemplate: "http://example.org",
@@ -215,7 +243,7 @@ func TestMarshalProtocol(t *testing.T) {
 				"webdav": map[string]any{
 					"sharedSecret": "secret",
 					"permissions":  []any{"read"},
-					"url":          "http://example.org",
+					"uri":          "http://example.org",
 				},
 				"webapp": map[string]any{
 					"uriTemplate": "http://example.org",


### PR DESCRIPTION
Fixed the OCM WebDAV protocol entity mismatch

https://github.com/owncloud/ocis/issues/11736

`url` -> `uri`

```
"protocol": {
    "name": "multi",
    "options": {},
    "webdav": {
      "sharedSecret": "AHLjBwQIBJheUwsPPtRayYBAlgySsjKQ",
      "permissions": [
        "read"
      ],
      "uri": "https://1.ocis.cloud.test.azadehafzar.io/dav/ocm/c7e1fa89-eebc-4255-97d4-59a6576be9a2"
    }
  }
```