### PR TITLE
[OCISDEV-822] preserve upload bin on Finalize failure

### DIFF
--- a/changelog/unreleased/fix-preserve-upload-bin-on-finalize-failure.md
+++ b/changelog/unreleased/fix-preserve-upload-bin-on-finalize-failure.md
@@ -1,0 +1,11 @@
+Bugfix: Preserve upload bin when synchronous Finalize fails
+
+When a synchronous upload finalization (e.g. storage-system with NFS blobstore) called
+Finalize and WriteBlob failed, Cleanup was invoked with cleanBin=true unconditionally.
+This permanently deleted the bin file from uploads/ even though the blob never reached
+blobs/, making it unrecoverable — including via the move-stuck-upload-blobs CLI.
+
+Fix: only clean the bin file when Finalize succeeds (err == nil), so a failed upload
+bin is preserved for manual recovery.
+
+https://github.com/owncloud/reva/pull/577

--- a/pkg/storage/utils/decomposedfs/upload/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload/upload.go
@@ -238,7 +238,7 @@ func (session *OcisSession) FinishUploadDecomposed(ctx context.Context) error {
 	if !session.store.async || session.info.Size == 0 {
 		// handle postprocessing synchronously
 		err = session.Finalize(ctx)
-		session.Cleanup(err != nil, true, true, true)
+		session.Cleanup(err != nil, err == nil, true, true)
 		if err != nil {
 			log.Error().Err(err).Msg("failed to upload")
 			return err


### PR DESCRIPTION
## Summary

- When `Finalize` fails during synchronous upload finalization, `Cleanup` was called with `cleanBin=true` unconditionally, permanently deleting the bin file from `uploads/` even though the blob never reached `blobs/`
- This made blobs unrecoverable — including via `move-stuck-upload-blobs` — causing e.g. missing `received.json` blobs in the jsoncs3 share manager metadata space
- Fix: pass `err == nil` as `cleanBin` so the bin is only removed on success

## Test plan

- [ ] Trigger a `WriteBlob` failure during synchronous finalization (e.g. cross-device rename on NFS); confirm bin file is preserved in `uploads/`
- [ ] Confirm successful uploads still clean up the bin file normally
- [ ] Run `move-stuck-upload-blobs` after a failed finalization; confirm the bin is now recoverable

🤖 Generated with [Claude Code](https://claude.com/claude-code)