### PR TITLE
feat: implement brute force protection for public links

### DIFF
--- a/internal/grpc/interceptors/metadata/metadata.go
+++ b/internal/grpc/interceptors/metadata/metadata.go
@@ -8,6 +8,7 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
+// NewUnary returns a server interceptor that will propagate GRPC metadata
 func NewUnary(autoPropPrefix string) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		md, ok := metadata.FromIncomingContext(ctx)
@@ -29,6 +30,7 @@ func NewUnary(autoPropPrefix string) grpc.UnaryServerInterceptor {
 	}
 }
 
+// NewStream returns a server interceptor that will propagate GRPC metadata
 func NewStream(autoPropPrefix string) grpc.StreamServerInterceptor {
 	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		ctx := ss.Context()
@@ -54,6 +56,8 @@ func NewStream(autoPropPrefix string) grpc.StreamServerInterceptor {
 	}
 }
 
+// newWrappedServerStream returns a wrapped server stream in order to customize
+// the GRPC server stream's context. It will use the one provided.
 func newWrappedServerStream(ctx context.Context, ss grpc.ServerStream) *wrappedServerStream {
 	return &wrappedServerStream{ServerStream: ss, newCtx: ctx}
 }
@@ -63,6 +67,7 @@ type wrappedServerStream struct {
 	newCtx context.Context
 }
 
+// Context returns the context of the server stream
 func (ss *wrappedServerStream) Context() context.Context {
 	return ss.newCtx
 }

--- a/internal/grpc/interceptors/metadata/metadata.go
+++ b/internal/grpc/interceptors/metadata/metadata.go
@@ -1,0 +1,68 @@
+package metadata
+
+import (
+	"context"
+	"strings"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+func NewUnary(autoPropPrefix string) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		md, ok := metadata.FromIncomingContext(ctx)
+		if !ok {
+			md = metadata.MD{}
+		}
+
+		pairs := make([]string, 0, md.Len()*2)
+		for key, values := range md {
+			if strings.HasPrefix(key, autoPropPrefix) {
+				for _, value := range values {
+					pairs = append(pairs, key, value)
+				}
+			}
+		}
+
+		newctx := metadata.AppendToOutgoingContext(ctx, pairs...)
+		return handler(newctx, req)
+	}
+}
+
+func NewStream(autoPropPrefix string) grpc.StreamServerInterceptor {
+	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		ctx := ss.Context()
+
+		md, ok := metadata.FromIncomingContext(ctx)
+		if !ok {
+			md = metadata.MD{}
+		}
+
+		pairs := make([]string, 0, md.Len()*2)
+		for key, values := range md {
+			if strings.HasPrefix(key, autoPropPrefix) {
+				for _, value := range values {
+					pairs = append(pairs, key, value)
+				}
+			}
+		}
+
+		newctx := metadata.AppendToOutgoingContext(ctx, pairs...)
+
+		wrapped := newWrappedServerStream(newctx, ss)
+		return handler(srv, wrapped)
+	}
+}
+
+func newWrappedServerStream(ctx context.Context, ss grpc.ServerStream) *wrappedServerStream {
+	return &wrappedServerStream{ServerStream: ss, newCtx: ctx}
+}
+
+type wrappedServerStream struct {
+	grpc.ServerStream
+	newCtx context.Context
+}
+
+func (ss *wrappedServerStream) Context() context.Context {
+	return ss.newCtx
+}

