### PR TITLE
fix: do not compute temporary managers when removing space managers

### DIFF
--- a/internal/grpc/services/gateway/usershareprovider.go
+++ b/internal/grpc/services/gateway/usershareprovider.go
@@ -803,7 +803,9 @@ func isSpaceManagerRemaining(grants []*provider.Grant, grantee *provider.Grantee
 		// RemoveGrant is currently the way to check for the manager role
 		// If it is not set than the current grant is not for a manager and
 		// we can just continue with the next one.
-		if g.Permissions.RemoveGrant && !isEqualGrantee(g.Grantee, grantee) {
+		// Expirable grants won't be computed because the space needs
+		// at least one permanent space manager.
+		if g.Permissions.RemoveGrant && !isEqualGrantee(g.Grantee, grantee) && g.Expiration == nil {
 			return true
 		}
 	}


### PR DESCRIPTION
Temporary space managers (a space was shared with them having an expiration) were counted as "valid" space managers when removing space members. This can lead to a scenario where a space is left unmanaged because the last space manager was expired.

This PR fixes that so if you're the only permanent space manager left, you won't be able to remove yourself from the space unless there is another permanent space manager in the space.

Ref: https://github.com/owncloud/ocis/issues/11831