### PR TITLE
fix: UploadReady FileRef uses SpaceID instead of NodeID

### DIFF
--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -390,9 +390,8 @@ func (fs *Decomposedfs) Postprocessing(ch <-chan events.Event) {
 						ResourceId: &provider.ResourceId{
 							StorageId: session.ProviderID(),
 							SpaceId:   session.SpaceID(),
-							OpaqueId:  session.SpaceID(),
+							OpaqueId:  session.NodeID(),
 						},
-						Path: utils.MakeRelativePath(filepath.Join(session.Dir(), session.Filename())),
 					},
 					ResourceID: &provider.ResourceId{
 						StorageId: session.ProviderID(),

--- a/pkg/storage/utils/decomposedfs/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload.go
@@ -101,9 +101,8 @@ func (fs *Decomposedfs) Upload(ctx context.Context, req storage.UploadRequest, u
 			ResourceId: &provider.ResourceId{
 				StorageId: session.ProviderID(),
 				SpaceId:   session.SpaceID(),
-				OpaqueId:  session.SpaceID(),
+				OpaqueId:  session.NodeID(),
 			},
-			Path: utils.MakeRelativePath(filepath.Join(session.Dir(), session.Filename())),
 		}
 		executant := session.Executant()
 		uff(session.SpaceOwner(), &executant, uploadRef)


### PR DESCRIPTION
## Summary

- **FileRef.ResourceId.OpaqueId** was set to `session.SpaceID()` instead of `session.NodeID()` in both the postprocessing event and the upload-finished callback. Every upload event reported the space root UUID as the file identifier instead of the actual file node ID.
- **FileRef.Path** was redundant now that PR #547 added the `ResourceID` field with the correct node reference. Removed it from both locations.

Related:
- https://github.com/owncloud/ocis/issues/12056
- https://github.com/owncloud/ocis/pull/12060
- https://github.com/owncloud/reva/pull/546
- https://github.com/owncloud/reva/pull/547

## Test plan

- [x] `go build ./pkg/storage/utils/decomposedfs/...` passes
- [x] `go test ./pkg/storage/utils/decomposedfs/...` all tests pass
- [ ] Verify UploadReady event consumers receive the correct file node ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)