### PR TITLE
[tests-only][full-ci] Bump latest ocis commit id on main branch

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,4 +1,4 @@
 # The test runner source for API tests
-APITESTS_COMMITID=9227c7f6f755c0a646bf3c01921c1842fefe5b7a
+APITESTS_COMMITID=2c918627b370fae0ad1e1074c3f022866dab1d4a
 APITESTS_BRANCH=master
 APITESTS_REPO_GIT_URL=https://github.com/owncloud/ocis.git


### PR DESCRIPTION
## Description
Bump latest ocis `master` branch commit id.

Part of: https://github.com/owncloud/QA/issues/927