### PR TITLE
fix: [OCISDEV-483] add app fallback

### DIFF
--- a/changelog/unreleased/fix-add-app-fallback.md
+++ b/changelog/unreleased/fix-add-app-fallback.md
@@ -1,0 +1,6 @@
+Bugfix: Add app fallback
+
+When no app is specified in the open with web request, we now fallback to the first app provider found for the resource.
+If no app providers are found, we return an error.
+
+https://github.com/owncloud/reva/pull/443

--- a/internal/http/services/appprovider/errors.go
+++ b/internal/http/services/appprovider/errors.go
@@ -37,6 +37,7 @@ const (
 	appErrorInvalidParameter appErrorCode = "INVALID_PARAMETER"
 	appErrorServerError      appErrorCode = "SERVER_ERROR"
 	appErrorTooEarly         appErrorCode = "TOO_EARLY"
+	appErrorProviderNotFound appErrorCode = "PROVIDER_NOT_FOUND"
 )
 
 // appErrorCodeMapping stores the HTTP error code mapping for various APIErrorCodes
@@ -49,6 +50,7 @@ var appErrorCodeMapping = map[appErrorCode]int{
 	appErrorServerError:      http.StatusInternalServerError,
 	appErrorPermissionDenied: http.StatusForbidden,
 	appErrorTooEarly:         http.StatusTooEarly,
+	appErrorProviderNotFound: http.StatusNotFound,
 }
 
 // APIError encompasses the error type and message


### PR DESCRIPTION
When no app is specified in the open with web request, we now fallback to the first app provider found for the resource. If no app providers are found, we return an error.