### PR TITLE
feat(conversions): [OCISDEV-807] add SpaceEditorWithoutVersionsWithoutTrashbin role

### DIFF
--- a/changelog/unreleased/add-space-editor-without-versions-without-trashbin-role.md
+++ b/changelog/unreleased/add-space-editor-without-versions-without-trashbin-role.md
@@ -5,4 +5,4 @@ Added a new `NewSpaceEditorWithoutVersionsWithoutTrashbinRole` constructor and
 editor permissions (create, upload, download, edit, move, delete) on a space
 without access to file versions or the trashbin.
 
-https://github.com/owncloud/reva/pull/PLACEHOLDER
+https://github.com/owncloud/reva/pull/575

--- a/changelog/unreleased/add-space-editor-without-versions-without-trashbin-role.md
+++ b/changelog/unreleased/add-space-editor-without-versions-without-trashbin-role.md
@@ -1,0 +1,8 @@
+Enhancement: Add SpaceEditorWithoutVersionsWithoutTrashbin role
+
+Added a new `NewSpaceEditorWithoutVersionsWithoutTrashbinRole` constructor and
+`RoleSpaceEditorWithoutVersionsWithoutTrashbin` constant. This role grants full
+editor permissions (create, upload, download, edit, move, delete) on a space
+without access to file versions or the trashbin.
+
+https://github.com/owncloud/reva/pull/PLACEHOLDER

--- a/pkg/conversions/role.go
+++ b/pkg/conversions/role.go
@@ -299,74 +299,6 @@ func NewEditorListGrantsWithVersionsRole() *Role {
 	return role
 }
 
-// NewSpaceEditorRole creates an editor role
-func NewSpaceEditorRole() *Role {
-	return &Role{
-		Name: RoleSpaceEditor,
-		cS3ResourcePermissions: &provider.ResourcePermissions{
-			CreateContainer:      true,
-			Delete:               true,
-			GetPath:              true,
-			GetQuota:             true,
-			InitiateFileDownload: true,
-			InitiateFileUpload:   true,
-			ListContainer:        true,
-			ListFileVersions:     true,
-			ListGrants:           true,
-			ListRecycle:          true,
-			Move:                 true,
-			RestoreFileVersion:   true,
-			RestoreRecycleItem:   true,
-			Stat:                 true,
-		},
-		ocsPermissions: PermissionRead | PermissionCreate | PermissionWrite | PermissionDelete,
-	}
-}
-
-// NewSpaceEditorWithoutVersionsRole creates an editor without list/restore versions role
-func NewSpaceEditorWithoutVersionsRole() *Role {
-	return &Role{
-		Name: RoleSpaceEditorWithoutVersions,
-		cS3ResourcePermissions: &provider.ResourcePermissions{
-			CreateContainer:      true,
-			Delete:               true,
-			GetPath:              true,
-			GetQuota:             true,
-			InitiateFileDownload: true,
-			InitiateFileUpload:   true,
-			ListContainer:        true,
-			ListGrants:           true,
-			ListRecycle:          true,
-			Move:                 true,
-			RestoreRecycleItem:   true,
-			Stat:                 true,
-		},
-		ocsPermissions: PermissionRead | PermissionCreate | PermissionWrite | PermissionDelete,
-	}
-}
-
-// NewSpaceEditorWithoutTrashbinRole creates an editor role without list/restore resources in trashbin on a space.
-func NewSpaceEditorWithoutTrashbinRole() *Role {
-	return &Role{
-		Name: RoleSpaceEditorWithoutTrashbin,
-		cS3ResourcePermissions: &provider.ResourcePermissions{
-			CreateContainer:      true,
-			Delete:               true,
-			GetPath:              true,
-			GetQuota:             true,
-			InitiateFileDownload: true,
-			InitiateFileUpload:   true,
-			ListContainer:        true,
-			ListFileVersions:     true,
-			ListGrants:           true,
-			Move:                 true,
-			RestoreFileVersion:   true,
-			Stat:                 true,
-		},
-		ocsPermissions: PermissionRead | PermissionCreate | PermissionWrite | PermissionDelete,
-	}
-}
-
 // NewSpaceEditorWithoutVersionsWithoutTrashbinRole creates an editor role without list/restore versions and without list/restore resources in trashbin on a space.
 func NewSpaceEditorWithoutVersionsWithoutTrashbinRole() *Role {
 	return &Role{
@@ -385,6 +317,33 @@ func NewSpaceEditorWithoutVersionsWithoutTrashbinRole() *Role {
 		},
 		ocsPermissions: PermissionRead | PermissionCreate | PermissionWrite | PermissionDelete,
 	}
+}
+
+// NewSpaceEditorWithoutVersionsRole creates an editor without list/restore versions role
+func NewSpaceEditorWithoutVersionsRole() *Role {
+	role := NewSpaceEditorWithoutVersionsWithoutTrashbinRole()
+	role.Name = RoleSpaceEditorWithoutVersions
+	role.cS3ResourcePermissions.ListRecycle = true
+	role.cS3ResourcePermissions.RestoreRecycleItem = true
+	return role
+}
+
+// NewSpaceEditorWithoutTrashbinRole creates an editor role without list/restore resources in trashbin on a space.
+func NewSpaceEditorWithoutTrashbinRole() *Role {
+	role := NewSpaceEditorWithoutVersionsWithoutTrashbinRole()
+	role.Name = RoleSpaceEditorWithoutTrashbin
+	role.cS3ResourcePermissions.ListFileVersions = true
+	role.cS3ResourcePermissions.RestoreFileVersion = true
+	return role
+}
+
+// NewSpaceEditorRole creates an editor role
+func NewSpaceEditorRole() *Role {
+	role := NewSpaceEditorWithoutVersionsRole()
+	role.Name = RoleSpaceEditor
+	role.cS3ResourcePermissions.ListFileVersions = true
+	role.cS3ResourcePermissions.RestoreFileVersion = true
+	return role
 }
 
 // NewFileEditorRole creates a file-editor role

