### PR TITLE
fix: trying to remove an already deleted space permission will success

### DIFF
--- a/internal/grpc/services/gateway/usershareprovider.go
+++ b/internal/grpc/services/gateway/usershareprovider.go
@@ -770,7 +770,8 @@ func (s *svc) removeSpaceShare(ctx context.Context, ref *provider.ResourceId, gr
 		}
 	}
 	if permissions == nil {
-		return nil, errors.New("gateway: error getting grant to remove from storage")
+		// The grantee is missing; assume it was already removed
+		return &collaboration.RemoveShareResponse{Status: status.NewOK(ctx)}, nil
 	}
 
 	if len(listGrantRes.Grants) == 1 || !isSpaceManagerRemaining(listGrantRes.Grants, grantee) {


### PR DESCRIPTION
Trying to delete an already deleted permission from a space was causing a 500 error.

The easiest way to reproduce the issue is to resend the delete request that happens when a user is removed from a space. You can use the web developer tools for that.
This can also happen with multiple clients: manager A and manager B see the same space information from web and mobile respectively. They both try to delete a user from a space at the same time. One of them (the second one) will receive the 500 error.

This fix will cause the request to finish with a 204 code, as if the deletion was successful (the user isn't a member of the space anyway).