### PR TITLE
fix: flaky wopi test due to app registry ordering

### DIFF
--- a/changelog/unreleased/fix-wopi-app-open-with-web-due-to-app-registry-ordering.md
+++ b/changelog/unreleased/fix-wopi-app-open-with-web-due-to-app-registry-ordering.md
@@ -1,0 +1,5 @@
+Bugfix: Fix WOPI open-with-web due to app registry ordering
+
+Made app selection deterministic when no app is specified: the system now uses the configured default app for the file type, or picks the first provider sorted by priority then name, ensuring users get consistent results instead of random app selection based on registration timing.
+
+https://github.com/owncloud/reva/pull/540

--- a/pkg/app/registry/micro/micro_test.go
+++ b/pkg/app/registry/micro/micro_test.go
@@ -997,7 +997,7 @@ func registerWithMicroReg(ns string, p *registrypb.ProviderInfo) error {
 	node.Metadata[ns+".app-provider.icon"] = p.Icon
 
 	node.Metadata[ns+".app-provider.allow_creation"] = registrypb.ProviderInfo_Capability_name[int32(p.Capability)]
-	node.Metadata[ns+".app-provider.priority"] = getPriority(p)
+	node.Metadata[ns+".app-provider.priority"] = GetPriority(p)
 	if p.DesktopOnly {
 		node.Metadata[ns+".app-provider.desktop_only"] = "true"
 	}


### PR DESCRIPTION
Fixes potential cause of flakiness in [wopi.feature](https://github.com/owncloud/ocis/blob/7429b6ca927b291f67ac5821dbfb5dcf98d8ddee/tests/acceptance/features/apiCollaboration/wopi.feature
), failed 10 pipelines in ocis/master last 200 commits alone

**Likely root cause:** Test assumes default app = FakeOffice when no `app_name`; server uses first provider from registry (order = priority then registration, or snapshot timing); that first provider is not guaranteed to be FakeOffice. 

- **Tests:** Four open-with-web scenarios (wopi.feature **348–372**, **396**, **418**, **449**) send POST to `/app/open-with-web?...` with no `app_name` in the second example row; **FeatureContext::theJsonDataOfTheResponseShouldMatch()** asserts `uri` matches a pattern with **`app=FakeOffice`**.
- **Missing in tests:** No check that FakeOffice is in the provider list or first; no call to `/app/list` before asserting; the second row does not send `app_name=FakeOffice` even though the assertion requires it.
- **Missing in server:** When `app_name` is empty, **appprovider.go 394–411** sets **`appName = apps.Providers[0].Name`**; the handler never uses `default_app` or **GetDefaultProviderForMimeType** (registry config in `ocis/tests/config/drone/app-registry.yaml` has `default_app: FakeOffice` but that is not honored).
- **Provider list source:** **appregistry.go 103–112** returns `Providers: p` from **FindProviders(ctx, MimeType)**; order = registry order (static: static.go **153–178** heap/registration order; micro: **micro/manager.go 219–236** `sortByPriority(lst)` then registration order into `m.mimeTypes`).
- **Most of the time:** Micro registry **sortByPriority** (manager.go **225**) keeps stable order when all have default priority "0"; if CI runs wopi-fakeoffice → wopi-collabora → wopi-onlyoffice sequentially, FakeOffice registers first and is **Providers[0]**, so the test passes.
- **When flakiness strikes:** Either (a) **Providers[0]** is Collabora (registration order or priority differs), so response `uri` contains `app=Collabora` and the schema pattern `app=FakeOffice` fails; or (b) **updateProvidersFromMicroRegistry()** snapshot (manager.go **63**, ticker **69–86** every 30s) was taken before FakeOffice registered, so FakeOffice is missing from the list and **Providers[0]** is again another app (e.g. Collabora).
- **Evidence in fails:** failed steps logs show `"app=Collabora"` in `uri` vs expected `app=FakeOffice`; failed step is **localApiTests-wopi**; scenario e.g. **open file with .odt extension (open-with-web)** at wopi.feature **348** (second example row).

**Possible fixes**
1. Change `open-with-web` fallback in `reva/internal/http/services/appprovider/appprovider.go` to resolve default app via `GetDefaultProviderForMimeType` (or equivalent deterministic policy) instead of `apps.Providers[0]`.  default_app for that MIME type (in oCIS CI that’s default_app: FakeOffice in tests/config/drone/app-registry.yaml), making the chosen app deterministic and matching what the WOPI tests assert. 
2. Keep current server behavior but enforce deterministic registry order in CI by assigning explicit app-provider priorities (FakeOffice highest) so `sortByPriority` always yields stable first provider. reva has priority config, however oCIS does not expose it.
3. Keep server behavior unchanged and split acceptance tests into explicit-app vs no-app cases, where no-app assertions validate selected app from `/app/list` (or any valid provider) rather than hardcoded `app=FakeOffice`.  
