### PR TITLE
[tests-only][full-ci] Bump latest ocis commit id on main branch

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,4 +1,4 @@
 # The test runner source for API tests
-APITESTS_COMMITID=2c2e868a9d8e41213d4ee7f59482b030a36aca9a
+APITESTS_COMMITID=b030cf56d9241d72d4d2f685f7f2e9ebddf6fee8
 APITESTS_BRANCH=master
 APITESTS_REPO_GIT_URL=https://github.com/owncloud/ocis.git


### PR DESCRIPTION
## Description
Bump latest ocis `master` branch commit id.

Part of: https://github.com/owncloud/QA/issues/911