### PR TITLE
fix: [OCISDEV-848] create empty share files on first sync to stop 404…

### DIFF
--- a/pkg/share/manager/jsoncs3/providercache/providercache.go
+++ b/pkg/share/manager/jsoncs3/providercache/providercache.go
@@ -503,6 +503,9 @@ func (c *Cache) syncWithLock(ctx context.Context, storageID, spaceID string) err
 		span.AddEvent("updating local cache")
 	case errtypes.NotFound:
 		span.SetStatus(codes.Ok, "")
+		if err := c.Persist(ctx, storageID, spaceID); err != nil {
+			log.Warn().Err(err).Msg("failed to create empty provider cache file")
+		}
 		return nil
 	case errtypes.NotModified:
 		span.SetStatus(codes.Ok, "")

--- a/pkg/share/manager/jsoncs3/providercache/providercache_test.go
+++ b/pkg/share/manager/jsoncs3/providercache/providercache_test.go
@@ -73,6 +73,50 @@ var _ = Describe("Cache", func() {
 		}
 	})
 
+	Describe("ListSpace", func() {
+		Context("when no cache file exists yet", func() {
+			It("creates the cache file on first call", func() {
+				_, err := c.ListSpace(ctx, storageID, spaceID)
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = os.Stat(filepath.Join(tmpdir, "storages", storageID, spaceID+".json"))
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("sets an etag after the first call", func() {
+				_, err := c.ListSpace(ctx, storageID, spaceID)
+				Expect(err).ToNot(HaveOccurred())
+
+				spaces, ok := c.Providers.Load(storageID)
+				Expect(ok).To(BeTrue())
+				space, ok := spaces.Spaces.Load(spaceID)
+				Expect(ok).To(BeTrue())
+				Expect(space.Etag).ToNot(BeEmpty())
+			})
+
+			It("returns empty shares", func() {
+				shares, err := c.ListSpace(ctx, storageID, spaceID)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(shares.Shares).To(BeEmpty())
+			})
+
+			It("does not upload again on second call", func() {
+				_, err := c.ListSpace(ctx, storageID, spaceID)
+				Expect(err).ToNot(HaveOccurred())
+
+				spaces, _ := c.Providers.Load(storageID)
+				space, _ := spaces.Spaces.Load(spaceID)
+				etagAfterFirst := space.Etag
+
+				_, err = c.ListSpace(ctx, storageID, spaceID)
+				Expect(err).ToNot(HaveOccurred())
+
+				space, _ = spaces.Spaces.Load(spaceID)
+				Expect(space.Etag).To(Equal(etagAfterFirst))
+			})
+		})
+	})
+
 	Describe("Add", func() {
 		It("adds a share", func() {
 			s, err := c.Get(ctx, storageID, spaceID, shareID, false)

--- a/pkg/share/manager/jsoncs3/receivedsharecache/receivedsharecache.go
+++ b/pkg/share/manager/jsoncs3/receivedsharecache/receivedsharecache.go
@@ -307,6 +307,9 @@ func (c *Cache) syncWithLock(ctx context.Context, userID string) error {
 		span.AddEvent("updating local cache")
 	case errtypes.NotFound:
 		span.SetStatus(codes.Ok, "")
+		if err := c.persist(ctx, userID); err != nil {
+			log.Warn().Err(err).Msg("failed to create empty received share cache file")
+		}
 		return nil
 	case errtypes.NotModified:
 		span.SetStatus(codes.Ok, "")

--- a/pkg/share/manager/jsoncs3/receivedsharecache/receivedsharecache_test.go
+++ b/pkg/share/manager/jsoncs3/receivedsharecache/receivedsharecache_test.go
@@ -71,6 +71,35 @@ var _ = Describe("Cache", func() {
 		}
 	})
 
+	Describe("List", func() {
+		Context("when no cache file exists yet", func() {
+			It("creates the cache file on first call", func() {
+				_, err := c.List(ctx, userID)
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = os.Stat(tmpdir + "/users/" + userID + "/received.json")
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("returns empty spaces", func() {
+				spaces, err := c.List(ctx, userID)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(spaces).To(BeEmpty())
+			})
+
+			It("is readable by a fresh cache instance after first call", func() {
+				_, err := c.List(ctx, userID)
+				Expect(err).ToNot(HaveOccurred())
+
+				// a new cache instance must be able to read the bootstrapped file
+				c2 := receivedsharecache.New(storage, 0*time.Second)
+				spaces, err := c2.List(ctx, userID)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(spaces).To(BeEmpty())
+			})
+		})
+	})
+
 	Describe("Add", func() {
 		It("adds an entry", func() {
 			rs := &collaboration.ReceivedShare{

--- a/pkg/share/manager/jsoncs3/receivedsharecache/receivedsharecache_test.go
+++ b/pkg/share/manager/jsoncs3/receivedsharecache/receivedsharecache_test.go
@@ -97,6 +97,21 @@ var _ = Describe("Cache", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(spaces).To(BeEmpty())
 			})
+
+			It("allows adding a share after bootstrap", func() {
+				_, err := c.List(ctx, userID)
+				Expect(err).ToNot(HaveOccurred())
+
+				rs := &collaboration.ReceivedShare{
+					Share: share,
+					State: collaboration.ShareState_SHARE_STATE_PENDING,
+				}
+				Expect(c.Add(ctx, userID, spaceID, rs)).To(Succeed())
+
+				spaces, err := c.List(ctx, userID)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(spaces[spaceID].States).To(HaveKey(shareID))
+			})
 		})
 	})
 

--- a/pkg/share/manager/jsoncs3/sharecache/sharecache.go
+++ b/pkg/share/manager/jsoncs3/sharecache/sharecache.go
@@ -284,6 +284,9 @@ func (c *Cache) syncWithLock(ctx context.Context, userID string) error {
 		span.AddEvent("updating local cache")
 	case errtypes.NotFound:
 		span.SetStatus(codes.Ok, "")
+		if err := c.Persist(ctx, userID); err != nil {
+			log.Warn().Err(err).Msg("failed to create empty share cache file")
+		}
 		return nil
 	case errtypes.NotModified:
 		span.SetStatus(codes.Ok, "")

--- a/pkg/share/manager/jsoncs3/sharecache/sharecache_test.go
+++ b/pkg/share/manager/jsoncs3/sharecache/sharecache_test.go
@@ -82,4 +82,45 @@ var _ = Describe("Sharecache", func() {
 			})
 		})
 	})
+
+	Describe("List", func() {
+		Context("when no cache file exists yet", func() {
+			It("creates the cache file on first call", func() {
+				_, err := c.List(ctx, userid)
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = os.Stat(tmpdir + "/users/" + userid + "/created.json")
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("sets an etag after the first call", func() {
+				_, err := c.List(ctx, userid)
+				Expect(err).ToNot(HaveOccurred())
+
+				uc, ok := c.UserShares.Load(userid)
+				Expect(ok).To(BeTrue())
+				Expect(uc.Etag).ToNot(BeEmpty())
+			})
+
+			It("returns empty shares", func() {
+				shares, err := c.List(ctx, userid)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(shares).To(BeEmpty())
+			})
+
+			It("does not upload again on second call", func() {
+				_, err := c.List(ctx, userid)
+				Expect(err).ToNot(HaveOccurred())
+
+				uc, _ := c.UserShares.Load(userid)
+				etagAfterFirst := uc.Etag
+
+				_, err = c.List(ctx, userid)
+				Expect(err).ToNot(HaveOccurred())
+
+				uc, _ = c.UserShares.Load(userid)
+				Expect(uc.Etag).To(Equal(etagAfterFirst))
+			})
+		})
+	})
 })


### PR DESCRIPTION
The goal is to get rid of 404 warn logs, when a user has never received a share yet. 
The proposed solution in the ticket was implementing a negative cache, keeping track of files that don't exist yet. An in memory cache causes a regression that when a share is created in node A, node B would not see this share until the cache TTL expires. A shared cache (either in NATS or file) is possible, but adds more complexity. I propose initializing empty received.json /  created.json files earlier, getting rid of the file not found warnings.