### PR TITLE
fix: Return 404 when deleting a non-existing link share on a space

### DIFF
--- a/changelog/unreleased/bugfix-delete-nonexisting-space-link-returns-404.md
+++ b/changelog/unreleased/bugfix-delete-nonexisting-space-link-returns-404.md
@@ -1,0 +1,8 @@
+Bugfix: Return 404 when removing a non-existing public or user share
+
+`RemovePublicShare` and `RemoveShare` returned `CODE_INTERNAL` when the
+share to be deleted was not found, causing callers to receive a 500 error
+instead of the correct 404. Both handlers now propagate `IsNotFound`
+errors from the share manager as `CODE_NOT_FOUND`.
+
+https://github.com/owncloud/reva/pull/581

--- a/internal/grpc/services/publicshareprovider/publicshareprovider.go
+++ b/internal/grpc/services/publicshareprovider/publicshareprovider.go
@@ -31,13 +31,13 @@ import (
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	link "github.com/cs3org/go-cs3apis/cs3/sharing/link/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	"github.com/mitchellh/mapstructure"
 	"github.com/owncloud/reva/v2/pkg/password"
 	"github.com/owncloud/reva/v2/pkg/permission"
 	"github.com/owncloud/reva/v2/pkg/rgrpc/todo/pool"
 	"github.com/owncloud/reva/v2/pkg/sharedconf"
 	"github.com/owncloud/reva/v2/pkg/storage/utils/grants"
 	"github.com/owncloud/reva/v2/pkg/utils"
-	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"google.golang.org/grpc"
@@ -352,9 +352,14 @@ func (s *service) RemovePublicShare(ctx context.Context, req *link.RemovePublicS
 	user := ctxpkg.ContextMustGetUser(ctx)
 	ps, err := s.sm.GetPublicShare(ctx, user, req.GetRef(), false)
 	if err != nil {
-		return &link.RemovePublicShareResponse{
-			Status: status.NewInternal(ctx, "error loading public share"),
-		}, err
+		var st *rpc.Status
+		switch err.(type) {
+		case errtypes.IsNotFound:
+			st = status.NewNotFound(ctx, err.Error())
+		default:
+			st = status.NewInternal(ctx, "error loading public share")
+		}
+		return &link.RemovePublicShareResponse{Status: st}, nil
 	}
 
 	sRes, err := gatewayClient.Stat(ctx, &provider.StatRequest{Ref: &provider.Reference{ResourceId: ps.ResourceId}})

--- a/internal/grpc/services/publicshareprovider/publicshareprovider_test.go
+++ b/internal/grpc/services/publicshareprovider/publicshareprovider_test.go
@@ -10,6 +10,8 @@ import (
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	link "github.com/cs3org/go-cs3apis/cs3/sharing/link/v1beta1"
 	providerpb "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"github.com/owncloud/reva/v2/internal/grpc/services/publicshareprovider"
 	ctxpkg "github.com/owncloud/reva/v2/pkg/ctx"
 	"github.com/owncloud/reva/v2/pkg/errtypes"
@@ -21,8 +23,6 @@ import (
 	"github.com/owncloud/reva/v2/pkg/rgrpc/todo/pool"
 	"github.com/owncloud/reva/v2/pkg/utils"
 	cs3mocks "github.com/owncloud/reva/v2/tests/cs3mocks/mocks"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/mock"
 	"google.golang.org/grpc"
@@ -752,7 +752,7 @@ var _ = Describe("PublicShareProvider", func() {
 				},
 			}
 			res, err := provider.RemovePublicShare(ctx, req)
-			Expect(err).To(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(res.GetStatus().GetCode()).To(Equal(rpc.Code_CODE_INTERNAL))
 			Expect(res.GetStatus().GetMessage()).To(Equal("error loading public share"))
 		})

--- a/internal/grpc/services/usershareprovider/usershareprovider.go
+++ b/internal/grpc/services/usershareprovider/usershareprovider.go
@@ -262,9 +262,14 @@ func (s *service) RemoveShare(ctx context.Context, req *collaboration.RemoveShar
 	user := ctxpkg.ContextMustGetUser(ctx)
 	share, err := s.sm.GetShare(ctx, req.Ref)
 	if err != nil {
-		return &collaboration.RemoveShareResponse{
-			Status: status.NewInternal(ctx, "error getting share"),
-		}, nil
+		var st *rpc.Status
+		switch err.(type) {
+		case errtypes.IsNotFound:
+			st = status.NewNotFound(ctx, err.Error())
+		default:
+			st = status.NewInternal(ctx, "error getting share")
+		}
+		return &collaboration.RemoveShareResponse{Status: st}, nil
 	}
 
 	gatewayClient, err := s.gatewaySelector.Next()


### PR DESCRIPTION
https://github.com/owncloud/ocis/pull/12266