### PR TITLE
fix(ocm): OCM Specification Compliance

### DIFF
--- a/internal/grpc/services/ocmcore/ocmcore.go
+++ b/internal/grpc/services/ocmcore/ocmcore.go
@@ -207,7 +207,7 @@ func (s *service) UpdateOCMCoreShare(ctx context.Context, req *ocmcore.UpdateOCM
 	}
 	fileMask := &fieldmaskpb.FieldMask{Paths: []string{"protocols"}}
 
-	user := &userpb.User{Id: ocmuser.RemoteID(&userpb.UserId{OpaqueId: grantee})}
+	user := &userpb.User{Id: ocmuser.DecodeRemoteUserFederatedID(&userpb.UserId{OpaqueId: grantee})}
 	_, err := s.repo.UpdateReceivedShare(ctx, user, &ocm.ReceivedShare{
 		Id: &ocm.ShareId{
 			OpaqueId: req.GetOcmShareId(),
@@ -234,7 +234,7 @@ func (s *service) DeleteOCMCoreShare(ctx context.Context, req *ocmcore.DeleteOCM
 		return nil, errtypes.UserRequired("missing remote user id in a metadata")
 	}
 
-	share, err := s.repo.GetReceivedShare(ctx, &userpb.User{Id: ocmuser.RemoteID(&userpb.UserId{OpaqueId: grantee})}, &ocm.ShareReference{
+	share, err := s.repo.GetReceivedShare(ctx, &userpb.User{Id: ocmuser.DecodeRemoteUserFederatedID(&userpb.UserId{OpaqueId: grantee})}, &ocm.ShareReference{
 		Spec: &ocm.ShareReference_Id{
 			Id: &ocm.ShareId{
 				OpaqueId: req.GetId(),
@@ -245,7 +245,7 @@ func (s *service) DeleteOCMCoreShare(ctx context.Context, req *ocmcore.DeleteOCM
 		return nil, errtypes.InternalError("unable to get share details")
 	}
 
-	granteeUser := &userpb.User{Id: ocmuser.RemoteID(&userpb.UserId{OpaqueId: grantee})}
+	granteeUser := &userpb.User{Id: ocmuser.DecodeRemoteUserFederatedID(&userpb.UserId{OpaqueId: grantee})}
 	err = s.repo.DeleteReceivedShare(ctx, granteeUser, &ocm.ShareReference{
 		Spec: &ocm.ShareReference_Id{
 			Id: &ocm.ShareId{
@@ -262,7 +262,7 @@ func (s *service) DeleteOCMCoreShare(ctx context.Context, req *ocmcore.DeleteOCM
 			if err := events.Publish(ctx, s.eventStream, events.OCMCoreShareDelete{
 				ShareID:      share.Id.OpaqueId,
 				Sharer:       share.GetOwner(),
-				Grantee:      ocmuser.RemoteID(&userpb.UserId{OpaqueId: grantee}),
+				Grantee:      ocmuser.DecodeRemoteUserFederatedID(&userpb.UserId{OpaqueId: grantee}),
 				ResourceName: share.Name,
 				CTime:        &typespb.Timestamp{Seconds: uint64(time.Now().Unix())},
 			}); err != nil {

--- a/internal/grpc/services/ocminvitemanager/ocminvitemanager.go
+++ b/internal/grpc/services/ocminvitemanager/ocminvitemanager.go
@@ -180,9 +180,9 @@ func (s *service) ForwardInvite(ctx context.Context, req *invitepb.ForwardInvite
 	remoteUser, err := s.ocmClient.InviteAccepted(ctx, ocmEndpoint, &client.InviteAcceptedRequest{
 		Token:             req.InviteToken.GetToken(),
 		RecipientProvider: s.conf.ProviderDomain,
-		// The UserID is only a string here. To not loose the IDP information we use the FederatedID encoding
-		// i.e. base64(UserID@IDP)
-		UserID: ocmuser.FederatedID(user.GetId(), "").GetOpaqueId(),
+		// The UserID is only a string here. To not lose the IDP information we use the LocalUserFederatedID encoding
+		// i.e. UserID@IDP
+		UserID: ocmuser.LocalUserFederatedID(user.GetId(), "").GetOpaqueId(),
 		Email:  user.GetMail(),
 		Name:   user.GetDisplayName(),
 	})
@@ -222,6 +222,9 @@ func (s *service) ForwardInvite(ctx context.Context, req *invitepb.ForwardInvite
 		Idp:      req.GetOriginSystemProvider().Domain,
 		OpaqueId: remoteUser.UserID,
 	}
+
+	// we need to use a unique identifier for federated users
+	remoteUserID = ocmuser.EncodeRemoteUserFederatedID(remoteUserID)
 
 	if err := s.repo.AddRemoteUser(ctx, user.Id, &userpb.User{
 		Id:          remoteUserID,
@@ -282,6 +285,8 @@ func (s *service) AcceptInvite(ctx context.Context, req *invitepb.AcceptInviteRe
 	}
 
 	remoteUser := req.GetRemoteUser()
+	// we need to use a unique identifier for federated users
+	remoteUser.Id = ocmuser.EncodeRemoteUserFederatedID(remoteUser.Id)
 
 	if err := s.repo.AddRemoteUser(ctx, token.GetUserId(), remoteUser); err != nil {
 		if !errors.Is(err, invite.ErrUserAlreadyAccepted) {

--- a/internal/grpc/services/ocmshareprovider/ocmshareprovider.go
+++ b/internal/grpc/services/ocmshareprovider/ocmshareprovider.go
@@ -325,11 +325,11 @@ func (s *service) CreateOCMShare(ctx context.Context, req *ocm.CreateOCMShareReq
 
 	// 2.b replace outgoing user ids with ocm user ids
 	// unpack the federated user id
-	shareWith := ocmuser.FormatOCMUser(ocmuser.RemoteID(req.GetGrantee().GetUserId()))
+	shareWith := ocmuser.FormatOCMUser(ocmuser.DecodeRemoteUserFederatedID(req.GetGrantee().GetUserId()))
 
-	// wrap the local user id in a federated user id
-	owner := ocmuser.FormatOCMUser(ocmuser.FederatedID(info.Owner, s.conf.ProviderDomain))
-	sender := ocmuser.FormatOCMUser(ocmuser.FederatedID(user.Id, s.conf.ProviderDomain))
+	// wrap the local user id in a local federated user id
+	owner := ocmuser.FormatOCMUser(ocmuser.LocalUserFederatedID(info.Owner, s.conf.ProviderDomain))
+	sender := ocmuser.FormatOCMUser(ocmuser.LocalUserFederatedID(user.Id, s.conf.ProviderDomain))
 
 	newShareReq := &client.NewShareRequest{
 		ShareWith:         shareWith,

--- a/internal/http/services/ocmd/invites.go
+++ b/internal/http/services/ocmd/invites.go
@@ -60,7 +60,7 @@ type acceptInviteRequest struct {
 	Email             string `json:"email"`
 }
 
-// AcceptInvite informs avout an accepted invitation so that the users
+// AcceptInvite informs about an accepted invitation so that the users
 // can initiate the OCM share creation.
 func (h *invitesHandler) AcceptInvite(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -73,7 +73,7 @@ func (h *invitesHandler) AcceptInvite(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if req.Token == "" || req.UserID == "" || req.RecipientProvider == "" {
-		reqres.WriteError(w, r, reqres.APIErrorInvalidParameter, "token, userID and recipiendProvider must not be null", nil)
+		reqres.WriteError(w, r, reqres.APIErrorInvalidParameter, "token, userID and recipientProvider must not be null", nil)
 		return
 	}
 
@@ -146,7 +146,7 @@ func (h *invitesHandler) AcceptInvite(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := json.NewEncoder(w).Encode(&user{
-		UserID: ocmuser.FederatedID(acceptInviteResponse.UserId, "").GetOpaqueId(),
+		UserID: ocmuser.LocalUserFederatedID(acceptInviteResponse.UserId, "").GetOpaqueId(),
 		Email:  acceptInviteResponse.Email,
 		Name:   acceptInviteResponse.DisplayName,
 	}); err != nil {

--- a/internal/http/services/ocmd/shares.go
+++ b/internal/http/services/ocmd/shares.go
@@ -206,6 +206,10 @@ func getLocalUserID(user string) (id, provider string, err error) {
 	// Handle nested @ in idPart (e.g. "user@idp@provider")
 	if inner := strings.LastIndex(idPart, "@"); inner != -1 {
 		id = idPart[:inner]
+
+		if id == "" {
+			return "", "", errors.New("inner id cannot be empty")
+		}
 	} else {
 		id = idPart
 	}
@@ -226,12 +230,22 @@ func getUserIDFromOCMUser(user string) (*userpb.UserId, error) {
 	}, nil
 }
 
-func getIDAndMeshProvider(user string) (id, provider string, err error) {
+func getIDAndMeshProvider(user string) (string, string, error) {
 	last := strings.LastIndex(user, "@")
 	if last == -1 {
 		return "", "", errors.New("not in the form <id>@<provider>")
 	}
-	return user[:last], user[last+1:], nil
+
+	id, provider := user[:last], user[last+1:]
+
+	if id == "" {
+		return "", "", errors.New("id cannot be empty")
+	}
+	if provider == "" {
+		return "", "", errors.New("provider cannot be empty")
+	}
+
+	return id, provider, nil
 }
 
 func getCreateShareRequest(r *http.Request) (*createShareRequest, error) {

--- a/pkg/ocm/user/user.go
+++ b/pkg/ocm/user/user.go
@@ -3,16 +3,16 @@ package user
 import (
 	"encoding/base64"
 	"fmt"
+	"net/url"
 	"strings"
 
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 )
 
-// FederatedID creates a federated user id by
+// LocalUserFederatedID creates a federated id for local users by
 // 1. stripping the protocol from the domain and
-// 2. base64 encoding the opaque id with the domain to get a unique identifier that cannot collide with other users
-func FederatedID(id *userpb.UserId, domain string) *userpb.UserId {
-	opaqueId := base64.URLEncoding.EncodeToString([]byte(id.OpaqueId + "@" + id.Idp))
+func LocalUserFederatedID(id *userpb.UserId, domain string) *userpb.UserId {
+	opaqueId := id.OpaqueId + "@" + id.Idp
 	return &userpb.UserId{
 		Type:     userpb.UserType_USER_TYPE_FEDERATED,
 		Idp:      domain,
@@ -20,10 +20,26 @@ func FederatedID(id *userpb.UserId, domain string) *userpb.UserId {
 	}
 }
 
-// RemoteID creates a remote user id by
+// EncodeRemoteUserFederatedID encodes a federated id for remote users by
+// 1. stripping the protocol from the domain and
+// 2. base64 encoding the opaque id with the domain to get a unique identifier that cannot collide with other users
+func EncodeRemoteUserFederatedID(id *userpb.UserId) *userpb.UserId {
+	// strip protocol from the domain
+	domain := id.Idp
+	if u, err := url.Parse(domain); err == nil && u.Host != "" {
+		domain = u.Host
+	}
+	return &userpb.UserId{
+		Type:     userpb.UserType_USER_TYPE_FEDERATED,
+		Idp:      domain,
+		OpaqueId: base64.URLEncoding.EncodeToString([]byte(id.OpaqueId + "@" + domain)),
+	}
+}
+
+// DecodeRemoteUserFederatedID decodes opaque id into remote user's federated id by
 // 1. decoding the base64 encoded opaque id
 // 2. splitting the opaque id at the last @ to get the opaque id and the domain
-func RemoteID(id *userpb.UserId) *userpb.UserId {
+func DecodeRemoteUserFederatedID(id *userpb.UserId) *userpb.UserId {
 	remoteId := &userpb.UserId{
 		Type:     userpb.UserType_USER_TYPE_PRIMARY,
 		Idp:      id.Idp,

--- a/tests/integration/grpc/ocm_invitation_test.go
+++ b/tests/integration/grpc/ocm_invitation_test.go
@@ -21,7 +21,6 @@ package grpc_test
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -119,7 +118,7 @@ var _ = Describe("ocm invitation workflow", func() {
 			Id: &userpb.UserId{
 				Type:     userpb.UserType_USER_TYPE_FEDERATED,
 				Idp:      "cernbox.cern.ch",
-				OpaqueId: base64.URLEncoding.EncodeToString([]byte("4c510ada-c86b-4815-8820-42cdf82c3d51@https://cernbox.cern.ch")),
+				OpaqueId: "4c510ada-c86b-4815-8820-42cdf82c3d51@https://cernbox.cern.ch",
 			},
 			Username:    "einstein",
 			Mail:        "einstein@cern.ch",
@@ -139,7 +138,7 @@ var _ = Describe("ocm invitation workflow", func() {
 			Id: &userpb.UserId{
 				Type:     userpb.UserType_USER_TYPE_FEDERATED,
 				Idp:      "cesnet.cz",
-				OpaqueId: base64.URLEncoding.EncodeToString([]byte("f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c@https://cesnet.cz")),
+				OpaqueId: "f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c@https://cesnet.cz",
 			},
 			Username:    "marie",
 			Mail:        "marie@cesnet.cz",

--- a/tests/integration/grpc/ocm_share_test.go
+++ b/tests/integration/grpc/ocm_share_test.go
@@ -21,7 +21,6 @@ package grpc_test
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"io"
 	"net/http"
 	"path/filepath"
@@ -36,6 +35,7 @@ import (
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	storagep "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	typespb "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
+	"github.com/owncloud/ocis/v2/services/webdav/pkg/net"
 	"github.com/owncloud/reva/v2/internal/http/services/datagateway"
 	"github.com/owncloud/reva/v2/pkg/conversions"
 	ctxpkg "github.com/owncloud/reva/v2/pkg/ctx"
@@ -46,7 +46,6 @@ import (
 	"github.com/owncloud/reva/v2/pkg/storage/fs/ocis"
 	jwt "github.com/owncloud/reva/v2/pkg/token/manager/jwt"
 	"github.com/owncloud/reva/v2/tests/helpers"
-	"github.com/owncloud/ocis/v2/services/webdav/pkg/net"
 	"github.com/pkg/errors"
 	"github.com/studio-b12/gowebdav"
 	"google.golang.org/grpc/metadata"
@@ -127,7 +126,7 @@ var _ = PDescribe("ocm share", func() {
 		federatedEinsteinID = &userpb.UserId{
 			Type:     userpb.UserType_USER_TYPE_FEDERATED,
 			Idp:      "cernbox.cern.ch",
-			OpaqueId: base64.URLEncoding.EncodeToString([]byte("4c510ada-c86b-4815-8820-42cdf82c3d51@https://cernbox.cern.ch")),
+			OpaqueId: "4c510ada-c86b-4815-8820-42cdf82c3d51@cernbox.cern.ch",
 		}
 		marie = &userpb.User{
 			Id: &userpb.UserId{
@@ -142,7 +141,7 @@ var _ = PDescribe("ocm share", func() {
 		federatedMarieID = &userpb.UserId{
 			Type:     userpb.UserType_USER_TYPE_FEDERATED,
 			Idp:      "cesnet.cz",
-			OpaqueId: base64.URLEncoding.EncodeToString([]byte("f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c@https://cesnet.cz")),
+			OpaqueId: "f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c@cesnet.cz",
 		}
 	)
 
@@ -215,7 +214,7 @@ var _ = PDescribe("ocm share", func() {
 			Expect(invRes.UserId.Type).To(Equal(userpb.UserType_USER_TYPE_FEDERATED))
 			// Federated users use the OCM provider id which MUST NOT contain the protocol
 			Expect(invRes.UserId.Idp).To(Equal("cernbox.cern.ch"))
-			// The OpaqueId is the base64 encoded user id and the provider id to provent collisions with other users on the graph API
+			// The OpaqueId is the base64 encoded user id and the provider id to prevent collisions with other users on the graph API
 			Expect(invRes.UserId.OpaqueId).To(Equal(federatedEinsteinID.OpaqueId))
 		})
 


### PR DESCRIPTION
Fixed https://github.com/owncloud/ocis/issues/11735

Based on the:
- https://github.com/owncloud/ocis/issues/9927
- https://github.com/cs3org/reva/pull/4833
- https://github.com/cs3org/reva/pull/4933

The issue I raised has happened.

The combined goal of those 2 PRs is:

1. Avoid collision from remote users
2. Preserve the local user IdP info when federating by constructing the opaque_id = user@idp, which is completely fine based on OCM spec, even without the base64

The issue:

- oCIS should only base64 encode INCOMING user contact information, not OUTGOING (changed in [4933](https://github.com/cs3org/reva/pull/4933))

P.S. Tests are probably still outdated or wrong