### PR TITLE
feat: [OCISDEV-531] add the vault capabilities endpoint support

### DIFF
--- a/changelog/unreleased/feat-vault-capabilities.md
+++ b/changelog/unreleased/feat-vault-capabilities.md
@@ -1,0 +1,10 @@
+Enhancement: Add vault=true query parameter support to the capabilities endpoint
+
+The OCS capabilities handler now accepts a `vault=true` query parameter.
+When `CapabilitiesVault.Enabled` is true and the parameter is present, the
+endpoint returns a modified capabilities response where public sharing
+(`files_sharing.public.enabled`) and federation sharing
+(`files_sharing.federation.outgoing` / `incoming`) are disabled.
+All other capabilities remain unchanged.
+
+https://github.com/owncloud/reva/pull/584

--- a/internal/http/services/owncloud/ocs/handlers/cloud/capabilities/capabilities.go
+++ b/internal/http/services/owncloud/ocs/handlers/cloud/capabilities/capabilities.go
@@ -234,5 +234,31 @@ func (h *Handler) Init(c *config.Config) {
 // Handler renders the capabilities
 func (h *Handler) GetCapabilities(w http.ResponseWriter, r *http.Request) {
 	c := h.getCapabilitiesForUserAgent(r.UserAgent())
+	if r.URL.Query().Get("vault") == "true" && c.Capabilities != nil && c.Capabilities.Vault != nil && bool(c.Capabilities.Vault.Enabled) {
+		c = h.vaultCapabilities(c)
+	}
 	response.WriteOCSSuccess(w, r, c)
+}
+
+// vaultCapabilities returns a copy of the capabilities with public sharing and federation disabled.
+func (h *Handler) vaultCapabilities(c ocs.CapabilitiesData) ocs.CapabilitiesData {
+	if c.Capabilities == nil || c.Capabilities.FilesSharing == nil {
+		return c
+	}
+	sharing := *c.Capabilities.FilesSharing
+	if sharing.Public != nil {
+		pub := *sharing.Public
+		pub.Enabled = false
+		sharing.Public = &pub
+	}
+	if sharing.Federation != nil {
+		fed := *sharing.Federation
+		fed.Outgoing = false
+		fed.Incoming = false
+		sharing.Federation = &fed
+	}
+	caps := *c.Capabilities
+	caps.FilesSharing = &sharing
+	c.Capabilities = &caps
+	return c
 }

--- a/pkg/owncloud/ocs/capabilities.go
+++ b/pkg/owncloud/ocs/capabilities.go
@@ -62,6 +62,7 @@ type Capabilities struct {
 	Theme          *CapabilitiesTheme          `json:"theme,omitempty" xml:"theme,omitempty" mapstructure:"theme"`
 	Notifications  *CapabilitiesNotifications  `json:"notifications,omitempty" xml:"notifications,omitempty"`
 	Auth           *CapabilitiesAuth           `json:"auth,omitempty" xml:"auth,omitempty"`
+	Vault          *CapabilitiesVault          `json:"vault,omitempty" xml:"vault,omitempty" mapstructure:"vault"`
 }
 
 // CapabilitiesSearch holds the search capabilities
@@ -331,4 +332,9 @@ type Version struct {
 	Edition        string `json:"edition" xml:"edition"`
 	Product        string `json:"product" xml:"product"`
 	ProductVersion string `json:"productversion" xml:"productversion"`
+}
+
+// CapabilitiesVault holds vault capabilities
+type CapabilitiesVault struct {
+	Enabled ocsBool `json:"enabled" xml:"enabled" mapstructure:"enabled"`
 }


### PR DESCRIPTION
When CapabilitiesVault.Enabled is true, GET /ocs/v2.php/cloud/capabilities?vault=true returns a modified response with public sharing and federation sharing disabled.