--- a/internal/grpc/services/gateway/authprovider.go
+++ b/internal/grpc/services/gateway/authprovider.go
@@ -65,6 +65,8 @@ func (s *svc) Authenticate(ctx context.Context, req *gateway.AuthenticateRequest
 		fallthrough
 	case res.Status.Code == rpc.Code_CODE_UNAUTHENTICATED:
 		fallthrough
+	case res.Status.Code == rpc.Code_CODE_RESOURCE_EXHAUSTED:
+		fallthrough
 	case res.Status.Code == rpc.Code_CODE_NOT_FOUND:
 		// normal failures, no need to log
 		return &gateway.AuthenticateResponse{

--- a/internal/http/services/owncloud/ocdav/dav.go
+++ b/internal/http/services/owncloud/ocdav/dav.go
@@ -330,6 +330,9 @@ func (h *DavHandler) Handler(s *svc) http.Handler {
 			case res.Status.Code == rpc.Code_CODE_NOT_FOUND:
 				w.WriteHeader(http.StatusNotFound)
 				return
+			case res.Status.Code == rpc.Code_CODE_RESOURCE_EXHAUSTED:
+				w.WriteHeader(http.StatusTooManyRequests)
+				return
 			case res.Status.Code != rpc.Code_CODE_OK:
 				w.WriteHeader(http.StatusInternalServerError)
 				return

--- a/pkg/auth/manager/publicshares/bruteforceprotection.go
+++ b/pkg/auth/manager/publicshares/bruteforceprotection.go
@@ -26,15 +26,9 @@ type BruteForceProtection struct {
 }
 
 // NewBruteForceProtection creates a new instance of BruteForceProtection
+// If either the timeGap or maxAttempts are 0, the BruteForceProtection
+// won't register any failed attempt and it will act as if it is disabled.
 func NewBruteForceProtection(timeGap time.Duration, maxAttempts int) *BruteForceProtection {
-	if timeGap == 0 {
-		timeGap = 1 * time.Hour
-	}
-
-	if maxAttempts == 0 {
-		maxAttempts = 5
-	}
-
 	return &BruteForceProtection{
 		rwmutex:     &sync.RWMutex{},
 		attemptMap:  make(map[string][]*attemptData),
@@ -44,7 +38,13 @@ func NewBruteForceProtection(timeGap time.Duration, maxAttempts int) *BruteForce
 }
 
 // AddAttempt register a new failed attempt for the provided public share
+// If the time gap or the max attempts are 0, the failed attempt won't be
+// registered
 func (bfp *BruteForceProtection) AddAttempt(shareToken string) {
+	if bfp.timeGap <= 0 || bfp.maxAttempts <= 0 {
+		return
+	}
+
 	bfp.rwmutex.Lock()
 	defer bfp.rwmutex.Unlock()
 

--- a/pkg/auth/manager/publicshares/bruteforceprotection.go
+++ b/pkg/auth/manager/publicshares/bruteforceprotection.go
@@ -1,0 +1,120 @@
+package publicshares
+
+import (
+	"sync"
+	"time"
+)
+
+// attemptData contains the data we need to store for each failed attempt.
+// Right now, only the timestamp of the failed attempt is needed
+type attemptData struct {
+	Timestamp int64
+}
+
+// BruteForceProtection implements a rate-limit-based protection for the
+// public shares.
+// Given a time duration (10 minutes, for example), a maximum of X failed
+// attempts are allowed. If that rate is reached, access to the public link
+// should be blocked until the rate decreases.
+// Note that the time the link should be blocked is undefined and will be
+// somewhere between 0 and the given duration
+type BruteForceProtection struct {
+	rwmutex     *sync.RWMutex
+	attemptMap  map[string][]*attemptData
+	timeGap     time.Duration
+	maxAttempts int
+}
+
+// NewBruteForceProtection creates a new instance of BruteForceProtection
+func NewBruteForceProtection(timeGap time.Duration, maxAttempts int) *BruteForceProtection {
+	if timeGap == 0 {
+		timeGap = 1 * time.Hour
+	}
+
+	if maxAttempts == 0 {
+		maxAttempts = 5
+	}
+
+	return &BruteForceProtection{
+		rwmutex:     &sync.RWMutex{},
+		attemptMap:  make(map[string][]*attemptData),
+		timeGap:     timeGap,
+		maxAttempts: maxAttempts,
+	}
+}
+
+// AddAttempt register a new failed attempt for the provided public share
+func (bfp *BruteForceProtection) AddAttempt(shareToken string) {
+	bfp.rwmutex.Lock()
+	defer bfp.rwmutex.Unlock()
+
+	attempt := &attemptData{
+		Timestamp: time.Now().Unix(),
+	}
+
+	bfp.attemptMap[shareToken] = append(bfp.attemptMap[shareToken], attempt)
+
+	// clean data if needed
+	bfp.checkProtection(shareToken)
+}
+
+// Verify checks if you're allowed to access to the public share based on the
+// registered failed attempts.
+// If the registered failed attempts are lower or equal than the maximum
+// allowed, this method will return true, meaning you're allowed to access
+// If the failed attempts are greater than the maximum allowed, this method
+// will return false. Note that there could be failed attempts that are no
+// longer applicable, so if this method return false you should call the
+// "CleanInfo" method to remove obsolete attempts.
+func (bfp *BruteForceProtection) Verify(shareToken string) bool {
+	bfp.rwmutex.RLock()
+	defer bfp.rwmutex.RUnlock()
+
+	attemptList, ok := bfp.attemptMap[shareToken]
+	if !ok {
+		// no failed attempt registered
+		return true
+	}
+
+	return len(attemptList) <= bfp.maxAttempts
+}
+
+// CleanInfo will remove obsolete failed attempts for the public share and
+// return whether you're allowed to access to the public share after cleaning
+// the info.
+func (bfp *BruteForceProtection) CleanInfo(shareToken string) bool {
+	bfp.rwmutex.Lock()
+	defer bfp.rwmutex.Unlock()
+
+	return bfp.checkProtection(shareToken)
+}
+
+// checkProtection return true if the check is successful and you're allowed
+// to access, false otherwise
+func (bfp *BruteForceProtection) checkProtection(shareToken string) bool {
+	// write lock should have been acquired before calling this method
+	minTimestamp := time.Now().Add(-1 * bfp.timeGap).Unix()
+
+	attemptList, ok := bfp.attemptMap[shareToken]
+	if !ok {
+		return true
+	}
+
+	var index int
+	for index = 0; index < len(attemptList); index++ {
+		if attemptList[index].Timestamp >= minTimestamp {
+			break
+		}
+	}
+
+	if index > len(attemptList) {
+		// the attempt info is obsolete
+		delete(bfp.attemptMap, shareToken)
+		return true
+	} else if index != 0 {
+		// remove obsolete info and leave only useful one
+		bfp.attemptMap[shareToken] = bfp.attemptMap[shareToken][index:]
+	}
+
+	return len(bfp.attemptMap[shareToken]) <= bfp.maxAttempts
+}

--- a/pkg/auth/manager/publicshares/publicshares.go
+++ b/pkg/auth/manager/publicshares/publicshares.go
@@ -132,7 +132,7 @@ func (m *manager) Authenticate(ctx context.Context, token, secret string) (*user
 	case publicShareResponse.Status.Code == rpcv1beta1.Code_CODE_NOT_FOUND:
 		return nil, nil, errtypes.NotFound(publicShareResponse.Status.Message)
 	case publicShareResponse.Status.Code == rpcv1beta1.Code_CODE_PERMISSION_DENIED:
-		if secret != "" && secret != "|" { // FIXME: needs better detection
+		if secret != "" && secret != "|" && !CheckSkipAttempt(ctx, token) { // FIXME: needs better detection
 			m.bfp.AddAttempt(token)
 		}
 		return nil, nil, errtypes.InvalidCredentials(publicShareResponse.Status.Message)

--- a/pkg/auth/manager/publicshares/publicshares.go
+++ b/pkg/auth/manager/publicshares/publicshares.go
@@ -28,13 +28,13 @@ import (
 	rpcv1beta1 "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	link "github.com/cs3org/go-cs3apis/cs3/sharing/link/v1beta1"
 	types "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
+	"github.com/mitchellh/mapstructure"
 	"github.com/owncloud/reva/v2/pkg/auth"
 	"github.com/owncloud/reva/v2/pkg/auth/manager/registry"
 	"github.com/owncloud/reva/v2/pkg/auth/scope"
 	"github.com/owncloud/reva/v2/pkg/errtypes"
 	"github.com/owncloud/reva/v2/pkg/rgrpc/todo/pool"
 	"github.com/owncloud/reva/v2/pkg/utils"
-	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 )
 
@@ -43,11 +43,14 @@ func init() {
 }
 
 type manager struct {
-	c *config
+	c   *config
+	bfp *BruteForceProtection
 }
 
 type config struct {
-	GatewayAddr string `mapstructure:"gateway_addr"`
+	GatewayAddr           string        `mapstructure:"gateway_addr"`
+	BruteForceTimeGap     time.Duration `mapstructure:"brute_force_time_gap"`
+	BruteForceMaxAttempts int           `mapstructure:"brute_force_max_attempts"`
 }
 
 func parseConfig(m map[string]interface{}) (*config, error) {
@@ -66,6 +69,7 @@ func New(m map[string]interface{}) (auth.Manager, error) {
 	if err != nil {
 		return nil, err
 	}
+	mgr.bfp = NewBruteForceProtection(mgr.c.BruteForceTimeGap, mgr.c.BruteForceMaxAttempts)
 	return mgr, nil
 }
 
@@ -79,6 +83,12 @@ func (m *manager) Configure(ml map[string]interface{}) error {
 }
 
 func (m *manager) Authenticate(ctx context.Context, token, secret string) (*user.User, map[string]*authpb.Scope, error) {
+	if !m.bfp.Verify(token) && !m.bfp.CleanInfo(token) {
+		// brute force protection fail to verify the token even after
+		// cleaning the info
+		return nil, nil, errtypes.TooManyRequests("Too many failed requests")
+	}
+
 	gwConn, err := pool.GetGatewayServiceClient(m.c.GatewayAddr)
 	if err != nil {
 		return nil, nil, err
@@ -122,6 +132,9 @@ func (m *manager) Authenticate(ctx context.Context, token, secret string) (*user
 	case publicShareResponse.Status.Code == rpcv1beta1.Code_CODE_NOT_FOUND:
 		return nil, nil, errtypes.NotFound(publicShareResponse.Status.Message)
 	case publicShareResponse.Status.Code == rpcv1beta1.Code_CODE_PERMISSION_DENIED:
+		if secret != "" && secret != "|" { // FIXME: needs better detection
+			m.bfp.AddAttempt(token)
+		}
 		return nil, nil, errtypes.InvalidCredentials(publicShareResponse.Status.Message)
 	case publicShareResponse.Status.Code != rpcv1beta1.Code_CODE_OK:
 		return nil, nil, errtypes.InternalError(publicShareResponse.Status.Message)

--- a/pkg/errtypes/errtypes.go
+++ b/pkg/errtypes/errtypes.go
@@ -205,6 +205,14 @@ func (e TooEarly) Error() string { return "error: too early: " + string(e) }
 // IsTooEarly implements the IsTooEarly interface.
 func (e TooEarly) IsTooEarly() {}
 
+// TooManyRequests is the error to use when too many requests have been received in a given period of time
+type TooManyRequests string
+
+func (e TooManyRequests) Error() string { return "error: too many requests: " + string(e) }
+
+// IsTooManyRequests implements the IsTooManyRequests interface
+func (e TooManyRequests) IsTooManyRequests() {}
+
 // IsNotFound is the interface to implement
 // to specify that a resource is not found.
 type IsNotFound interface {
@@ -295,6 +303,12 @@ type IsTooEarly interface {
 	IsTooEarly()
 }
 
+// IsTooManyRequests is the interface to implement
+// to specify that too many requests have been received in a period of time
+type IsTooManyRequests interface {
+	IsTooManyRequests()
+}
+
 // NewErrtypeFromStatus maps a rpc status to an errtype
 func NewErrtypeFromStatus(status *rpc.Status) error {
 	switch status.Code {
@@ -365,6 +379,8 @@ func NewErrtypeFromHTTPStatusCode(code int, message string) error {
 		return PartialContent(message)
 	case http.StatusTooEarly:
 		return TooEarly(message)
+	case http.StatusTooManyRequests:
+		return TooManyRequests(message)
 	case StatusChecksumMismatch:
 		return ChecksumMismatch(message)
 	default:
@@ -401,6 +417,8 @@ func NewHTTPStatusCodeFromErrtype(err error) int {
 		return http.StatusPartialContent
 	case TooEarly:
 		return http.StatusTooEarly
+	case TooManyRequests:
+		return http.StatusTooManyRequests
 	case ChecksumMismatch:
 		return StatusChecksumMismatch
 	default:

--- a/pkg/rgrpc/rgrpc.go
+++ b/pkg/rgrpc/rgrpc.go
@@ -30,6 +30,7 @@ import (
 	"github.com/owncloud/reva/v2/internal/grpc/interceptors/appctx"
 	"github.com/owncloud/reva/v2/internal/grpc/interceptors/auth"
 	"github.com/owncloud/reva/v2/internal/grpc/interceptors/log"
+	"github.com/owncloud/reva/v2/internal/grpc/interceptors/metadata"
 	"github.com/owncloud/reva/v2/internal/grpc/interceptors/recovery"
 	"github.com/owncloud/reva/v2/internal/grpc/interceptors/token"
 	"github.com/owncloud/reva/v2/internal/grpc/interceptors/useragent"
@@ -44,6 +45,11 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/reflection"
+)
+
+const (
+	// Prefix used to auto-propagate GRPC metadata across reva services
+	AutoPropPrefix = "autoprop-"
 )
 
 // UnaryInterceptors is a map of registered unary grpc interceptors.
@@ -336,6 +342,7 @@ func (s *Server) getInterceptors(unprotected []string) ([]grpc.ServerOption, err
 		log.NewUnary(),
 		recovery.NewUnary(),
 		authUnary,
+		metadata.NewUnary(AutoPropPrefix),
 	}
 
 	for _, t := range unaryTriples {
@@ -378,6 +385,7 @@ func (s *Server) getInterceptors(unprotected []string) ([]grpc.ServerOption, err
 		log.NewStream(),
 		recovery.NewStream(),
 		authStream,
+		metadata.NewStream(AutoPropPrefix),
 	}
 
 	for _, t := range streamTriples {

--- a/pkg/rgrpc/status/status.go
+++ b/pkg/rgrpc/status/status.go
@@ -161,6 +161,15 @@ func NewLocked(ctx context.Context, msg string) *rpc.Status {
 	}
 }
 
+// NewTooManyRequests return a status Code_CODE_RESOURCE_EXHAUSTED
+func NewTooManyRequests(ctx context.Context, msg string) *rpc.Status {
+	return &rpc.Status{
+		Code:    rpc.Code_CODE_RESOURCE_EXHAUSTED,
+		Message: msg,
+		Trace:   getTrace(ctx),
+	}
+}
+
 // NewStatusFromErrType returns a status that corresponds to the given errtype
 func NewStatusFromErrType(ctx context.Context, msg string, err error) *rpc.Status {
 	switch e := err.(type) {
@@ -191,6 +200,8 @@ func NewStatusFromErrType(ctx context.Context, msg string, err error) *rpc.Statu
 		return NewUnimplemented(ctx, err, msg+":"+err.Error())
 	case errtypes.BadRequest:
 		return NewInvalid(ctx, msg+":"+err.Error())
+	case errtypes.TooManyRequests:
+		return NewTooManyRequests(ctx, msg+": "+err.Error())
 	}
 
 	// map GRPC status codes coming from the auth middleware


### PR DESCRIPTION
Note: https://github.com/cs3org/go-cs3apis/blob/main/cs3/rpc/v1beta1/code.pb.go#L121-L125 has a recommended RPC matching for the "Too Many Requests" error, so we're following along.

Implement brute force protection for public shares. The implementation follows a rate-limit approach. This means that you can access the share while the access failure rate is below certain threshold. If such threshold is surpassed, the public share won't be accessible until the failure rate goes below the threshold.

By default, the failure rate is 5 failures per hour (configurable). This means that you're allowed to fail the password for the share up to 5 times per hour before the share is blocked.
The duration of the blockage will be undefined, but between 0 and the configuration duration:
* If the configuration is 10 failures each 2 hours, and the failures come in a quick burst (10 failures in a couple of seconds), the share will be blocked for 2 hours.
* With the same configuration, but with spaced failures, one every 10 minutes, the share will be blocked for around 30 minutes (20 minute gap for the last failure + 10 minutes until the first failure is out of the time scope)
* The share might be blocked just for a few seconds if the last allowed failure comes right before the 2 hours pass for the first failure.

~Note that this is an in-memory implementation, so the data won't be shared with other service replicas. This means that the **protection will be effective per-server replica**, which might not behave as expected: if there are 3 replicas, requests might block one replica but not others, and you might be allowed additional failures because requests will hit different replicas.~

Current implementation will use a reva store to make the related data accessible to all the service's replicas.
The recommended environment for the replicas is below (adjust the values if needed):
```
      LANG: C.UTF-8
      LC_ALL: C.UTF-8
      MICRO_REGISTRY: "nats-js-kv"
      MICRO_REGISTRY_ADDRESS: "ocis:9233"
      OCIS_RUNTIME_HOST: "ocis"
      OCIS_CONFIG_DIR: /etc/ocis/
      OCIS_URL: https://${OCIS_DOMAIN:-ocis.owncloud.test}
      OCIS_INSECURE: true

      STORAGE_PUBLICLINK_GRPC_ADDR: 0.0.0.0:9178
      OCIS_PERSISTENT_STORE: "nats-js-kv"
      OCIS_PERSISTENT_STORE_NODES: "ocis:9233"
```

### TODO:
* ~It needs a way to disable the feature. Right now, we need to keep timestamps in memory to keep track of the failed attempts. The greater the maximum number of attempts is, the more memory we might need to use; this also applies to the duration we need to store the timestamps.~
  Setting the configuration values with zeros will effectively disable the feature
* When writing data into the store, the "check" implementation (`areEqualLists`) is too strict and could lead to excessive retries and / or failures.
* Need to replace the RWLock for a regular mutex because the RWLock isn't needed any longer.
* Consider to include some logs to know what's going on.
* Consider to include an ID as part of the attempt data. At the moment, if 2 replicas try to write an attempt at the same exact second, it isn't possible to know which replica has written the attempt and both replicas will assume that the written attempt is theirs, so only one attempt will be registered instead of the expected 2 (one per replica).
* Consider to increase the time resolution, currently at seconds. This might not be needed if we use IDs.