--- a/pkg/conversions/role.go
+++ b/pkg/conversions/role.go
@@ -53,6 +53,8 @@ const (
 	RoleSpaceEditorWithoutVersions = "spaceeditor-without-versions"
 	// RoleSpaceEditorWithoutTrashbin grants editor permission without list/restore resources in trashbin on a space.
 	RoleSpaceEditorWithoutTrashbin = "spaceeditor-without-trashbin"
+	// RoleSpaceEditorWithoutVersionsWithoutTrashbin grants editor permission without list/restore versions and without list/restore resources in trashbin on a space.
+	RoleSpaceEditorWithoutVersionsWithoutTrashbin = "spaceeditor-without-versions-without-trashbin"
 	// RoleFileEditor grants editor permission on a single file.
 	RoleFileEditor = "file-editor"
 	// RoleFileEditorListGrants grants editor permission on a single file.
@@ -183,6 +185,8 @@ func RoleFromName(name string) *Role {
 		return NewSpaceEditorRole()
 	case RoleSpaceEditorWithoutTrashbin:
 		return NewSpaceEditorWithoutTrashbinRole()
+	case RoleSpaceEditorWithoutVersionsWithoutTrashbin:
+		return NewSpaceEditorWithoutVersionsWithoutTrashbinRole()
 	case RoleFileEditor:
 		return NewFileEditorRole()
 	case RoleFileEditorListGrants:
@@ -357,6 +361,26 @@ func NewSpaceEditorWithoutTrashbinRole() *Role {
 			ListGrants:           true,
 			Move:                 true,
 			RestoreFileVersion:   true,
+			Stat:                 true,
+		},
+		ocsPermissions: PermissionRead | PermissionCreate | PermissionWrite | PermissionDelete,
+	}
+}
+
+// NewSpaceEditorWithoutVersionsWithoutTrashbinRole creates an editor role without list/restore versions and without list/restore resources in trashbin on a space.
+func NewSpaceEditorWithoutVersionsWithoutTrashbinRole() *Role {
+	return &Role{
+		Name: RoleSpaceEditorWithoutVersionsWithoutTrashbin,
+		cS3ResourcePermissions: &provider.ResourcePermissions{
+			CreateContainer:      true,
+			Delete:               true,
+			GetPath:              true,
+			GetQuota:             true,
+			InitiateFileDownload: true,
+			InitiateFileUpload:   true,
+			ListContainer:        true,
+			ListGrants:           true,
+			Move:                 true,
 			Stat:                 true,
 		},
 		ocsPermissions: PermissionRead | PermissionCreate | PermissionWrite | PermissionDelete,

--- a/pkg/conversions/role_test.go
+++ b/pkg/conversions/role_test.go
@@ -120,3 +120,31 @@ func TestSufficientPermissions(t *testing.T) {
 		assert.Equal(t, test.Sufficient, SufficientCS3Permissions(test.Existing, test.Requested))
 	}
 }
+
+func TestNewSpaceEditorWithoutVersionsWithoutTrashbinRole(t *testing.T) {
+	role := NewSpaceEditorWithoutVersionsWithoutTrashbinRole()
+	p := role.CS3ResourcePermissions()
+
+	assert.Equal(t, RoleSpaceEditorWithoutVersionsWithoutTrashbin, role.Name)
+
+	// should have basic editor permissions
+	assert.True(t, p.CreateContainer)
+	assert.True(t, p.Delete)
+	assert.True(t, p.GetPath)
+	assert.True(t, p.GetQuota)
+	assert.True(t, p.InitiateFileDownload)
+	assert.True(t, p.InitiateFileUpload)
+	assert.True(t, p.ListContainer)
+	assert.True(t, p.ListGrants)
+	assert.True(t, p.Move)
+	assert.True(t, p.Stat)
+
+	// should not have version permissions
+	assert.False(t, p.ListFileVersions)
+	assert.False(t, p.RestoreFileVersion)
+
+	// should not have trashbin permissions
+	assert.False(t, p.ListRecycle)
+	assert.False(t, p.RestoreRecycleItem)
+	assert.False(t, p.PurgeRecycle)
+}


### PR DESCRIPTION
## Summary

- Adds `RoleSpaceEditorWithoutVersionsWithoutTrashbin` constant and `NewSpaceEditorWithoutVersionsWithoutTrashbinRole()` constructor
- Refactors `NewSpaceEditorWithoutVersionsRole`, `NewSpaceEditorWithoutTrashbinRole` and `NewSpaceEditorRole` to compose from the new base role
- Adds `RoleFromName` case for the new role
- Adds unit test verifying permissions are correctly set/unset

## Test plan

- [x] `go test ./pkg/conversions/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)