### PR TITLE
fix: use NodeID instead of SpaceID for UploadReady event resource_id

### DIFF
--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -390,7 +390,7 @@ func (fs *Decomposedfs) Postprocessing(ch <-chan events.Event) {
 						ResourceId: &provider.ResourceId{
 							StorageId: session.ProviderID(),
 							SpaceId:   session.SpaceID(),
-							OpaqueId:  session.SpaceID(),
+							OpaqueId:  session.NodeID(),
 						},
 						Path: utils.MakeRelativePath(filepath.Join(session.Dir(), session.Filename())),
 					},

--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -392,7 +392,6 @@ func (fs *Decomposedfs) Postprocessing(ch <-chan events.Event) {
 							SpaceId:   session.SpaceID(),
 							OpaqueId:  session.NodeID(),
 						},
-						Path: utils.MakeRelativePath(filepath.Join(session.Dir(), session.Filename())),
 					},
 					Timestamp:         utils.TimeToTS(now),
 					SpaceOwner:        n.SpaceOwnerOrManager(ctx),

--- a/pkg/storage/utils/decomposedfs/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload.go
@@ -101,7 +101,7 @@ func (fs *Decomposedfs) Upload(ctx context.Context, req storage.UploadRequest, u
 			ResourceId: &provider.ResourceId{
 				StorageId: session.ProviderID(),
 				SpaceId:   session.SpaceID(),
-				OpaqueId:  session.SpaceID(),
+				OpaqueId:  session.NodeID(),
 			},
 			Path: utils.MakeRelativePath(filepath.Join(session.Dir(), session.Filename())),
 		}

--- a/pkg/storage/utils/decomposedfs/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload.go
@@ -103,7 +103,6 @@ func (fs *Decomposedfs) Upload(ctx context.Context, req storage.UploadRequest, u
 				SpaceId:   session.SpaceID(),
 				OpaqueId:  session.NodeID(),
 			},
-			Path: utils.MakeRelativePath(filepath.Join(session.Dir(), session.Filename())),
 		}
 		executant := session.Executant()
 		uff(session.SpaceOwner(), &executant, uploadRef)


### PR DESCRIPTION
## Summary

The `UploadReady` event and upload-finished callback both set `FileRef.ResourceId.OpaqueId` to `session.SpaceID()` instead of `session.NodeID()`, and include an unnecessary `Path` field. Every upload reports the space root UUID as the file identifier rather than the actual file's node ID.

## Fix

1. **`OpaqueId`**: Changed from `session.SpaceID()` to `session.NodeID()` in both locations
2. **`Path`**: Removed — with `OpaqueId` pointing directly to the file node, the Path is redundant and causes `CODE_NOT_FOUND` errors (NodeFromResource resolves the node from OpaqueId, then tries to walk Path from that node, which fails for file nodes)

The correct pattern already exists in `upload.go:117` (`FinishUpload` return value).

## Changes

| File | Change |
|------|--------|
| `decomposedfs.go:393` | `SpaceID()` → `NodeID()`, removed `Path` in UploadReady event |
| `upload.go:104` | `SpaceID()` → `NodeID()`, removed `Path` in upload-finished callback |

oCIS vendored PR: https://github.com/owncloud/ocis/pull/12057
Issue: https://github.com/owncloud/ocis/issues/12056

🤖 Generated with [Claude Code](https://claude.com/claude-code)