### PR TITLE
Revert "fix: UploadReady FileRef uses SpaceID instead of NodeID"

### DIFF
--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -390,8 +390,9 @@ func (fs *Decomposedfs) Postprocessing(ch <-chan events.Event) {
 						ResourceId: &provider.ResourceId{
 							StorageId: session.ProviderID(),
 							SpaceId:   session.SpaceID(),
-							OpaqueId:  session.NodeID(),
+							OpaqueId:  session.SpaceID(),
 						},
+						Path: utils.MakeRelativePath(filepath.Join(session.Dir(), session.Filename())),
 					},
 					ResourceID: &provider.ResourceId{
 						StorageId: session.ProviderID(),

--- a/pkg/storage/utils/decomposedfs/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload.go
@@ -101,8 +101,9 @@ func (fs *Decomposedfs) Upload(ctx context.Context, req storage.UploadRequest, u
 			ResourceId: &provider.ResourceId{
 				StorageId: session.ProviderID(),
 				SpaceId:   session.SpaceID(),
-				OpaqueId:  session.NodeID(),
+				OpaqueId:  session.SpaceID(),
 			},
+			Path: utils.MakeRelativePath(filepath.Join(session.Dir(), session.Filename())),
 		}
 		executant := session.Executant()
 		uff(session.SpaceOwner(), &executant, uploadRef)


### PR DESCRIPTION
owncloud/reva#560 Reverts the breaking change.
Ocis bump https://github.com/owncloud/ocis/pull/12137