### PR TITLE
[tests-only][full-ci] Bump latest ocis commit id on main branch

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,4 +1,4 @@
 # The test runner source for API tests
-APITESTS_COMMITID=327141eea1c023c1729f2dba6f292427ff67b933
+APITESTS_COMMITID=624b646bf3a4343d1d11f517d544067781a49131
 APITESTS_BRANCH=master
 APITESTS_REPO_GIT_URL=https://github.com/owncloud/ocis.git


### PR DESCRIPTION
## Description
Bump latest ocis `master` branch commit id.

Part of: https://github.com/owncloud/QA/issues/913