### PR TITLE
fix: add ResourceID field to UploadReady event

### DIFF
--- a/pkg/events/postprocessing.go
+++ b/pkg/events/postprocessing.go
@@ -184,10 +184,10 @@ type UploadReady struct {
 	ExecutingUser     *user.User
 	ImpersonatingUser *user.User
 	FileRef           *provider.Reference
+	ResourceID        *provider.ResourceId
 	Timestamp         *types.Timestamp
 	Failed            bool
 	IsVersion         bool
-	// add reference here? We could use it to inform client pp is finished
 }
 
 // Unmarshal to fulfill umarshaller interface

--- a/pkg/storage/fs/posix/tree/assimilation.go
+++ b/pkg/storage/fs/posix/tree/assimilation.go
@@ -504,6 +504,7 @@ func (t *Tree) assimilate(item scanItem) error {
 				t.PublishEvent(events.UploadReady{
 					SpaceOwner: user,
 					FileRef:    ref,
+					ResourceID: ref.ResourceId,
 					Timestamp:  utils.TSNow(),
 				})
 			}

--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -394,6 +394,11 @@ func (fs *Decomposedfs) Postprocessing(ch <-chan events.Event) {
 						},
 						Path: utils.MakeRelativePath(filepath.Join(session.Dir(), session.Filename())),
 					},
+					ResourceID: &provider.ResourceId{
+						StorageId: session.ProviderID(),
+						SpaceId:   session.SpaceID(),
+						OpaqueId:  session.NodeID(),
+					},
 					Timestamp:         utils.TimeToTS(now),
 					SpaceOwner:        n.SpaceOwnerOrManager(ctx),
 					IsVersion:         isVersion,

--- a/pkg/storage/utils/decomposedfs/upload_async_test.go
+++ b/pkg/storage/utils/decomposedfs/upload_async_test.go
@@ -92,6 +92,9 @@ var _ = Describe("Async file uploads", Ordered, func() {
 			ev, ok := (<-pub).(events.UploadReady)
 			Expect(ok).To(BeTrue())
 			Expect(ev.Failed).To(BeFalse())
+			Expect(ev.ResourceID).ToNot(BeNil())
+			Expect(ev.ResourceID.OpaqueId).ToNot(BeEmpty())
+			Expect(ev.ResourceID.OpaqueId).ToNot(Equal(ev.ResourceID.SpaceId), "ResourceID.OpaqueId should be the file node ID, not the space ID")
 		}
 
 		failPostprocessing = func(uploadID string, outcome events.PostprocessingOutcome) {


### PR DESCRIPTION
## Summary

The `UploadReady` event's `FileRef.ResourceId.OpaqueId` is set to the space root ID (required for CS3 gateway path resolution). Consumers that need the file's actual node ID get the space root instead.

## Fix

Add a separate `ResourceID` field to the `UploadReady` struct, following the same pattern used by `BytesReceived`. This carries the file's actual resource identifier with `OpaqueId` set to `session.NodeID()`.

`FileRef` is unchanged — CS3 gateway resolution continues to work. The new `ResourceID` gives consumers the correct file node ID for Graph API / PROPFIND operations.

## Why not just fix OpaqueId in FileRef?

A previous attempt (owncloud/ocis#12057, closed) changed `FileRef.ResourceId.OpaqueId` from `SpaceID()` to `NodeID()`. This broke CS3 gateway resolution: `NodeFromResource()` resolves the node from `OpaqueId`, then walks `FileRef.Path` from that node. With `OpaqueId` pointing to a file node, `WalkPath` fails because files can't have children (`CODE_NOT_FOUND`).

Removing `Path` to avoid the walk failure also broke external NATS consumers that read the file path from `FileRef.Path`.

The `ResourceID` field approach avoids both issues.

## Changes

| File | Change |
|------|--------|
| `pkg/events/postprocessing.go` | Add `ResourceID *provider.ResourceId` to `UploadReady` struct |
| `pkg/storage/utils/decomposedfs/decomposedfs.go` | Populate `ResourceID` with `session.NodeID()` |
| `pkg/storage/fs/posix/tree/assimilation.go` | Populate `ResourceID` from existing `ref.ResourceId` |

oCIS vendored PR: https://github.com/owncloud/ocis/pull/XXXXX
Issue: https://github.com/owncloud/ocis/issues/12056

🤖 Generated with [Claude Code](https://claude.com/claude-code)