### PR TITLE
Security: enforce postprocessing/antivirus quarantine on the storage Download path

### DIFF
--- a/changelog/unreleased/enforce-postprocessing-quarantine-on-download.md
+++ b/changelog/unreleased/enforce-postprocessing-quarantine-on-download.md
@@ -1,0 +1,11 @@
+Security: Enforce postprocessing quarantine on the storage download path
+
+The "still being processed" quarantine (used e.g. for antivirus scanning) was
+only enforced by the ocdav GET/HEAD/PROPFIND handlers via a separate Stat
+call. `Decomposedfs.Download` and `Decomposedfs.DownloadRevision` did not
+check the node's processing state, so the datagateway `/data` endpoint and
+revision downloads could serve unscanned/in-process content, and the ocdav
+path was racy. The processing state is now enforced at the storage layer and
+the data transfer handler returns `425 Too Early` accordingly.
+
+https://github.com/owncloud/reva/pull/596

--- a/pkg/rhttp/datatx/utils/download/download.go
+++ b/pkg/rhttp/datatx/utils/download/download.go
@@ -275,6 +275,9 @@ func handleError(w http.ResponseWriter, log *zerolog.Logger, err error, action s
 	case errtypes.Aborted:
 		log.Debug().Err(err).Str("action", action).Msg("etags do not match")
 		w.WriteHeader(http.StatusPreconditionFailed)
+	case errtypes.IsTooEarly:
+		log.Debug().Err(err).Str("action", action).Msg("resource still being processed")
+		w.WriteHeader(http.StatusTooEarly)
 	default:
 		log.Error().Err(err).Str("action", action).Msg("unexpected error")
 		w.WriteHeader(http.StatusInternalServerError)

--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -1133,6 +1133,15 @@ func (fs *Decomposedfs) Download(ctx context.Context, ref *provider.Reference, o
 		return nil, nil, errtypes.NotFound(f)
 	}
 
+	// Do not serve the blob while the node is still being post-processed
+	// (e.g. virus scan in progress). This must be enforced here, at the
+	// storage layer, so every caller (ocdav, the datagateway /data endpoint,
+	// the archiver, ...) is covered and the check cannot be raced against a
+	// preceding Stat.
+	if n.IsProcessing(ctx) {
+		return nil, nil, errtypes.TooEarly(n.ID)
+	}
+
 	ri, err := n.AsResourceInfo(ctx, rp, nil, []string{"size", "mimetype", "etag"}, true)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/storage/utils/decomposedfs/revisions.go
+++ b/pkg/storage/utils/decomposedfs/revisions.go
@@ -152,6 +152,14 @@ func (fs *Decomposedfs) DownloadRevision(ctx context.Context, ref *provider.Refe
 		return nil, nil, errtypes.NotFound(f)
 	}
 
+	// Do not serve a revision blob while the node is still being
+	// post-processed (e.g. virus scan in progress). Enforced at the storage
+	// layer so the revision download path cannot be used to bypass the
+	// quarantine.
+	if n.IsProcessing(ctx) {
+		return nil, nil, errtypes.TooEarly(n.ID)
+	}
+
 	contentPath := fs.lu.InternalPath(spaceID, revisionKey)
 
 	blobid, blobsize, err := fs.lu.ReadBlobIDAndSizeAttr(ctx, contentPath, nil)


### PR DESCRIPTION
# Security: enforce postprocessing/antivirus quarantine in the storage Download path

## Summary

The "still being processed / virus scan in progress" quarantine that protects
users from downloading unscanned or infected content is enforced **only** in
the ocdav HTTP handlers (`GET` / `HEAD` / `PROPFIND`), and even there only via a
*separate* `Stat` round-trip performed before the data is fetched. The
authoritative blob-serving layer — `Decomposedfs.Download` and
`Decomposedfs.DownloadRevision` — performs **no processing-state check at all**.

As a result the antivirus / postprocessing gate can be bypassed:

1. **Raceless bypass.** Any caller that reaches `Download` / `DownloadRevision`
   without going through the ocdav `GET` stat-gate serves the blob with no
   quarantine check. This includes the `/data` datagateway endpoint (which is
   `Unprotected` at the oCIS proxy and calls `fs.Download` directly) and any
   revision-style reference (`ResourceId.OpaqueId` containing the revision
   delimiter), which is routed straight into `DownloadRevision`.
2. **TOCTOU bypass.** For the ocdav path, the processing state is read from a
   `Stat` response and the content is then fetched in a *separate*
   `InitiateFileDownload` + data request, with no `If-Match`/etag binding
   between the two. The reva source already acknowledges this race in
   `internal/http/services/owncloud/ocdav/get.go` (`// TODO we need to send the
   If-Match etag in the GET to the datagateway to prevent race conditions
   between stating and reading the file`).

The correct fix is to enforce the quarantine at the resource boundary
(`Decomposedfs.Download` / `DownloadRevision`), so every consumer (ocdav, the
datagateway `/data` path, the archiver, app-provider, OCM) is covered and the
TOCTOU is closed.

## Affected code

- `pkg/storage/utils/decomposedfs/decomposedfs.go` — `Download()`
  resolves the node, checks per-user permissions, then calls
  `fs.tp.ReadBlob(n)` with **no** check of the node's postprocessing/scan
  status.
- `pkg/storage/utils/decomposedfs/revisions.go` — `DownloadRevision()`
  has the same gap.
- `internal/http/services/owncloud/ocdav/get.go` — the only place the
  `status == "processing"` check exists, performed on a prior `Stat` result
  (separate request → TOCTOU; explicit `TODO` acknowledging the race).
- Downstream context in oCIS: `services/proxy/pkg/config/defaults/defaultconfig.go`
  routes `/data` with `Unprotected: true`; the datagateway authorises with the
  transfer token only and calls `fs.Download` with no processing gate
  (`pkg/rhttp/datatx/utils/download/download.go`).

## Impact

- **Confidentiality / Integrity:** an uploaded file can be retrieved before the
  configured antivirus / postprocessing pipeline has finished or while it is
  reporting "processing", defeating the malware-quarantine guarantee. Combined
  with a public link on the parent folder, distribution is unauthenticated.
- **Prerequisites:** any user able to upload a file (the revision/`/data`
  variants are raceless; the ocdav variant requires winning a short, known
  window). No administrative privileges required.
- Deployments that rely on the antivirus postprocessing step as a security
  control are affected. (Note: in a default oCIS install the antivirus and
  policies services are opt-in and the postprocessing pipeline is empty — that
  is a separate hardening concern tracked elsewhere; this PR fixes the control
  for deployments that *do* enable it.)
- Suggested severity: **High / Critical** depending on deployment.
  CVSS:3.1 (proposed) `AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N`.

## Proposed fix

Enforce the postprocessing/scan quarantine in `Decomposedfs.Download` and
`Decomposedfs.DownloadRevision`, before `ReadBlob`:

1. After the node is resolved and permissions are assembled, read the same
   postprocessing status that `node.AsResourceInfo` uses to annotate
   `status: processing` on the resource (the node scan/processing marker).
2. If the node is still in postprocessing, return a clear error
   (`errtypes.NotFound` / a dedicated "still processing" error consistent with
   the existing ocdav `425 Too Early` behaviour) instead of streaming the blob.
3. Verify the antivirus/postprocessing flows do **not** rely on
   `Decomposedfs.Download` to read the content under scan — the scanner streams
   the upload `.bin` via the upload/TUS token path, not via `Download`, so the
   new gate must not regress scanning. Add an explicit allowance only if a
   legitimate internal-scanner code path is identified during review.

This makes the resource layer (not one HTTP caller) the authoritative
enforcement point and closes both the raceless and TOCTOU variants in a single
place. The ocdav `Stat`-based pre-check can remain as a fast-path / nicer
status code; the storage-layer check is the security boundary.

## Test plan

- Unit: `Download` / `DownloadRevision` return the processing error when the
  node is marked processing; succeed once the marker is cleared.
- Integration: upload a file with an artificially long postprocessing step;
  assert `GET /data...`, a revision-reference download, and ocdav `GET` all
  return the quarantine error during processing and succeed afterwards.
- Regression: antivirus scan of an uploaded file still completes (scanner path
  unaffected); normal download after a clean verdict works.
- Race: concurrent processing-finish + download no longer yields the blob
  before the verdict.

---

Nils Putnins / OffSeq Cybersecurity
npu@offseq.com / https://offseq.com / https://radar.offseq.com