### PR TITLE
fix(decomposedfs): [OCISDEV-943] return WriteResult with SpaceOwner f…

### DIFF
--- a/internal/grpc/interceptors/eventsmiddleware/conversion.go
+++ b/internal/grpc/interceptors/eventsmiddleware/conversion.go
@@ -246,7 +246,7 @@ func FileDownloaded(r *provider.InitiateFileDownloadResponse, req *provider.Init
 }
 
 // FileLocked converts the response to an events
-func FileLocked(r *provider.SetLockResponse, req *provider.SetLockRequest, owner *user.UserId, executant *user.User) events.FileLocked {
+func FileLocked(r *provider.SetLockResponse, req *provider.SetLockRequest, spaceOwner *user.UserId, executant *user.User) events.FileLocked {
 	return events.FileLocked{
 		Executant:         executant.GetId(),
 		Ref:               req.Ref,
@@ -256,7 +256,7 @@ func FileLocked(r *provider.SetLockResponse, req *provider.SetLockRequest, owner
 }
 
 // FileUnlocked converts the response to an event
-func FileUnlocked(r *provider.UnlockResponse, req *provider.UnlockRequest, owner *user.UserId, executant *user.User) events.FileUnlocked {
+func FileUnlocked(r *provider.UnlockResponse, req *provider.UnlockRequest, spaceOwner *user.UserId, executant *user.User) events.FileUnlocked {
 	return events.FileUnlocked{
 		Executant:         executant.GetId(),
 		Ref:               req.Ref,
@@ -284,18 +284,11 @@ func ItemTrashed(r *provider.DeleteResponse, req *provider.DeleteRequest, spaceO
 
 // ItemMoved converts the response to an event
 func ItemMoved(r *provider.MoveResponse, req *provider.MoveRequest, result *storage.MoveResult, executant *user.User) events.ItemMoved {
-	var spaceOwner *user.UserId
-	var newRef, oldRef *provider.Reference
-	if result != nil {
-		spaceOwner = result.SpaceOwner
-		newRef = result.NewReference
-		oldRef = result.OldReference
-	}
 	return events.ItemMoved{
-		SpaceOwner:        spaceOwner,
+		SpaceOwner:        result.SpaceOwner,
 		Executant:         executant.GetId(),
-		Ref:               newRef,
-		OldReference:      oldRef,
+		Ref:               result.NewReference,
+		OldReference:      result.OldReference,
 		Timestamp:         utils.TSNow(),
 		ImpersonatingUser: extractImpersonator(executant),
 	}

--- a/internal/grpc/interceptors/eventsmiddleware/conversion_test.go
+++ b/internal/grpc/interceptors/eventsmiddleware/conversion_test.go
@@ -7,8 +7,115 @@ import (
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/owncloud/reva/v2/pkg/storage"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// testSpaceOwner and testExecutant are shared across tests.
+var testSpaceOwner = &user.UserId{
+	Idp:      "test-idp",
+	OpaqueId: "space-owner-id",
+	Type:     user.UserType_USER_TYPE_PRIMARY,
+}
+
+var testExecutant = &user.User{
+	Id: &user.UserId{
+		Idp:      "test-idp",
+		OpaqueId: "executant-id",
+		Type:     user.UserType_USER_TYPE_PRIMARY,
+	},
+}
+
+var testRef = &provider.Reference{
+	ResourceId: &provider.ResourceId{
+		StorageId: "storage-1",
+		SpaceId:   "space-1",
+		OpaqueId:  "opaque-1",
+	},
+	Path: "./some/path",
+}
+
+func TestContainerCreated(t *testing.T) {
+	req := &provider.CreateContainerRequest{Ref: testRef}
+	resp := &provider.CreateContainerResponse{}
+
+	ev := ContainerCreated(resp, req, testSpaceOwner, testExecutant)
+
+	assert.Equal(t, testSpaceOwner, ev.SpaceOwner)
+	assert.Equal(t, testRef, ev.Ref)
+	assert.Equal(t, testExecutant.GetId(), ev.Executant)
+}
+
+func TestFileTouched(t *testing.T) {
+	req := &provider.TouchFileRequest{Ref: testRef}
+	resp := &provider.TouchFileResponse{}
+
+	ev := FileTouched(resp, req, testSpaceOwner, testExecutant)
+
+	assert.Equal(t, testSpaceOwner, ev.SpaceOwner)
+	assert.Equal(t, testRef, ev.Ref)
+	assert.Equal(t, testExecutant.GetId(), ev.Executant)
+}
+
+func TestFileLocked(t *testing.T) {
+	req := &provider.SetLockRequest{Ref: testRef}
+	resp := &provider.SetLockResponse{}
+
+	ev := FileLocked(resp, req, testSpaceOwner, testExecutant)
+
+	assert.Equal(t, testRef, ev.Ref)
+	assert.Equal(t, testExecutant.GetId(), ev.Executant)
+}
+
+func TestFileUnlocked(t *testing.T) {
+	req := &provider.UnlockRequest{Ref: testRef}
+	resp := &provider.UnlockResponse{}
+
+	ev := FileUnlocked(resp, req, testSpaceOwner, testExecutant)
+
+	assert.Equal(t, testRef, ev.Ref)
+	assert.Equal(t, testExecutant.GetId(), ev.Executant)
+}
+
+func TestItemRestored(t *testing.T) {
+	oldRef := &provider.Reference{
+		ResourceId: &provider.ResourceId{
+			StorageId: "storage-1",
+			SpaceId:   "space-1",
+			OpaqueId:  "trash-key-1",
+		},
+		Path: "./trash/path",
+	}
+	req := &provider.RestoreRecycleItemRequest{
+		Ref:        oldRef,
+		RestoreRef: testRef,
+		Key:        "trash-key-1",
+	}
+	resp := &provider.RestoreRecycleItemResponse{}
+
+	ev := ItemRestored(resp, req, testSpaceOwner, testExecutant)
+
+	assert.Equal(t, testSpaceOwner, ev.SpaceOwner)
+	// When RestoreRef is set, Ref should be RestoreRef; OldReference should be req.Ref.
+	assert.Equal(t, testRef, ev.Ref)
+	assert.Equal(t, oldRef, ev.OldReference)
+	assert.Equal(t, testExecutant.GetId(), ev.Executant)
+}
+
+func TestFileVersionRestored(t *testing.T) {
+	req := &provider.RestoreFileVersionRequest{
+		Ref: testRef,
+		Key: "v1",
+	}
+	resp := &provider.RestoreFileVersionResponse{}
+
+	ev := FileVersionRestored(resp, req, testSpaceOwner, testExecutant)
+
+	assert.Equal(t, testSpaceOwner, ev.SpaceOwner)
+	assert.Equal(t, testRef, ev.Ref)
+	assert.Equal(t, testExecutant.GetId(), ev.Executant)
+	assert.Equal(t, "v1", ev.Key)
+}
 
 func TestItemMoved(t *testing.T) {
 	spaceOwner := &user.UserId{OpaqueId: "owner-1"}

--- a/internal/grpc/interceptors/eventsmiddleware/events.go
+++ b/internal/grpc/interceptors/eventsmiddleware/events.go
@@ -22,12 +22,12 @@ import (
 	"context"
 	"fmt"
 
-	user "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	ocmcore "github.com/cs3org/go-cs3apis/cs3/ocm/core/v1beta1"
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	collaboration "github.com/cs3org/go-cs3apis/cs3/sharing/collaboration/v1beta1"
 	link "github.com/cs3org/go-cs3apis/cs3/sharing/link/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	"github.com/mitchellh/mapstructure"
 	"github.com/owncloud/reva/v2/pkg/appctx"
 	revactx "github.com/owncloud/reva/v2/pkg/ctx"
 	"github.com/owncloud/reva/v2/pkg/events"
@@ -35,7 +35,6 @@ import (
 	"github.com/owncloud/reva/v2/pkg/rgrpc"
 	"github.com/owncloud/reva/v2/pkg/storagespace"
 	"github.com/owncloud/reva/v2/pkg/utils"
-	"github.com/mitchellh/mapstructure"
 	"google.golang.org/grpc"
 )
 
@@ -58,24 +57,17 @@ func NewUnary(m map[string]interface{}) (grpc.UnaryServerInterceptor, int, error
 	}
 
 	interceptor := func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-		// Register a channel in the context to receive the space owner id from the handler(s) further down the stack
-		var ownerID *user.UserId
-		sendOwnerChan := make(chan *user.UserId)
-		ctx = storagespace.ContextRegisterSendOwnerChan(ctx, sendOwnerChan)
-
-		moveSlot := &storagespace.MoveResultSlot{}
-		ctx = storagespace.ContextRegisterMoveResultSlot(ctx, moveSlot)
+		// Register slots so the storage driver can pass data back up through
+		// the immutable context chain; values are read here after the handler returns.
+		ctx = storagespace.ContextRegisterSpaceOwnerSlot(ctx)
+		ctx = storagespace.ContextRegisterMoveResultSlot(ctx)
 
 		res, err := handler(ctx, req)
 		if err != nil {
 			return res, err
 		}
 
-		// Read the space owner id from the channel
-		select {
-		case ownerID = <-sendOwnerChan:
-		default:
-		}
+		spaceOwnerID := storagespace.ContextGetSpaceOwner(ctx) // nil if not set by handler
 
 		executant, _ := revactx.ContextGetUser(ctx)
 
@@ -83,7 +75,9 @@ func NewUnary(m map[string]interface{}) (grpc.UnaryServerInterceptor, int, error
 		switch v := res.(type) {
 		case *provider.MoveResponse:
 			if isSuccess(v) {
-				ev = ItemMoved(v, req.(*provider.MoveRequest), moveSlot.Result, executant)
+				if result := storagespace.ContextGetMoveResult(ctx); result != nil {
+					ev = ItemMoved(v, req.(*provider.MoveRequest), result, executant)
+				}
 			}
 		case *collaboration.CreateShareResponse:
 			if isSuccess(v) {
@@ -143,7 +137,7 @@ func NewUnary(m map[string]interface{}) (grpc.UnaryServerInterceptor, int, error
 			}
 		case *provider.CreateContainerResponse:
 			if isSuccess(v) {
-				ev = ContainerCreated(v, req.(*provider.CreateContainerRequest), ownerID, executant)
+				ev = ContainerCreated(v, req.(*provider.CreateContainerRequest), spaceOwnerID, executant)
 			}
 		case *provider.InitiateFileDownloadResponse:
 			if isSuccess(v) {
@@ -151,7 +145,7 @@ func NewUnary(m map[string]interface{}) (grpc.UnaryServerInterceptor, int, error
 			}
 		case *provider.DeleteResponse:
 			if isSuccess(v) {
-				ev = ItemTrashed(v, req.(*provider.DeleteRequest), ownerID, executant)
+				ev = ItemTrashed(v, req.(*provider.DeleteRequest), spaceOwnerID, executant)
 			}
 		case *provider.PurgeRecycleResponse:
 			if isSuccess(v) {
@@ -159,11 +153,11 @@ func NewUnary(m map[string]interface{}) (grpc.UnaryServerInterceptor, int, error
 			}
 		case *provider.RestoreRecycleItemResponse:
 			if isSuccess(v) {
-				ev = ItemRestored(v, req.(*provider.RestoreRecycleItemRequest), ownerID, executant)
+				ev = ItemRestored(v, req.(*provider.RestoreRecycleItemRequest), spaceOwnerID, executant)
 			}
 		case *provider.RestoreFileVersionResponse:
 			if isSuccess(v) {
-				ev = FileVersionRestored(v, req.(*provider.RestoreFileVersionRequest), ownerID, executant)
+				ev = FileVersionRestored(v, req.(*provider.RestoreFileVersionRequest), spaceOwnerID, executant)
 			}
 		case *provider.CreateStorageSpaceResponse:
 			if isSuccess(v) && v.StorageSpace != nil { // TODO: Why are there CreateStorageSpaceResponses with nil StorageSpace?
@@ -191,15 +185,15 @@ func NewUnary(m map[string]interface{}) (grpc.UnaryServerInterceptor, int, error
 			}
 		case *provider.TouchFileResponse:
 			if isSuccess(v) {
-				ev = FileTouched(v, req.(*provider.TouchFileRequest), ownerID, executant)
+				ev = FileTouched(v, req.(*provider.TouchFileRequest), spaceOwnerID, executant)
 			}
 		case *provider.SetLockResponse:
 			if isSuccess(v) {
-				ev = FileLocked(v, req.(*provider.SetLockRequest), ownerID, executant)
+				ev = FileLocked(v, req.(*provider.SetLockRequest), spaceOwnerID, executant)
 			}
 		case *provider.UnlockResponse:
 			if isSuccess(v) {
-				ev = FileUnlocked(v, req.(*provider.UnlockRequest), ownerID, executant)
+				ev = FileUnlocked(v, req.(*provider.UnlockRequest), spaceOwnerID, executant)
 			}
 		}
 

--- a/internal/grpc/services/storageprovider/storageprovider.go
+++ b/internal/grpc/services/storageprovider/storageprovider.go
@@ -239,7 +239,13 @@ func (s *Service) SetLock(ctx context.Context, req *provider.SetLockRequest) (*p
 			Status: status.NewPermissionDenied(ctx, nil, "no permission to lock the share"),
 		}, nil
 	}
-	err := s.Storage.SetLock(ctx, req.Ref, req.Lock)
+	res, err := s.Storage.SetLock(ctx, req.Ref, req.Lock)
+	if err != nil {
+		return &provider.SetLockResponse{
+			Status: status.NewStatusFromErrType(ctx, "set lock", err),
+		}, nil
+	}
+	storagespace.ContextSetSpaceOwner(ctx, res.SpaceOwner)
 
 	return &provider.SetLockResponse{
 		Status: status.NewStatusFromErrType(ctx, "set lock", err),
@@ -279,7 +285,13 @@ func (s *Service) Unlock(ctx context.Context, req *provider.UnlockRequest) (*pro
 		}, nil
 	}
 
-	err := s.Storage.Unlock(ctx, req.Ref, req.Lock)
+	res, err := s.Storage.Unlock(ctx, req.Ref, req.Lock)
+	if err != nil {
+		return &provider.UnlockResponse{
+			Status: status.NewStatusFromErrType(ctx, "unlock", err),
+		}, nil
+	}
+	storagespace.ContextSetSpaceOwner(ctx, res.SpaceOwner)
 
 	return &provider.UnlockResponse{
 		Status: status.NewStatusFromErrType(ctx, "unlock", err),
@@ -683,7 +695,13 @@ func (s *Service) CreateContainer(ctx context.Context, req *provider.CreateConta
 		}
 	}
 
-	err := s.Storage.CreateDir(ctx, req.Ref)
+	res, err := s.Storage.CreateDir(ctx, req.Ref)
+	if err != nil {
+		return &provider.CreateContainerResponse{
+			Status: status.NewStatusFromErrType(ctx, "create container", err),
+		}, nil
+	}
+	storagespace.ContextSetSpaceOwner(ctx, res.SpaceOwner)
 
 	return &provider.CreateContainerResponse{
 		Status: status.NewStatusFromErrType(ctx, "create container", err),
@@ -700,7 +718,13 @@ func (s *Service) TouchFile(ctx context.Context, req *provider.TouchFileRequest)
 		mtime = utils.ReadPlainFromOpaque(req.Opaque, "X-OC-Mtime")
 	}
 
-	err := s.Storage.TouchFile(ctx, req.Ref, utils.ExistsInOpaque(req.Opaque, "markprocessing"), mtime)
+	res, err := s.Storage.TouchFile(ctx, req.Ref, utils.ExistsInOpaque(req.Opaque, "markprocessing"), mtime)
+	if err != nil {
+		return &provider.TouchFileResponse{
+			Status: status.NewStatusFromErrType(ctx, "touch file", err),
+		}, nil
+	}
+	storagespace.ContextSetSpaceOwner(ctx, res.SpaceOwner)
 
 	return &provider.TouchFileResponse{
 		Status: status.NewStatusFromErrType(ctx, "touch file", err),
@@ -876,7 +900,13 @@ func (s *Service) ListFileVersions(ctx context.Context, req *provider.ListFileVe
 func (s *Service) RestoreFileVersion(ctx context.Context, req *provider.RestoreFileVersionRequest) (*provider.RestoreFileVersionResponse, error) {
 	ctx = ctxpkg.ContextSetLockID(ctx, req.LockId)
 
-	err := s.Storage.RestoreRevision(ctx, req.Ref, req.Key)
+	res, err := s.Storage.RestoreRevision(ctx, req.Ref, req.Key)
+	if err != nil {
+		return &provider.RestoreFileVersionResponse{
+			Status: status.NewStatusFromErrType(ctx, "restore file version", err),
+		}, nil
+	}
+	storagespace.ContextSetSpaceOwner(ctx, res.SpaceOwner)
 
 	return &provider.RestoreFileVersionResponse{
 		Status: status.NewStatusFromErrType(ctx, "restore file version", err),
@@ -975,12 +1005,17 @@ func (s *Service) RestoreRecycleItem(ctx context.Context, req *provider.RestoreR
 
 	// TODO(labkode): CRITICAL: fill recycle info with storage provider.
 	key, relativePath := splitKeyAndPath(req.GetKey())
-	err := s.Storage.RestoreRecycleItem(ctx, req.Ref, key, relativePath, req.RestoreRef)
-
-	res := &provider.RestoreRecycleItemResponse{
-		Status: status.NewStatusFromErrType(ctx, "restore recycle item", err),
+	writeRes, err := s.Storage.RestoreRecycleItem(ctx, req.Ref, key, relativePath, req.RestoreRef)
+	if err != nil {
+		return &provider.RestoreRecycleItemResponse{
+			Status: status.NewStatusFromErrType(ctx, "restore recycle item", err),
+		}, nil
 	}
-	return res, nil
+	storagespace.ContextSetSpaceOwner(ctx, writeRes.SpaceOwner)
+
+	return &provider.RestoreRecycleItemResponse{
+		Status: status.NewStatusFromErrType(ctx, "restore recycle item", err),
+	}, nil
 }
 
 func (s *Service) PurgeRecycle(ctx context.Context, req *provider.PurgeRecycleRequest) (*provider.PurgeRecycleResponse, error) {

--- a/pkg/cbox/storage/eoswrapper/eoswrapper.go
+++ b/pkg/cbox/storage/eoswrapper/eoswrapper.go
@@ -203,9 +203,9 @@ func (w *wrapper) DownloadRevision(ctx context.Context, ref *provider.Reference,
 	return w.FS.DownloadRevision(ctx, ref, revisionKey, openReaderfunc)
 }
 
-func (w *wrapper) RestoreRevision(ctx context.Context, ref *provider.Reference, revisionKey string) error {
+func (w *wrapper) RestoreRevision(ctx context.Context, ref *provider.Reference, revisionKey string) (*storage.RestoreRevisionResult, error) {
 	if err := w.userIsProjectAdmin(ctx, ref); err != nil {
-		return err
+		return nil, err
 	}
 
 	return w.FS.RestoreRevision(ctx, ref, revisionKey)

--- a/pkg/ocm/storage/received/ocm.go
+++ b/pkg/ocm/storage/received/ocm.go
@@ -213,12 +213,15 @@ func (d *driver) webdavClient(ctx context.Context, forUser *userpb.UserId, ref *
 	return c, share, rel, nil
 }
 
-func (d *driver) CreateDir(ctx context.Context, ref *provider.Reference) error {
+func (d *driver) CreateDir(ctx context.Context, ref *provider.Reference) (*storage.CreateDirResult, error) {
 	client, _, rel, err := d.webdavClient(ctx, nil, ref)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return client.MkdirAll(rel, 0)
+	if err := client.MkdirAll(rel, 0); err != nil {
+		return nil, err
+	}
+	return &storage.CreateDirResult{}, nil
 }
 
 func (d *driver) Delete(ctx context.Context, ref *provider.Reference) error {
@@ -229,12 +232,15 @@ func (d *driver) Delete(ctx context.Context, ref *provider.Reference) error {
 	return client.RemoveAll(rel)
 }
 
-func (d *driver) TouchFile(ctx context.Context, ref *provider.Reference, markprocessing bool, mtime string) error {
+func (d *driver) TouchFile(ctx context.Context, ref *provider.Reference, markprocessing bool, mtime string) (*storage.TouchFileResult, error) {
 	client, _, rel, err := d.webdavClient(ctx, nil, ref)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return client.Write(rel, []byte{}, 0)
+	if err := client.Write(rel, []byte{}, 0); err != nil {
+		return nil, err
+	}
+	return &storage.TouchFileResult{}, nil
 }
 
 func (d *driver) Move(ctx context.Context, oldRef, newRef *provider.Reference) (*storage.MoveResult, error) {
@@ -422,16 +428,16 @@ func (d *driver) DownloadRevision(ctx context.Context, ref *provider.Reference, 
 	return nil, nil, errtypes.NotSupported("operation not supported")
 }
 
-func (d *driver) RestoreRevision(ctx context.Context, ref *provider.Reference, key string) error {
-	return errtypes.NotSupported("operation not supported")
+func (d *driver) RestoreRevision(ctx context.Context, ref *provider.Reference, key string) (*storage.RestoreRevisionResult, error) {
+	return nil, errtypes.NotSupported("operation not supported")
 }
 
 func (d *driver) ListRecycle(ctx context.Context, ref *provider.Reference, key, relativePath string) ([]*provider.RecycleItem, error) {
 	return nil, errtypes.NotSupported("operation not supported")
 }
 
-func (d *driver) RestoreRecycleItem(ctx context.Context, ref *provider.Reference, key, relativePath string, restoreRef *provider.Reference) error {
-	return errtypes.NotSupported("operation not supported")
+func (d *driver) RestoreRecycleItem(ctx context.Context, ref *provider.Reference, key, relativePath string, restoreRef *provider.Reference) (*storage.RestoreRecycleItemResult, error) {
+	return nil, errtypes.NotSupported("operation not supported")
 }
 
 func (d *driver) PurgeRecycleItem(ctx context.Context, ref *provider.Reference, key, relativePath string) error {
@@ -479,13 +485,16 @@ func (d *driver) UnsetArbitraryMetadata(ctx context.Context, ref *provider.Refer
 }
 
 // SetLock sets a lock on a file
-func (d *driver) SetLock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) error {
+func (d *driver) SetLock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) (*storage.SetLockResult, error) {
 	client, _, rel, err := d.webdavClient(ctx, nil, ref)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return client.Lock(rel, lock.GetLockId())
+	if err := client.Lock(rel, lock.GetLockId()); err != nil {
+		return nil, err
+	}
+	return &storage.SetLockResult{}, nil
 }
 
 func (d *driver) GetLock(ctx context.Context, ref *provider.Reference) (*provider.Lock, error) {
@@ -512,13 +521,16 @@ func (d *driver) RefreshLock(ctx context.Context, ref *provider.Reference, lock 
 }
 
 // Unlock removes a lock from a file
-func (d *driver) Unlock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) error {
+func (d *driver) Unlock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) (*storage.UnlockResult, error) {
 	client, _, rel, err := d.webdavClient(ctx, nil, ref)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return client.Unlock(rel, lock.GetLockId())
+	if err := client.Unlock(rel, lock.GetLockId()); err != nil {
+		return nil, err
+	}
+	return &storage.UnlockResult{}, nil
 }
 
 func (d *driver) ListStorageSpaces(ctx context.Context, filters []*provider.ListStorageSpacesRequest_Filter, _ bool) ([]*provider.StorageSpace, error) {

--- a/pkg/storage/fs/cephfs/cephfs.go
+++ b/pkg/storage/fs/cephfs/cephfs.go
@@ -148,11 +148,11 @@ func (fs *cephfs) CreateHome(ctx context.Context) (err error) {
 	return getRevaError(err)
 }
 
-func (fs *cephfs) CreateDir(ctx context.Context, ref *provider.Reference) error {
+func (fs *cephfs) CreateDir(ctx context.Context, ref *provider.Reference) (*storage.CreateDirResult, error) {
 	user := fs.makeUser(ctx)
 	path, err := user.resolveRef(ref)
 	if err != nil {
-		return getRevaError(err)
+		return nil, getRevaError(err)
 	}
 
 	user.op(func(cv *cacheVal) {
@@ -163,12 +163,15 @@ func (fs *cephfs) CreateDir(ctx context.Context, ref *provider.Reference) error 
 		//TODO(tmourati): Add entry id logic
 	})
 
-	return getRevaError(err)
+	if err := getRevaError(err); err != nil {
+		return nil, err
+	}
+	return &storage.CreateDirResult{}, nil
 }
 
 // TouchFile as defined in the storage.FS interface
-func (fs *cephfs) TouchFile(ctx context.Context, ref *provider.Reference, markprocessing bool, mtime string) error {
-	return fmt.Errorf("unimplemented: TouchFile")
+func (fs *cephfs) TouchFile(ctx context.Context, ref *provider.Reference, markprocessing bool, mtime string) (*storage.TouchFileResult, error) {
+	return nil, fmt.Errorf("unimplemented: TouchFile")
 }
 
 func (fs *cephfs) Delete(ctx context.Context, ref *provider.Reference) (err error) {
@@ -216,7 +219,7 @@ func (fs *cephfs) Move(ctx context.Context, oldRef, newRef *provider.Reference) 
 
 	// has already been moved by direct mount
 	if err != nil && err.Error() == errNotFound {
-		return nil, nil
+		return &storage.MoveResult{}, nil
 	}
 
 	return nil, getRevaError(err)
@@ -387,12 +390,12 @@ func (fs *cephfs) DownloadRevision(ctx context.Context, ref *provider.Reference,
 	return ri, file, getRevaError(err)
 }
 
-func (fs *cephfs) RestoreRevision(ctx context.Context, ref *provider.Reference, key string) (err error) {
+func (fs *cephfs) RestoreRevision(ctx context.Context, ref *provider.Reference, key string) (_ *storage.RestoreRevisionResult, err error) {
 	//TODO(tmourati): Fix entry id logic
 	var path string
 	user := fs.makeUser(ctx)
 	if path, err = user.resolveRef(ref); err != nil {
-		return errors.Wrap(err, "cephfs: error resolving ref")
+		return nil, errors.Wrap(err, "cephfs: error resolving ref")
 	}
 
 	user.op(func(cv *cacheVal) {
@@ -416,7 +419,10 @@ func (fs *cephfs) RestoreRevision(ctx context.Context, ref *provider.Reference, 
 		_, err = io.Copy(dst, src)
 	})
 
-	return getRevaError(err)
+	if err := getRevaError(err); err != nil {
+		return nil, err
+	}
+	return &storage.RestoreRevisionResult{}, nil
 }
 
 func (fs *cephfs) GetPathByID(ctx context.Context, id *provider.ResourceId) (str string, err error) {
@@ -615,8 +621,8 @@ func (fs *cephfs) ListRecycle(ctx context.Context, ref *provider.Reference, key,
 	panic("implement me")
 }
 
-func (fs *cephfs) RestoreRecycleItem(ctx context.Context, ref *provider.Reference, key, relativePath string, restoreRef *provider.Reference) error {
-	return errors.New("cephfs: restoreRecycleItem not supported")
+func (fs *cephfs) RestoreRecycleItem(ctx context.Context, ref *provider.Reference, key, relativePath string, restoreRef *provider.Reference) (*storage.RestoreRecycleItemResult, error) {
+	return nil, errors.New("cephfs: restoreRecycleItem not supported")
 }
 
 func (fs *cephfs) PurgeRecycleItem(ctx context.Context, ref *provider.Reference, key, relativePath string) error {
@@ -641,8 +647,8 @@ func (fs *cephfs) GetLock(ctx context.Context, ref *provider.Reference) (*provid
 }
 
 // SetLock puts a lock on the given reference
-func (fs *cephfs) SetLock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) error {
-	return errtypes.NotSupported("unimplemented")
+func (fs *cephfs) SetLock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) (*storage.SetLockResult, error) {
+	return nil, errtypes.NotSupported("unimplemented")
 }
 
 // RefreshLock refreshes an existing lock on the given reference
@@ -651,6 +657,6 @@ func (fs *cephfs) RefreshLock(ctx context.Context, ref *provider.Reference, lock
 }
 
 // Unlock removes an existing lock from the given reference
-func (fs *cephfs) Unlock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) error {
-	return errtypes.NotSupported("unimplemented")
+func (fs *cephfs) Unlock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) (*storage.UnlockResult, error) {
+	return nil, errtypes.NotSupported("unimplemented")
 }

--- a/pkg/storage/fs/hello/unimplemented.go
+++ b/pkg/storage/fs/hello/unimplemented.go
@@ -52,15 +52,15 @@ func (fs *hellofs) DeleteStorageSpace(ctx context.Context, req *provider.DeleteS
 }
 
 // CreateDir creates a resource of type container
-func (fs *hellofs) CreateDir(ctx context.Context, ref *provider.Reference) error {
-	return errtypes.NotSupported("unimplemented")
+func (fs *hellofs) CreateDir(ctx context.Context, ref *provider.Reference) (*storage.CreateDirResult, error) {
+	return nil, errtypes.NotSupported("unimplemented")
 }
 
 // TouchFile sets the mtime of a resource, creating an empty file if it does not exist
 // FIXME the markprocessing flag is an implementation detail of decomposedfs, remove it from the function
 // FIXME the mtime should either be a time.Time or a CS3 Timestamp, not a string
-func (fs *hellofs) TouchFile(ctx context.Context, ref *provider.Reference, _ bool, _ string) error {
-	return errtypes.NotSupported("unimplemented")
+func (fs *hellofs) TouchFile(ctx context.Context, ref *provider.Reference, _ bool, _ string) (*storage.TouchFileResult, error) {
+	return nil, errtypes.NotSupported("unimplemented")
 }
 
 // Delete deletes a resource.
@@ -132,8 +132,8 @@ func (fs *hellofs) GetLock(ctx context.Context, ref *provider.Reference) (*provi
 }
 
 // SetLock puts a lock on the given reference
-func (fs *hellofs) SetLock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) error {
-	return errtypes.NotSupported("unimplemented")
+func (fs *hellofs) SetLock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) (*storage.SetLockResult, error) {
+	return nil, errtypes.NotSupported("unimplemented")
 }
 
 // RefreshLock refreshes an existing lock on the given reference
@@ -142,8 +142,8 @@ func (fs *hellofs) RefreshLock(ctx context.Context, ref *provider.Reference, loc
 }
 
 // Unlock removes an existing lock from the given reference
-func (fs *hellofs) Unlock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) error {
-	return errtypes.NotSupported("unimplemented")
+func (fs *hellofs) Unlock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) (*storage.UnlockResult, error) {
+	return nil, errtypes.NotSupported("unimplemented")
 }
 
 // revisions
@@ -159,8 +159,8 @@ func (fs *hellofs) DownloadRevision(ctx context.Context, ref *provider.Reference
 }
 
 // RestoreRevision restores a revision
-func (fs *hellofs) RestoreRevision(ctx context.Context, ref *provider.Reference, revisionKey string) error {
-	return errtypes.NotSupported("unimplemented")
+func (fs *hellofs) RestoreRevision(ctx context.Context, ref *provider.Reference, revisionKey string) (*storage.RestoreRevisionResult, error) {
+	return nil, errtypes.NotSupported("unimplemented")
 }
 
 // trash
@@ -182,8 +182,8 @@ func (fs *hellofs) ListRecycle(ctx context.Context, ref *provider.Reference, key
 
 // RestoreRecycleItem restores an item from the recyle bin
 // if restoreRef is nil the resource should be restored at the original path
-func (fs *hellofs) RestoreRecycleItem(ctx context.Context, ref *provider.Reference, key, relativePath string, restoreRef *provider.Reference) error {
-	return errtypes.NotSupported("unimplemented")
+func (fs *hellofs) RestoreRecycleItem(ctx context.Context, ref *provider.Reference, key, relativePath string, restoreRef *provider.Reference) (*storage.RestoreRecycleItemResult, error) {
+	return nil, errtypes.NotSupported("unimplemented")
 }
 
 // CreateHome creates a users home

--- a/pkg/storage/fs/nextcloud/nextcloud.go
+++ b/pkg/storage/fs/nextcloud/nextcloud.go
@@ -257,21 +257,24 @@ func (nc *StorageDriver) CreateHome(ctx context.Context) error {
 }
 
 // CreateDir as defined in the storage.FS interface
-func (nc *StorageDriver) CreateDir(ctx context.Context, ref *provider.Reference) error {
+func (nc *StorageDriver) CreateDir(ctx context.Context, ref *provider.Reference) (*storage.CreateDirResult, error) {
 	bodyStr, err := json.Marshal(ref)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	log := appctx.GetLogger(ctx)
 	log.Info().Msgf("CreateDir %s", bodyStr)
 
 	_, _, err = nc.do(ctx, Action{"CreateDir", string(bodyStr)})
-	return err
+	if err != nil {
+		return nil, err
+	}
+	return &storage.CreateDirResult{}, nil
 }
 
 // TouchFile as defined in the storage.FS interface
-func (nc *StorageDriver) TouchFile(ctx context.Context, ref *provider.Reference, markprocessing bool, mtime string) error {
-	return fmt.Errorf("unimplemented: TouchFile")
+func (nc *StorageDriver) TouchFile(ctx context.Context, ref *provider.Reference, markprocessing bool, mtime string) (*storage.TouchFileResult, error) {
+	return nil, fmt.Errorf("unimplemented: TouchFile")
 }
 
 // Delete as defined in the storage.FS interface
@@ -302,7 +305,10 @@ func (nc *StorageDriver) Move(ctx context.Context, oldRef, newRef *provider.Refe
 	log.Info().Msgf("Move %s", bodyStr)
 
 	_, _, err := nc.do(ctx, Action{"Move", string(bodyStr)})
-	return nil, err
+	if err != nil {
+		return nil, err
+	}
+	return &storage.MoveResult{}, nil
 }
 
 // GetMD as defined in the storage.FS interface
@@ -505,7 +511,7 @@ func (nc *StorageDriver) DownloadRevision(ctx context.Context, ref *provider.Ref
 }
 
 // RestoreRevision as defined in the storage.FS interface
-func (nc *StorageDriver) RestoreRevision(ctx context.Context, ref *provider.Reference, key string) error {
+func (nc *StorageDriver) RestoreRevision(ctx context.Context, ref *provider.Reference, key string) (*storage.RestoreRevisionResult, error) {
 	type paramsObj struct {
 		Ref *provider.Reference `json:"ref"`
 		Key string              `json:"key"`
@@ -519,7 +525,10 @@ func (nc *StorageDriver) RestoreRevision(ctx context.Context, ref *provider.Refe
 	log.Info().Msgf("RestoreRevision %s", bodyStr)
 
 	_, _, err := nc.do(ctx, Action{"RestoreRevision", string(bodyStr)})
-	return err
+	if err != nil {
+		return nil, err
+	}
+	return &storage.RestoreRevisionResult{}, nil
 }
 
 // ListRecycle as defined in the storage.FS interface
@@ -554,7 +563,7 @@ func (nc *StorageDriver) ListRecycle(ctx context.Context, ref *provider.Referenc
 }
 
 // RestoreRecycleItem as defined in the storage.FS interface
-func (nc *StorageDriver) RestoreRecycleItem(ctx context.Context, ref *provider.Reference, key, relativePath string, restoreRef *provider.Reference) error {
+func (nc *StorageDriver) RestoreRecycleItem(ctx context.Context, ref *provider.Reference, key, relativePath string, restoreRef *provider.Reference) (*storage.RestoreRecycleItemResult, error) {
 	type paramsObj struct {
 		Key        string              `json:"key"`
 		Path       string              `json:"path"`
@@ -571,8 +580,10 @@ func (nc *StorageDriver) RestoreRecycleItem(ctx context.Context, ref *provider.R
 	log.Info().Msgf("RestoreRecycleItem %s", bodyStr)
 
 	_, _, err := nc.do(ctx, Action{"RestoreRecycleItem", string(bodyStr)})
-
-	return err
+	if err != nil {
+		return nil, err
+	}
+	return &storage.RestoreRecycleItemResult{}, nil
 }
 
 // PurgeRecycleItem as defined in the storage.FS interface
@@ -848,8 +859,8 @@ func (nc *StorageDriver) GetLock(ctx context.Context, ref *provider.Reference) (
 }
 
 // SetLock puts a lock on the given reference
-func (nc *StorageDriver) SetLock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) error {
-	return errtypes.NotSupported("unimplemented")
+func (nc *StorageDriver) SetLock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) (*storage.SetLockResult, error) {
+	return nil, errtypes.NotSupported("unimplemented")
 }
 
 // RefreshLock refreshes an existing lock on the given reference
@@ -858,8 +869,8 @@ func (nc *StorageDriver) RefreshLock(ctx context.Context, ref *provider.Referenc
 }
 
 // Unlock removes an existing lock from the given reference
-func (nc *StorageDriver) Unlock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) error {
-	return errtypes.NotSupported("unimplemented")
+func (nc *StorageDriver) Unlock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) (*storage.UnlockResult, error) {
+	return nil, errtypes.NotSupported("unimplemented")
 }
 
 // ListStorageSpaces as defined in the storage.FS interface

--- a/pkg/storage/fs/nextcloud/nextcloud_test.go
+++ b/pkg/storage/fs/nextcloud/nextcloud_test.go
@@ -159,7 +159,7 @@ var _ = Describe("Nextcloud", func() {
 				},
 				Path: "/some/path",
 			}
-			err := nc.CreateDir(ctx, ref)
+			_, err := nc.CreateDir(ctx, ref)
 			Expect(err).ToNot(HaveOccurred())
 			checkCalled(called, `POST /apps/sciencemesh/~tester/api/storage/CreateDir {"resource_id":{"storage_id":"storage-id","opaque_id":"opaque-id"},"path":"/some/path"}`)
 		})
@@ -521,7 +521,7 @@ var _ = Describe("Nextcloud", func() {
 				Path: "some/file/path.txt",
 			}
 			key := "asdf"
-			err := nc.RestoreRevision(ctx, ref, key)
+			_, err := nc.RestoreRevision(ctx, ref, key)
 			Expect(err).ToNot(HaveOccurred())
 			checkCalled(called, `POST /apps/sciencemesh/~tester/api/storage/RestoreRevision {"ref":{"resource_id":{"storage_id":"storage-id","opaque_id":"opaque-id"},"path":"some/file/path.txt"},"key":"asdf"}`)
 		})
@@ -566,7 +566,7 @@ var _ = Describe("Nextcloud", func() {
 			}
 			path := "original/location/when/deleted.txt"
 			key := "asdf"
-			err := nc.RestoreRecycleItem(ctx, nil, key, path, restoreRef)
+			_, err := nc.RestoreRecycleItem(ctx, nil, key, path, restoreRef)
 			Expect(err).ToNot(HaveOccurred())
 			checkCalled(called, `POST /apps/sciencemesh/~tester/api/storage/RestoreRecycleItem {"key":"asdf","path":"original/location/when/deleted.txt","restoreRef":{"resource_id":{"storage_id":"storage-id","opaque_id":"opaque-id"},"path":"some/file/path.txt"}}`)
 		})

--- a/pkg/storage/fs/owncloudsql/owncloudsql.go
+++ b/pkg/storage/fs/owncloudsql/owncloudsql.go
@@ -754,38 +754,38 @@ func (fs *owncloudsqlfs) GetHome(ctx context.Context) (string, error) {
 	return "", nil
 }
 
-func (fs *owncloudsqlfs) CreateDir(ctx context.Context, ref *provider.Reference) (err error) {
+func (fs *owncloudsqlfs) CreateDir(ctx context.Context, ref *provider.Reference) (_ *storage.CreateDirResult, err error) {
 
 	ip, err := fs.resolve(ctx, ref)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// check permissions of parent dir
 	if perm, err := fs.readPermissions(ctx, filepath.Dir(ip)); err == nil {
 		if !perm.CreateContainer {
-			return errtypes.PermissionDenied("")
+			return nil, errtypes.PermissionDenied("")
 		}
 	} else {
 		if isNotFound(err) {
-			return errtypes.PreconditionFailed(ref.Path)
+			return nil, errtypes.PreconditionFailed(ref.Path)
 		}
-		return errors.Wrap(err, "owncloudsql: error reading permissions")
+		return nil, errors.Wrap(err, "owncloudsql: error reading permissions")
 	}
 
 	if err = os.Mkdir(ip, 0700); err != nil {
 		if os.IsNotExist(err) {
-			return errtypes.PreconditionFailed(ref.Path)
+			return nil, errtypes.PreconditionFailed(ref.Path)
 		}
 		if os.IsExist(err) {
-			return errtypes.AlreadyExists(ref.Path)
+			return nil, errtypes.AlreadyExists(ref.Path)
 		}
-		return errors.Wrap(err, "owncloudsql: error creating dir "+fs.toStoragePath(ctx, filepath.Dir(ip)))
+		return nil, errors.Wrap(err, "owncloudsql: error creating dir "+fs.toStoragePath(ctx, filepath.Dir(ip)))
 	}
 
 	fi, err := os.Stat(ip)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	mtime := time.Now().Unix()
 
@@ -803,54 +803,55 @@ func (fs *owncloudsqlfs) CreateDir(ctx context.Context, ref *provider.Reference)
 	}
 	storageID, err := fs.getStorage(ctx, ip)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	_, err = fs.filecache.InsertOrUpdate(ctx, storageID, data, false)
 	if err != nil {
-		if err != nil {
-			return err
-		}
+		return nil, err
 	}
 
-	return fs.propagate(ctx, filepath.Dir(ip))
+	if err := fs.propagate(ctx, filepath.Dir(ip)); err != nil {
+		return nil, err
+	}
+	return &storage.CreateDirResult{}, nil
 }
 
 // TouchFile as defined in the storage.FS interface
-func (fs *owncloudsqlfs) TouchFile(ctx context.Context, ref *provider.Reference, markprocessing bool, mtime string) error {
+func (fs *owncloudsqlfs) TouchFile(ctx context.Context, ref *provider.Reference, markprocessing bool, mtime string) (*storage.TouchFileResult, error) {
 	ip, err := fs.resolve(ctx, ref)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// check permissions of parent dir
 	parentPerms, err := fs.readPermissions(ctx, filepath.Dir(ip))
 	if err == nil {
 		if !parentPerms.InitiateFileUpload {
-			return errtypes.PermissionDenied("")
+			return nil, errtypes.PermissionDenied("")
 		}
 	} else {
 		if isNotFound(err) {
-			return errtypes.NotFound(ref.Path)
+			return nil, errtypes.NotFound(ref.Path)
 		}
-		return errors.Wrap(err, "owncloudsql: error reading permissions")
+		return nil, errors.Wrap(err, "owncloudsql: error reading permissions")
 	}
 
 	_, err = os.Create(ip)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return errtypes.NotFound(ref.Path)
+			return nil, errtypes.NotFound(ref.Path)
 		}
 		// FIXME we also need already exists error, webdav expects 405 MethodNotAllowed
-		return errors.Wrap(err, "owncloudsql: error creating file "+fs.toStoragePath(ctx, filepath.Dir(ip)))
+		return nil, errors.Wrap(err, "owncloudsql: error creating file "+fs.toStoragePath(ctx, filepath.Dir(ip)))
 	}
 
 	if err = os.Chmod(ip, 0700); err != nil {
-		return errors.Wrap(err, "owncloudsql: error setting file permissions on "+fs.toStoragePath(ctx, filepath.Dir(ip)))
+		return nil, errors.Wrap(err, "owncloudsql: error setting file permissions on "+fs.toStoragePath(ctx, filepath.Dir(ip)))
 	}
 
 	fi, err := os.Stat(ip)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	storageMtime := time.Now().Unix()
 	mt := storageMtime
@@ -874,14 +875,17 @@ func (fs *owncloudsqlfs) TouchFile(ctx context.Context, ref *provider.Reference,
 	}
 	storageID, err := fs.getStorage(ctx, ip)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	_, err = fs.filecache.InsertOrUpdate(ctx, storageID, data, false)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return fs.propagate(ctx, filepath.Dir(ip))
+	if err := fs.propagate(ctx, filepath.Dir(ip)); err != nil {
+		return nil, err
+	}
+	return &storage.TouchFileResult{}, nil
 }
 
 func (fs *owncloudsqlfs) CreateReference(ctx context.Context, sp string, targetURI *url.URL) error {
@@ -1143,8 +1147,8 @@ func (fs *owncloudsqlfs) GetLock(ctx context.Context, ref *provider.Reference) (
 }
 
 // SetLock puts a lock on the given reference
-func (fs *owncloudsqlfs) SetLock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) error {
-	return errtypes.NotSupported("unimplemented")
+func (fs *owncloudsqlfs) SetLock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) (*storage.SetLockResult, error) {
+	return nil, errtypes.NotSupported("unimplemented")
 }
 
 // RefreshLock refreshes an existing lock on the given reference
@@ -1153,8 +1157,8 @@ func (fs *owncloudsqlfs) RefreshLock(ctx context.Context, ref *provider.Referenc
 }
 
 // Unlock removes an existing lock from the given reference
-func (fs *owncloudsqlfs) Unlock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) error {
-	return errtypes.NotSupported("unimplemented")
+func (fs *owncloudsqlfs) Unlock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) (*storage.UnlockResult, error) {
+	return nil, errtypes.NotSupported("unimplemented")
 }
 
 // Delete is actually only a move to trash
@@ -1339,7 +1343,7 @@ func (fs *owncloudsqlfs) Move(ctx context.Context, oldRef, newRef *provider.Refe
 			return nil, err
 		}
 	}
-	return nil, nil
+	return &storage.MoveResult{}, nil
 }
 
 func (fs *owncloudsqlfs) GetMD(ctx context.Context, ref *provider.Reference, mdKeys []string, fieldMask []string) (*provider.ResourceInfo, error) {
@@ -1657,22 +1661,22 @@ func (fs *owncloudsqlfs) DownloadRevision(ctx context.Context, ref *provider.Ref
 	return nil, nil, errtypes.NotSupported("download revision")
 }
 
-func (fs *owncloudsqlfs) RestoreRevision(ctx context.Context, ref *provider.Reference, revisionKey string) error {
+func (fs *owncloudsqlfs) RestoreRevision(ctx context.Context, ref *provider.Reference, revisionKey string) (*storage.RestoreRevisionResult, error) {
 	ip, err := fs.resolve(ctx, ref)
 	if err != nil {
-		return errors.Wrap(err, "owncloudsql: error resolving reference")
+		return nil, errors.Wrap(err, "owncloudsql: error resolving reference")
 	}
 
 	// check permissions
 	if perm, err := fs.readPermissions(ctx, ip); err == nil {
 		if !perm.RestoreFileVersion {
-			return errtypes.PermissionDenied("")
+			return nil, errtypes.PermissionDenied("")
 		}
 	} else {
 		if isNotFound(err) {
-			return errtypes.NotFound(fs.toStoragePath(ctx, filepath.Dir(ip)))
+			return nil, errtypes.NotFound(fs.toStoragePath(ctx, filepath.Dir(ip)))
 		}
-		return errors.Wrap(err, "owncloudsql: error reading permissions")
+		return nil, errors.Wrap(err, "owncloudsql: error reading permissions")
 	}
 
 	vp := fs.getVersionsPath(ctx, ip)
@@ -1681,34 +1685,34 @@ func (fs *owncloudsqlfs) RestoreRevision(ctx context.Context, ref *provider.Refe
 	// check revision exists
 	rs, err := os.Stat(rp)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if !rs.Mode().IsRegular() {
-		return fmt.Errorf("%s is not a regular file", rp)
+		return nil, fmt.Errorf("%s is not a regular file", rp)
 	}
 
 	source, err := os.Open(rp)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer source.Close()
 
 	// destination should be available, otherwise we could not have navigated to its revisions
 	if err := fs.archiveRevision(ctx, fs.getVersionsPath(ctx, ip), ip); err != nil {
-		return err
+		return nil, err
 	}
 
 	destination, err := os.Create(ip)
 	if err != nil {
 		// TODO(jfd) bring back revision in case sth goes wrong?
-		return err
+		return nil, err
 	}
 	defer destination.Close()
 
 	_, err = io.Copy(destination, source)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	sha1h, md5h, adler32h, err := fs.HashFile(ip)
@@ -1717,7 +1721,7 @@ func (fs *owncloudsqlfs) RestoreRevision(ctx context.Context, ref *provider.Refe
 	}
 	fi, err := os.Stat(ip)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	mtime := time.Now().Unix()
 	data := map[string]interface{}{
@@ -1731,15 +1735,18 @@ func (fs *owncloudsqlfs) RestoreRevision(ctx context.Context, ref *provider.Refe
 	}
 	storageID, err := fs.getStorage(ctx, ip)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	_, err = fs.filecache.InsertOrUpdate(ctx, storageID, data, false)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// TODO(jfd) bring back revision in case sth goes wrong?
-	return fs.propagate(ctx, ip)
+	if err := fs.propagate(ctx, ip); err != nil {
+		return nil, err
+	}
+	return &storage.RestoreRevisionResult{}, nil
 }
 
 func (fs *owncloudsqlfs) PurgeRecycleItem(ctx context.Context, ref *provider.Reference, key, relativePath string) error {
@@ -1902,18 +1909,18 @@ func (fs *owncloudsqlfs) ListRecycle(ctx context.Context, ref *provider.Referenc
 	return items, nil
 }
 
-func (fs *owncloudsqlfs) RestoreRecycleItem(ctx context.Context, ref *provider.Reference, key, relativePath string, restoreRef *provider.Reference) error {
+func (fs *owncloudsqlfs) RestoreRecycleItem(ctx context.Context, ref *provider.Reference, key, relativePath string, restoreRef *provider.Reference) (*storage.RestoreRecycleItemResult, error) {
 	log := appctx.GetLogger(ctx)
 
 	base, ttime, err := splitTrashKey(key)
 	if err != nil {
 		log.Error().Str("path", key).Msg("invalid trash item key")
-		return fmt.Errorf("invalid trash item suffix")
+		return nil, fmt.Errorf("invalid trash item suffix")
 	}
 
 	recyclePath, err := fs.getRecyclePath(ctx)
 	if err != nil {
-		return errors.Wrap(err, "owncloudsql: error resolving recycle path")
+		return nil, errors.Wrap(err, "owncloudsql: error resolving recycle path")
 	}
 	src := filepath.Join(recyclePath, filepath.Clean(key))
 
@@ -1923,7 +1930,7 @@ func (fs *owncloudsqlfs) RestoreRecycleItem(ctx context.Context, ref *provider.R
 		if err != nil {
 			log := appctx.GetLogger(ctx)
 			log.Error().Err(err).Str("path", key).Msg("could not get trash item")
-			return nil
+			return nil, err
 		}
 		restoreRef.Path = filepath.Join(item.Path, item.Name)
 	}
@@ -1932,27 +1939,30 @@ func (fs *owncloudsqlfs) RestoreRecycleItem(ctx context.Context, ref *provider.R
 	// move back to original location
 	if err := os.Rename(src, tgt); err != nil {
 		log.Error().Err(err).Str("key", key).Str("restorePath", restoreRef.Path).Str("src", src).Str("tgt", tgt).Msg("could not restore item")
-		return errors.Wrap(err, "owncloudsql: could not restore item")
+		return nil, errors.Wrap(err, "owncloudsql: could not restore item")
 	}
 
-	storage, err := fs.getStorage(ctx, src)
+	storageID, err := fs.getStorage(ctx, src)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	err = fs.filecache.Move(ctx, storage, fs.toDatabasePath(src), fs.toDatabasePath(tgt))
+	err = fs.filecache.Move(ctx, storageID, fs.toDatabasePath(src), fs.toDatabasePath(tgt))
 	if err != nil {
-		return err
+		return nil, err
 	}
 	err = fs.filecache.DeleteRecycleItem(ctx, ctxpkg.ContextMustGetUser(ctx).Username, base, ttime)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	err = fs.RestoreRecycleItemVersions(ctx, key, tgt)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return fs.propagate(ctx, tgt)
+	if err := fs.propagate(ctx, tgt); err != nil {
+		return nil, err
+	}
+	return &storage.RestoreRecycleItemResult{}, nil
 }
 
 func (fs *owncloudsqlfs) RestoreRecycleItemVersions(ctx context.Context, key, target string) error {

--- a/pkg/storage/fs/posix/testhelpers/helpers.go
+++ b/pkg/storage/fs/posix/testhelpers/helpers.go
@@ -234,7 +234,7 @@ func (t *TestEnv) CreateTestDir(name string, parentRef *providerv1beta1.Referenc
 	ref := parentRef
 	ref.Path = name
 
-	err := t.Fs.CreateDir(t.Ctx, ref)
+	_, err := t.Fs.CreateDir(t.Ctx, ref)
 	if err != nil {
 		return nil, err
 	}
@@ -352,7 +352,7 @@ func (t *TestEnv) CreateTestStorageSpace(typ string, quota *providerv1beta1.Quot
 		CreateContainer: true,
 	}, nil).Times(1) // Permissions required for setup below
 	ref.Path = "./dir1/subdir1"
-	err = t.Fs.CreateDir(t.Ctx, ref)
+	_, err = t.Fs.CreateDir(t.Ctx, ref)
 	if err != nil {
 		return nil, err
 	}
@@ -368,7 +368,7 @@ func (t *TestEnv) CreateTestStorageSpace(typ string, quota *providerv1beta1.Quot
 		CreateContainer: true,
 	}, nil).Times(1) // Permissions required for setup below
 	ref.Path = "/emptydir"
-	err = t.Fs.CreateDir(t.Ctx, ref)
+	_, err = t.Fs.CreateDir(t.Ctx, ref)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/fs/posix/trashbin/trashbin.go
+++ b/pkg/storage/fs/posix/trashbin/trashbin.go
@@ -226,10 +226,10 @@ func (tb *Trashbin) ListRecycle(ctx context.Context, ref *provider.Reference, ke
 }
 
 // RestoreRecycleItem restores the specified item
-func (tb *Trashbin) RestoreRecycleItem(ctx context.Context, ref *provider.Reference, key, relativePath string, restoreRef *provider.Reference) error {
+func (tb *Trashbin) RestoreRecycleItem(ctx context.Context, ref *provider.Reference, key, relativePath string, restoreRef *provider.Reference) (*storage.RestoreRecycleItemResult, error) {
 	n, err := tb.lu.NodeFromResource(ctx, ref)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	trashRoot := trashRootForNode(n)
@@ -237,33 +237,33 @@ func (tb *Trashbin) RestoreRecycleItem(ctx context.Context, ref *provider.Refere
 
 	restoreBaseNode, err := tb.lu.NodeFromID(ctx, restoreRef.GetResourceId())
 	if err != nil {
-		return err
+		return nil, err
 	}
 	restorePath := filepath.Join(restoreBaseNode.InternalPath(), restoreRef.GetPath())
 
 	id, err := tb.lu.MetadataBackend().Get(ctx, trashPath, prefixes.IDAttr)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// update parent id in case it was restored to a different location
 	parentID, err := tb.lu.MetadataBackend().Get(ctx, filepath.Dir(restorePath), prefixes.IDAttr)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if len(parentID) == 0 {
-		return fmt.Errorf("trashbin: parent id not found for %s", restorePath)
+		return nil, fmt.Errorf("trashbin: parent id not found for %s", restorePath)
 	}
 
 	err = tb.lu.MetadataBackend().Set(ctx, trashPath, prefixes.ParentidAttr, parentID)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// restore the item
 	err = os.Rename(trashPath, restorePath)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if err := tb.lu.CacheID(ctx, n.SpaceID, string(id), restorePath); err != nil {
 		tb.log.Error().Err(err).Str("spaceID", n.SpaceID).Str("id", string(id)).Str("path", restorePath).Msg("trashbin: error caching id")
@@ -271,10 +271,11 @@ func (tb *Trashbin) RestoreRecycleItem(ctx context.Context, ref *provider.Refere
 
 	// cleanup trash info
 	if relativePath == "." || relativePath == "/" {
-		return os.Remove(filepath.Join(trashRoot, "info", key+".trashinfo"))
-	} else {
-		return nil
+		if err := os.Remove(filepath.Join(trashRoot, "info", key+".trashinfo")); err != nil {
+			return nil, err
+		}
 	}
+	return &storage.RestoreRecycleItemResult{SpaceOwner: n.SpaceOwnerOrManager(ctx)}, nil
 }
 
 // PurgeRecycleItem purges the specified item, all its children and all their revisions

--- a/pkg/storage/fs/s3/s3.go
+++ b/pkg/storage/fs/s3/s3.go
@@ -36,13 +36,13 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	types "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
+	"github.com/mitchellh/mapstructure"
 	"github.com/owncloud/reva/v2/pkg/appctx"
 	"github.com/owncloud/reva/v2/pkg/errtypes"
 	"github.com/owncloud/reva/v2/pkg/events"
 	"github.com/owncloud/reva/v2/pkg/mime"
 	"github.com/owncloud/reva/v2/pkg/storage"
 	"github.com/owncloud/reva/v2/pkg/storage/fs/registry"
-	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 )
@@ -288,8 +288,8 @@ func (fs *s3FS) GetLock(ctx context.Context, ref *provider.Reference) (*provider
 }
 
 // SetLock puts a lock on the given reference
-func (fs *s3FS) SetLock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) error {
-	return errtypes.NotSupported("unimplemented")
+func (fs *s3FS) SetLock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) (*storage.SetLockResult, error) {
+	return nil, errtypes.NotSupported("unimplemented")
 }
 
 // RefreshLock refreshes an existing lock on the given reference
@@ -298,8 +298,8 @@ func (fs *s3FS) RefreshLock(ctx context.Context, ref *provider.Reference, lock *
 }
 
 // Unlock removes an existing lock from the given reference
-func (fs *s3FS) Unlock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) error {
-	return errtypes.NotSupported("unimplemented")
+func (fs *s3FS) Unlock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) (*storage.UnlockResult, error) {
+	return nil, errtypes.NotSupported("unimplemented")
 }
 
 func (fs *s3FS) CreateReference(ctx context.Context, path string, targetURI *url.URL) error {
@@ -315,12 +315,12 @@ func (fs *s3FS) CreateHome(ctx context.Context) error {
 	return errtypes.NotSupported("s3fs: not supported")
 }
 
-func (fs *s3FS) CreateDir(ctx context.Context, ref *provider.Reference) error {
+func (fs *s3FS) CreateDir(ctx context.Context, ref *provider.Reference) (*storage.CreateDirResult, error) {
 	log := appctx.GetLogger(ctx)
 
 	fn, err := fs.resolve(ctx, ref)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 
 	fn = fs.addRoot(fn) + "/" // append / to indicate folder // TODO only if fn does not end in /
@@ -337,20 +337,20 @@ func (fs *s3FS) CreateDir(ctx context.Context, ref *provider.Reference) error {
 		log.Error().Err(err)
 		if aerr, ok := err.(awserr.Error); ok {
 			if aerr.Code() == s3.ErrCodeNoSuchBucket {
-				return errtypes.NotFound(ref.Path)
+				return nil, errtypes.NotFound(ref.Path)
 			}
 		}
 		// FIXME we also need already exists error, webdav expects 405 MethodNotAllowed
-		return errors.Wrap(err, "s3fs: error creating dir "+ref.Path)
+		return nil, errors.Wrap(err, "s3fs: error creating dir "+ref.Path)
 	}
 
 	log.Debug().Interface("result", result) // todo cache etag?
-	return nil
+	return &storage.CreateDirResult{}, nil
 }
 
 // TouchFile as defined in the storage.FS interface
-func (fs *s3FS) TouchFile(ctx context.Context, ref *provider.Reference, markprocessing bool, mtime string) error {
-	return fmt.Errorf("unimplemented: TouchFile")
+func (fs *s3FS) TouchFile(ctx context.Context, ref *provider.Reference, markprocessing bool, mtime string) (*storage.TouchFileResult, error) {
+	return nil, fmt.Errorf("unimplemented: TouchFile")
 }
 
 func (fs *s3FS) Delete(ctx context.Context, ref *provider.Reference) error {
@@ -507,7 +507,7 @@ func (fs *s3FS) Move(ctx context.Context, oldRef, newRef *provider.Reference) (*
 			isTruncated = *output.IsTruncated
 		}
 		// ok, we are done
-		return nil, nil
+		return &storage.MoveResult{}, nil
 	}
 
 	// move single object
@@ -515,7 +515,7 @@ func (fs *s3FS) Move(ctx context.Context, oldRef, newRef *provider.Reference) (*
 	if err != nil {
 		return nil, err
 	}
-	return nil, nil
+	return &storage.MoveResult{}, nil
 }
 
 func (fs *s3FS) GetMD(ctx context.Context, ref *provider.Reference, mdKeys []string, fieldMask []string) (*provider.ResourceInfo, error) {
@@ -663,8 +663,8 @@ func (fs *s3FS) DownloadRevision(ctx context.Context, ref *provider.Reference, r
 	return nil, nil, errtypes.NotSupported("download revision")
 }
 
-func (fs *s3FS) RestoreRevision(ctx context.Context, ref *provider.Reference, revisionKey string) error {
-	return errtypes.NotSupported("restore revision")
+func (fs *s3FS) RestoreRevision(ctx context.Context, ref *provider.Reference, revisionKey string) (*storage.RestoreRevisionResult, error) {
+	return nil, errtypes.NotSupported("restore revision")
 }
 
 func (fs *s3FS) PurgeRecycleItem(ctx context.Context, ref *provider.Reference, key, relativePath string) error {
@@ -679,8 +679,8 @@ func (fs *s3FS) ListRecycle(ctx context.Context, ref *provider.Reference, key, r
 	return nil, errtypes.NotSupported("list recycle")
 }
 
-func (fs *s3FS) RestoreRecycleItem(ctx context.Context, ref *provider.Reference, key, relativePath string, restoreRef *provider.Reference) error {
-	return errtypes.NotSupported("restore recycle")
+func (fs *s3FS) RestoreRecycleItem(ctx context.Context, ref *provider.Reference, key, relativePath string, restoreRef *provider.Reference) (*storage.RestoreRecycleItemResult, error) {
+	return nil, errtypes.NotSupported("restore recycle")
 }
 
 func (fs *s3FS) ListStorageSpaces(ctx context.Context, filter []*provider.ListStorageSpacesRequest_Filter, unrestricted bool) ([]*provider.StorageSpace, error) {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -24,16 +24,48 @@ import (
 	"net/url"
 
 	user "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	registry "github.com/cs3org/go-cs3apis/cs3/storage/registry/v1beta1"
 	tusd "github.com/tus/tusd/v2/pkg/handler"
 )
 
-// MoveResult carries the resolved references returned by a successful Move.
 type MoveResult struct {
 	SpaceOwner   *user.UserId
 	OldReference *provider.Reference
 	NewReference *provider.Reference
+}
+
+type CreateDirResult struct {
+	SpaceOwner *userpb.UserId
+	SpaceID    string
+	ResourceID *provider.ResourceId
+}
+
+type TouchFileResult struct {
+	SpaceOwner *userpb.UserId
+	SpaceID    string
+	ResourceID *provider.ResourceId
+}
+
+type RestoreRevisionResult struct {
+	SpaceOwner *userpb.UserId
+	SpaceID    string
+}
+
+type RestoreRecycleItemResult struct {
+	SpaceOwner *userpb.UserId
+	SpaceID    string
+}
+
+type SetLockResult struct {
+	SpaceOwner *userpb.UserId
+	SpaceID    string
+}
+
+type UnlockResult struct {
+	SpaceOwner *userpb.UserId
+	SpaceID    string
 }
 
 // FS is the interface to implement access to the storage.
@@ -67,11 +99,11 @@ type FS interface {
 	// CreateReference creates a resource of type reference
 	CreateReference(ctx context.Context, path string, targetURI *url.URL) error
 	// CreateDir creates a resource of type container
-	CreateDir(ctx context.Context, ref *provider.Reference) error
+	CreateDir(ctx context.Context, ref *provider.Reference) (*CreateDirResult, error)
 	// TouchFile sets the mtime of a resource, creating an empty file if it does not exist
 	// FIXME the markprocessing flag is an implementation detail of decomposedfs, remove it from the function
 	// FIXME the mtime should either be a time.Time or a CS3 Timestamp, not a string
-	TouchFile(ctx context.Context, ref *provider.Reference, markprocessing bool, mtime string) error
+	TouchFile(ctx context.Context, ref *provider.Reference, markprocessing bool, mtime string) (*TouchFileResult, error)
 	// Delete deletes a resource.
 	// If the storage driver supports a recycle bin it should moves it to the recycle bin
 	Delete(ctx context.Context, ref *provider.Reference) error
@@ -89,7 +121,7 @@ type FS interface {
 	// DownloadRevision downloads a revision
 	DownloadRevision(ctx context.Context, ref *provider.Reference, key string, openReaderFunc func(md *provider.ResourceInfo) bool) (*provider.ResourceInfo, io.ReadCloser, error)
 	// RestoreRevision restores a revision
-	RestoreRevision(ctx context.Context, ref *provider.Reference, key string) error
+	RestoreRevision(ctx context.Context, ref *provider.Reference, key string) (*RestoreRevisionResult, error)
 
 	// Recyce bin
 
@@ -97,7 +129,7 @@ type FS interface {
 	ListRecycle(ctx context.Context, ref *provider.Reference, key, relativePath string) ([]*provider.RecycleItem, error)
 	// RestoreRecycleItem restores an item from the recyle bin
 	// if restoreRef is nil the resource should be restored at the original path
-	RestoreRecycleItem(ctx context.Context, ref *provider.Reference, key, relativePath string, restoreRef *provider.Reference) error
+	RestoreRecycleItem(ctx context.Context, ref *provider.Reference, key, relativePath string, restoreRef *provider.Reference) (*RestoreRecycleItemResult, error)
 	// PurgeRecycleItem removes a resource from the recycle bin
 	PurgeRecycleItem(ctx context.Context, ref *provider.Reference, key, relativePath string) error
 	// EmptyRecycle removes all resource from the recycle bin
@@ -129,11 +161,11 @@ type FS interface {
 	// GetLock returns an existing lock on the given reference
 	GetLock(ctx context.Context, ref *provider.Reference) (*provider.Lock, error)
 	// SetLock puts a lock on the given reference
-	SetLock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) error
+	SetLock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) (*SetLockResult, error)
 	// RefreshLock refreshes an existing lock on the given reference
 	RefreshLock(ctx context.Context, ref *provider.Reference, lock *provider.Lock, existingLockID string) error
 	// Unlock removes an existing lock from the given reference
-	Unlock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) error
+	Unlock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) (*UnlockResult, error)
 
 	// Spaces
 

--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -745,13 +745,13 @@ func (fs *Decomposedfs) GetPathByID(ctx context.Context, id *provider.ResourceId
 }
 
 // CreateDir creates the specified directory
-func (fs *Decomposedfs) CreateDir(ctx context.Context, ref *provider.Reference) (err error) {
+func (fs *Decomposedfs) CreateDir(ctx context.Context, ref *provider.Reference) (_ *storage.CreateDirResult, err error) {
 	ctx, span := tracer.Start(ctx, "CreateDir")
 	defer span.End()
 
 	name := path.Base(ref.Path)
 	if name == "" || name == "." || name == "/" {
-		return errtypes.BadRequest("Invalid path: " + ref.Path)
+		return nil, errtypes.BadRequest("Invalid path: " + ref.Path)
 	}
 
 	parentRef := &provider.Reference{
@@ -763,52 +763,51 @@ func (fs *Decomposedfs) CreateDir(ctx context.Context, ref *provider.Reference) 
 	var n *node.Node
 	if n, err = fs.lu.NodeFromResource(ctx, parentRef); err != nil {
 		if e, ok := err.(errtypes.NotFound); ok {
-			return errtypes.PreconditionFailed(e.Error())
+			return nil, errtypes.PreconditionFailed(e.Error())
 		}
-		return
+		return nil, err
 	}
 	// TODO check if user has access to root / space
 	if !n.Exists {
-		return errtypes.PreconditionFailed(parentRef.Path)
+		return nil, errtypes.PreconditionFailed(parentRef.Path)
 	}
 
 	rp, err := fs.p.AssemblePermissions(ctx, n)
 	switch {
 	case err != nil:
-		return err
+		return nil, err
 	case !rp.CreateContainer:
 		f, _ := storagespace.FormatReference(ref)
 		if rp.Stat {
-			return errtypes.PermissionDenied(f)
+			return nil, errtypes.PermissionDenied(f)
 		}
-		return errtypes.NotFound(f)
+		return nil, errtypes.NotFound(f)
 	}
 
-	// Set space owner in context
-	storagespace.ContextSendSpaceOwnerID(ctx, n.SpaceOwnerOrManager(ctx))
+	spaceOwner := n.SpaceOwnerOrManager(ctx)
 
 	// check lock
 	if err := n.CheckLock(ctx); err != nil {
-		return err
+		return nil, err
 	}
 
 	// verify child does not exist, yet
 	if n, err = n.Child(ctx, name); err != nil {
-		return
+		return nil, err
 	}
 	if n.Exists {
-		return errtypes.AlreadyExists(ref.Path)
+		return nil, errtypes.AlreadyExists(ref.Path)
 	}
 
 	if err = fs.tp.CreateDir(ctx, n); err != nil {
-		return
+		return nil, err
 	}
 
-	return
+	return &storage.CreateDirResult{SpaceOwner: spaceOwner, SpaceID: n.SpaceID, ResourceID: &provider.ResourceId{OpaqueId: n.ID, SpaceId: n.SpaceID}}, nil
 }
 
 // TouchFile as defined in the storage.FS interface
-func (fs *Decomposedfs) TouchFile(ctx context.Context, ref *provider.Reference, markprocessing bool, mtime string) error {
+func (fs *Decomposedfs) TouchFile(ctx context.Context, ref *provider.Reference, markprocessing bool, mtime string) (*storage.TouchFileResult, error) {
 	ctx, span := tracer.Start(ctx, "TouchFile")
 	defer span.End()
 	parentRef := &provider.Reference{
@@ -819,37 +818,39 @@ func (fs *Decomposedfs) TouchFile(ctx context.Context, ref *provider.Reference, 
 	// verify parent exists
 	parent, err := fs.lu.NodeFromResource(ctx, parentRef)
 	if err != nil {
-		return errtypes.InternalError(err.Error())
+		return nil, errtypes.InternalError(err.Error())
 	}
 	if !parent.Exists {
-		return errtypes.NotFound(parentRef.Path)
+		return nil, errtypes.NotFound(parentRef.Path)
 	}
 
 	n, err := fs.lu.NodeFromResource(ctx, ref)
 	if err != nil {
-		return errtypes.InternalError(err.Error())
+		return nil, errtypes.InternalError(err.Error())
 	}
 
 	rp, err := fs.p.AssemblePermissions(ctx, n)
 	switch {
 	case err != nil:
-		return err
+		return nil, err
 	case !rp.InitiateFileUpload:
 		f, _ := storagespace.FormatReference(ref)
 		if rp.Stat {
-			return errtypes.PermissionDenied(f)
+			return nil, errtypes.PermissionDenied(f)
 		}
-		return errtypes.NotFound(f)
+		return nil, errtypes.NotFound(f)
 	}
 
-	// Set space owner in context
-	storagespace.ContextSendSpaceOwnerID(ctx, n.SpaceOwnerOrManager(ctx))
+	spaceOwner := n.SpaceOwnerOrManager(ctx)
 
 	// check lock
 	if err := n.CheckLock(ctx); err != nil {
-		return err
+		return nil, err
 	}
-	return fs.tp.TouchFile(ctx, n, markprocessing, mtime)
+	if err := fs.tp.TouchFile(ctx, n, markprocessing, mtime); err != nil {
+		return nil, err
+	}
+	return &storage.TouchFileResult{SpaceOwner: spaceOwner, SpaceID: n.SpaceID, ResourceID: &provider.ResourceId{OpaqueId: n.ID, SpaceId: n.SpaceID}}, nil
 }
 
 // CreateReference creates a reference as a node folder with the target stored in extended attributes
@@ -912,6 +913,9 @@ func (fs *Decomposedfs) Move(ctx context.Context, oldRef, newRef *provider.Refer
 		return nil, errtypes.NotFound(f)
 	}
 
+	// Set space owner in context
+	storagespace.ContextSetSpaceOwner(ctx, newNode.SpaceOwnerOrManager(ctx))
+
 	// check lock on source
 	if err := oldNode.CheckLock(ctx); err != nil {
 		return nil, err
@@ -924,13 +928,13 @@ func (fs *Decomposedfs) Move(ctx context.Context, oldRef, newRef *provider.Refer
 	log := appctx.GetLogger(ctx)
 	newResolved := newRef
 	if nref, err := fs.refFromNode(ctx, newNode, newRef.GetResourceId().GetStorageId(), nrp); err != nil {
-		log.Error().Err(err).Msg("move: failed to resolve new reference")
+		log.Error().Err(err).Str("ref", newRef.String()).Msg("move: failed to resolve new reference")
 	} else {
 		newResolved = nref
 	}
 	oldResolved := oldRef
 	if oref, err := fs.refFromNode(ctx, oldNode, oldRef.GetResourceId().GetStorageId(), orp); err != nil {
-		log.Error().Err(err).Msg("move: failed to resolve old reference")
+		log.Error().Err(err).Str("ref", oldRef.String()).Msg("move: failed to resolve old reference")
 	} else {
 		oldResolved = oref
 	}
@@ -1104,7 +1108,7 @@ func (fs *Decomposedfs) Delete(ctx context.Context, ref *provider.Reference) (er
 	}
 
 	// Set space owner in context
-	storagespace.ContextSendSpaceOwnerID(ctx, node.SpaceOwnerOrManager(ctx))
+	storagespace.ContextSetSpaceOwner(ctx, node.SpaceOwnerOrManager(ctx))
 
 	if err := node.CheckLock(ctx); err != nil {
 		return err
@@ -1189,31 +1193,36 @@ func (fs *Decomposedfs) GetLock(ctx context.Context, ref *provider.Reference) (*
 }
 
 // SetLock puts a lock on the given reference
-func (fs *Decomposedfs) SetLock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) error {
+func (fs *Decomposedfs) SetLock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) (*storage.SetLockResult, error) {
 	ctx, span := tracer.Start(ctx, "SetLock")
 	defer span.End()
 	node, err := fs.lu.NodeFromResource(ctx, ref)
 	if err != nil {
-		return errors.Wrap(err, "Decomposedfs: error resolving ref")
+		return nil, errors.Wrap(err, "Decomposedfs: error resolving ref")
 	}
 
 	if !node.Exists {
-		return errtypes.NotFound(filepath.Join(node.ParentID, node.Name))
+		return nil, errtypes.NotFound(filepath.Join(node.ParentID, node.Name))
 	}
 
 	rp, err := fs.p.AssemblePermissions(ctx, node)
 	switch {
 	case err != nil:
-		return err
+		return nil, err
 	case !rp.InitiateFileUpload:
 		f, _ := storagespace.FormatReference(ref)
 		if rp.Stat {
-			return errtypes.PermissionDenied(f)
+			return nil, errtypes.PermissionDenied(f)
 		}
-		return errtypes.NotFound(f)
+		return nil, errtypes.NotFound(f)
 	}
 
-	return node.SetLock(ctx, lock)
+	spaceOwner := node.SpaceOwnerOrManager(ctx)
+
+	if err := node.SetLock(ctx, lock); err != nil {
+		return nil, err
+	}
+	return &storage.SetLockResult{SpaceOwner: spaceOwner, SpaceID: node.SpaceID}, nil
 }
 
 // RefreshLock refreshes an existing lock on the given reference
@@ -1249,41 +1258,46 @@ func (fs *Decomposedfs) RefreshLock(ctx context.Context, ref *provider.Reference
 }
 
 // Unlock removes an existing lock from the given reference
-func (fs *Decomposedfs) Unlock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) error {
+func (fs *Decomposedfs) Unlock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) (*storage.UnlockResult, error) {
 	ctx, span := tracer.Start(ctx, "Unlock")
 	defer span.End()
 	if lock.LockId == "" {
-		return errtypes.BadRequest("missing lockid")
+		return nil, errtypes.BadRequest("missing lockid")
 	}
 
 	node, err := fs.lu.NodeFromResource(ctx, ref)
 	if err != nil {
-		return errors.Wrap(err, "Decomposedfs: error resolving ref")
+		return nil, errors.Wrap(err, "Decomposedfs: error resolving ref")
 	}
 
 	if !node.Exists {
-		return errtypes.NotFound(filepath.Join(node.ParentID, node.Name))
+		return nil, errtypes.NotFound(filepath.Join(node.ParentID, node.Name))
 	}
 
 	rp, err := fs.p.AssemblePermissions(ctx, node)
 	switch {
 	case err != nil:
-		return err
+		return nil, err
 	case !rp.InitiateFileUpload: // TODO do we need a dedicated permission?
 		f, _ := storagespace.FormatReference(ref)
 		if rp.Stat {
-			return errtypes.PermissionDenied(f)
+			return nil, errtypes.PermissionDenied(f)
 		}
-		return errtypes.NotFound(f)
+		return nil, errtypes.NotFound(f)
 	}
 
-	return node.Unlock(ctx, lock)
+	spaceOwner := node.SpaceOwnerOrManager(ctx)
+
+	if err := node.Unlock(ctx, lock); err != nil {
+		return nil, err
+	}
+	return &storage.UnlockResult{SpaceOwner: spaceOwner, SpaceID: node.SpaceID}, nil
 }
 
 func (fs *Decomposedfs) ListRecycle(ctx context.Context, ref *provider.Reference, key, relativePath string) ([]*provider.RecycleItem, error) {
 	return fs.trashbin.ListRecycle(ctx, ref, key, relativePath)
 }
-func (fs *Decomposedfs) RestoreRecycleItem(ctx context.Context, ref *provider.Reference, key, relativePath string, restoreRef *provider.Reference) error {
+func (fs *Decomposedfs) RestoreRecycleItem(ctx context.Context, ref *provider.Reference, key, relativePath string, restoreRef *provider.Reference) (*storage.RestoreRecycleItemResult, error) {
 	return fs.trashbin.RestoreRecycleItem(ctx, ref, key, relativePath, restoreRef)
 }
 func (fs *Decomposedfs) PurgeRecycleItem(ctx context.Context, ref *provider.Reference, key, relativePath string) error {

--- a/pkg/storage/utils/decomposedfs/decomposedfs_concurrency_test.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs_concurrency_test.go
@@ -195,7 +195,7 @@ var _ = Describe("Decomposed", func() {
 							ResourceId: env.SpaceRootRes,
 							Path:       "./fightforit",
 						}
-						if err := env.Fs.CreateDir(env.Ctx, ref); err != nil {
+						if _, err := env.Fs.CreateDir(env.Ctx, ref); err != nil {
 							Expect(err).To(MatchError(ContainSubstring("already exists")))
 							rinfo, err := env.Fs.GetMD(env.Ctx, ref, nil, nil)
 							Expect(err).ToNot(HaveOccurred())

--- a/pkg/storage/utils/decomposedfs/decomposedfs_test.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Decomposed", func() {
 					Path:       "/dir2",
 				}
 				env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(&provider.ResourcePermissions{CreateContainer: true, Stat: true}, nil)
-				err := env.Fs.CreateDir(env.Ctx, dir2)
+				_, err := env.Fs.CreateDir(env.Ctx, dir2)
 				Expect(err).ToNot(HaveOccurred())
 				ri, err := env.Fs.GetMD(env.Ctx, dir2, []string{}, []string{})
 				Expect(err).ToNot(HaveOccurred())
@@ -86,15 +86,26 @@ var _ = Describe("Decomposed", func() {
 					Path:       "/dir1/dir2",
 				}
 				env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(&provider.ResourcePermissions{CreateContainer: true, Stat: true}, nil)
-				err := env.Fs.CreateDir(env.Ctx, dir2)
+				_, err := env.Fs.CreateDir(env.Ctx, dir2)
 				Expect(err).ToNot(HaveOccurred())
 				ri, err := env.Fs.GetMD(env.Ctx, dir2, []string{}, []string{})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ri.Path).To(Equal(dir2.Path))
 			})
+			It("returns SpaceOwner in WriteResult", func() {
+				dir2 := &provider.Reference{
+					ResourceId: env.SpaceRootRes,
+					Path:       "/dir2",
+				}
+				env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(&provider.ResourcePermissions{CreateContainer: true, Stat: true}, nil)
+				res, err := env.Fs.CreateDir(env.Ctx, dir2)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res).ToNot(BeNil())
+				Expect(res.SpaceOwner).ToNot(BeNil())
+			})
 			It("dir already exists", func() {
 				env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(&provider.ResourcePermissions{CreateContainer: true}, nil)
-				err := env.Fs.CreateDir(env.Ctx, ref)
+				_, err := env.Fs.CreateDir(env.Ctx, ref)
 				Expect(err).To(HaveOccurred())
 				Expect(err).Should(MatchError(errtypes.AlreadyExists("/dir1")))
 			})
@@ -104,9 +115,9 @@ var _ = Describe("Decomposed", func() {
 					Path:       "/dir1/dir3",
 				}
 				env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(&provider.ResourcePermissions{CreateContainer: true}, nil)
-				err := env.Fs.CreateDir(env.Ctx, dir3)
+				_, err := env.Fs.CreateDir(env.Ctx, dir3)
 				Expect(err).ToNot(HaveOccurred())
-				err = env.Fs.CreateDir(env.Ctx, dir3)
+				_, err = env.Fs.CreateDir(env.Ctx, dir3)
 				Expect(err).To(HaveOccurred())
 				Expect(err).Should(MatchError(errtypes.AlreadyExists("/dir1/dir3")))
 			})
@@ -116,7 +127,7 @@ var _ = Describe("Decomposed", func() {
 					Path:       "/dir1/dir2/dir3",
 				}
 				env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(&provider.ResourcePermissions{CreateContainer: true}, nil)
-				err := env.Fs.CreateDir(env.Ctx, dir2)
+				_, err := env.Fs.CreateDir(env.Ctx, dir2)
 				Expect(err).To(HaveOccurred())
 				Expect(err).Should(MatchError(errtypes.PreconditionFailed("/dir1/dir2")))
 			})
@@ -126,7 +137,7 @@ var _ = Describe("Decomposed", func() {
 					Path:       "/dir1/dir2/dir3/dir4",
 				}
 				env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(&provider.ResourcePermissions{CreateContainer: true}, nil)
-				err := env.Fs.CreateDir(env.Ctx, dir2)
+				_, err := env.Fs.CreateDir(env.Ctx, dir2)
 				Expect(err).To(HaveOccurred())
 				Expect(err).Should(MatchError(errtypes.PreconditionFailed("error: not found: dir2")))
 			})

--- a/pkg/storage/utils/decomposedfs/events_test.go
+++ b/pkg/storage/utils/decomposedfs/events_test.go
@@ -1,0 +1,223 @@
+package decomposedfs_test
+
+import (
+	"os"
+
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/owncloud/reva/v2/pkg/storage/utils/decomposedfs/metadata/prefixes"
+	helpers "github.com/owncloud/reva/v2/pkg/storage/utils/decomposedfs/testhelpers"
+	"github.com/owncloud/reva/v2/pkg/storagespace"
+)
+
+var _ = Describe("Storage event SpaceOwner propagation", func() {
+	var (
+		env *helpers.TestEnv
+	)
+
+	BeforeEach(func() {
+		var err error
+		env, err = helpers.NewTestEnv(nil)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		if env != nil {
+			env.Cleanup()
+		}
+	})
+
+	Describe("CreateDir", func() {
+		It("returns a WriteResult with SpaceOwner and propagates it via context slot", func() {
+			env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything).
+				Return(&provider.ResourcePermissions{
+					CreateContainer: true,
+					Stat:            true,
+				}, nil)
+
+			ctx := storagespace.ContextRegisterSpaceOwnerSlot(env.Ctx)
+
+			res, err := env.Fs.CreateDir(ctx, &provider.Reference{
+				ResourceId: env.SpaceRootRes,
+				Path:       "/events-test-createdir",
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res).ToNot(BeNil())
+			Expect(res.SpaceOwner).ToNot(BeNil())
+
+			storagespace.ContextSetSpaceOwner(ctx, res.SpaceOwner)
+
+			Expect(storagespace.ContextGetSpaceOwner(ctx)).To(Equal(res.SpaceOwner))
+		})
+	})
+
+	Describe("TouchFile", func() {
+		It("returns a WriteResult with SpaceOwner and propagates it via context slot", func() {
+			env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything).
+				Return(&provider.ResourcePermissions{
+					InitiateFileUpload: true,
+					Stat:               true,
+				}, nil)
+
+			ctx := storagespace.ContextRegisterSpaceOwnerSlot(env.Ctx)
+
+			res, err := env.Fs.TouchFile(ctx, &provider.Reference{
+				ResourceId: env.SpaceRootRes,
+				Path:       "/dir1/events-touch-file.txt",
+			}, false, "")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res).ToNot(BeNil())
+			Expect(res.SpaceOwner).ToNot(BeNil())
+
+			storagespace.ContextSetSpaceOwner(ctx, res.SpaceOwner)
+
+			Expect(storagespace.ContextGetSpaceOwner(ctx)).To(Equal(res.SpaceOwner))
+		})
+	})
+
+	Describe("SetLock", func() {
+		It("returns a WriteResult with SpaceOwner and propagates it via context slot", func() {
+			env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything).
+				Return(&provider.ResourcePermissions{
+					InitiateFileUpload: true,
+					Stat:               true,
+				}, nil)
+
+			ctx := storagespace.ContextRegisterSpaceOwnerSlot(env.Ctx)
+
+			res, err := env.Fs.SetLock(ctx, &provider.Reference{
+				ResourceId: env.SpaceRootRes,
+				Path:       "/dir1/file1",
+			}, &provider.Lock{
+				Type:   provider.LockType_LOCK_TYPE_EXCL,
+				LockId: "events-test-lock-id",
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res).ToNot(BeNil())
+			Expect(res.SpaceOwner).ToNot(BeNil())
+
+			storagespace.ContextSetSpaceOwner(ctx, res.SpaceOwner)
+
+			Expect(storagespace.ContextGetSpaceOwner(ctx)).To(Equal(res.SpaceOwner))
+		})
+	})
+
+	Describe("Unlock", func() {
+		It("returns a WriteResult with SpaceOwner and propagates it via context slot", func() {
+			env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything).
+				Return(&provider.ResourcePermissions{
+					InitiateFileUpload: true,
+					Stat:               true,
+				}, nil)
+
+			ref := &provider.Reference{
+				ResourceId: env.SpaceRootRes,
+				Path:       "/dir1/file1",
+			}
+			lock := &provider.Lock{
+				Type:   provider.LockType_LOCK_TYPE_EXCL,
+				LockId: "events-unlock-test-lock",
+			}
+
+			_, err := env.Fs.SetLock(env.Ctx, ref, lock)
+			Expect(err).ToNot(HaveOccurred())
+
+			ctx := storagespace.ContextRegisterSpaceOwnerSlot(env.Ctx)
+
+			res, err := env.Fs.Unlock(ctx, ref, lock)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res).ToNot(BeNil())
+			Expect(res.SpaceOwner).ToNot(BeNil())
+
+			storagespace.ContextSetSpaceOwner(ctx, res.SpaceOwner)
+
+			Expect(storagespace.ContextGetSpaceOwner(ctx)).To(Equal(res.SpaceOwner))
+		})
+	})
+
+	Describe("RestoreRecycleItem", func() {
+		It("returns a WriteResult with SpaceOwner and propagates it via context slot", func() {
+			registerPermissions(env.Permissions, helpers.OwnerID, &provider.ResourcePermissions{
+				Stat:               true,
+				InitiateFileUpload: true,
+				Delete:             true,
+				ListRecycle:        true,
+				RestoreRecycleItem: true,
+			})
+
+			err := env.Fs.Delete(env.Ctx, &provider.Reference{
+				ResourceId: env.SpaceRootRes,
+				Path:       "/dir1/file1",
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			items, err := env.Fs.ListRecycle(env.Ctx, &provider.Reference{ResourceId: env.SpaceRootRes}, "", "")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(items)).To(BeNumerically(">=", 1))
+
+			ctx := storagespace.ContextRegisterSpaceOwnerSlot(env.Ctx)
+
+			res, err := env.Fs.RestoreRecycleItem(ctx, &provider.Reference{ResourceId: env.SpaceRootRes}, items[0].Key, "", nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res).ToNot(BeNil())
+			Expect(res.SpaceOwner).ToNot(BeNil())
+
+			storagespace.ContextSetSpaceOwner(ctx, res.SpaceOwner)
+
+			Expect(storagespace.ContextGetSpaceOwner(ctx)).To(Equal(res.SpaceOwner))
+		})
+	})
+
+	Describe("RestoreRevision", func() {
+		It("returns a WriteResult with SpaceOwner and propagates it via context slot", func() {
+			env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything).
+				Return(&provider.ResourcePermissions{
+					Stat:               true,
+					InitiateFileUpload: true,
+					ListFileVersions:   true,
+					RestoreFileVersion: true,
+				}, nil)
+
+			fileRef := &provider.Reference{
+				ResourceId: env.SpaceRootRes,
+				Path:       "/dir1/file1",
+			}
+
+			ri, err := env.Fs.GetMD(env.Ctx, fileRef, []string{}, []string{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ri).ToNot(BeNil())
+
+			nodeID := ri.Id.OpaqueId
+			spaceID := ri.Id.SpaceId
+			nodePath := env.Lookup.InternalPath(spaceID, nodeID)
+
+			revisionPath := nodePath + ".REV." + "2024-01-01T00:00:00.000000000Z"
+			revFile, err := os.Create(revisionPath)
+			Expect(err).ToNot(HaveOccurred())
+			revFile.Close()
+
+			err = env.Lookup.MetadataBackend().SetMultiple(env.Ctx, revisionPath,
+				map[string][]byte{prefixes.BlobsizeAttr: []byte("0")},
+				false)
+			Expect(err).ToNot(HaveOccurred())
+
+			revisions, err := env.Fs.ListRevisions(env.Ctx, fileRef)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(revisions)).To(BeNumerically(">=", 1))
+
+			ctx := storagespace.ContextRegisterSpaceOwnerSlot(env.Ctx)
+
+			res, err := env.Fs.RestoreRevision(ctx, fileRef, revisions[0].Key)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res).ToNot(BeNil())
+			Expect(res.SpaceOwner).ToNot(BeNil())
+
+			storagespace.ContextSetSpaceOwner(ctx, res.SpaceOwner)
+
+			Expect(storagespace.ContextGetSpaceOwner(ctx)).To(Equal(res.SpaceOwner))
+		})
+	})
+})

--- a/pkg/storage/utils/decomposedfs/metadata.go
+++ b/pkg/storage/utils/decomposedfs/metadata.go
@@ -64,7 +64,7 @@ func (fs *Decomposedfs) SetArbitraryMetadata(ctx context.Context, ref *provider.
 	}
 
 	// Set space owner in context
-	storagespace.ContextSendSpaceOwnerID(ctx, n.SpaceOwnerOrManager(ctx))
+	storagespace.ContextSetSpaceOwner(ctx, n.SpaceOwnerOrManager(ctx))
 
 	// check lock
 	if err := n.CheckLock(ctx); err != nil {
@@ -159,7 +159,7 @@ func (fs *Decomposedfs) UnsetArbitraryMetadata(ctx context.Context, ref *provide
 	}
 
 	// Set space owner in context
-	storagespace.ContextSendSpaceOwnerID(ctx, n.SpaceOwnerOrManager(ctx))
+	storagespace.ContextSetSpaceOwner(ctx, n.SpaceOwnerOrManager(ctx))
 
 	// check lock
 	if err := n.CheckLock(ctx); err != nil {

--- a/pkg/storage/utils/decomposedfs/node/node_test.go
+++ b/pkg/storage/utils/decomposedfs/node/node_test.go
@@ -24,14 +24,14 @@ import (
 	"time"
 
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	ocsconv "github.com/owncloud/reva/v2/pkg/conversions"
 	ctxpkg "github.com/owncloud/reva/v2/pkg/ctx"
 	"github.com/owncloud/reva/v2/pkg/storage/utils/decomposedfs/metadata/prefixes"
 	"github.com/owncloud/reva/v2/pkg/storage/utils/decomposedfs/node"
 	helpers "github.com/owncloud/reva/v2/pkg/storage/utils/decomposedfs/testhelpers"
 	"github.com/owncloud/reva/v2/pkg/storage/utils/grants"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
 	"google.golang.org/protobuf/testing/protocmp"
 )

--- a/pkg/storage/utils/decomposedfs/recycle.go
+++ b/pkg/storage/utils/decomposedfs/recycle.go
@@ -37,7 +37,6 @@ import (
 	"github.com/owncloud/reva/v2/pkg/storage/utils/decomposedfs/lookup"
 	"github.com/owncloud/reva/v2/pkg/storage/utils/decomposedfs/metadata/prefixes"
 	"github.com/owncloud/reva/v2/pkg/storage/utils/decomposedfs/node"
-	"github.com/owncloud/reva/v2/pkg/storagespace"
 )
 
 type DecomposedfsTrashbin struct {
@@ -346,18 +345,18 @@ func (tb *DecomposedfsTrashbin) listTrashRoot(ctx context.Context, spaceID strin
 }
 
 // RestoreRecycleItem restores the specified item
-func (tb *DecomposedfsTrashbin) RestoreRecycleItem(ctx context.Context, ref *provider.Reference, key, relativePath string, restoreRef *provider.Reference) error {
+func (tb *DecomposedfsTrashbin) RestoreRecycleItem(ctx context.Context, ref *provider.Reference, key, relativePath string, restoreRef *provider.Reference) (*storage.RestoreRecycleItemResult, error) {
 	_, span := tracer.Start(ctx, "RestoreRecycleItem")
 	defer span.End()
 	if ref == nil {
-		return errtypes.BadRequest("missing reference, needs a space id")
+		return nil, errtypes.BadRequest("missing reference, needs a space id")
 	}
 
 	var targetNode *node.Node
 	if restoreRef != nil {
 		tn, err := tb.fs.lu.NodeFromResource(ctx, restoreRef)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		targetNode = tn
@@ -365,39 +364,40 @@ func (tb *DecomposedfsTrashbin) RestoreRecycleItem(ctx context.Context, ref *pro
 
 	rn, parent, restoreFunc, err := tb.fs.tp.RestoreRecycleItemFunc(ctx, ref.ResourceId.SpaceId, key, relativePath, targetNode)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// check permissions of deleted node
 	rp, err := tb.fs.p.AssembleTrashPermissions(ctx, rn)
 	switch {
 	case err != nil:
-		return err
+		return nil, err
 	case !rp.RestoreRecycleItem:
 		if rp.Stat {
-			return errtypes.PermissionDenied(key)
+			return nil, errtypes.PermissionDenied(key)
 		}
-		return errtypes.NotFound(key)
+		return nil, errtypes.NotFound(key)
 	}
 
-	// Set space owner in context
-	storagespace.ContextSendSpaceOwnerID(ctx, rn.SpaceOwnerOrManager(ctx))
+	spaceOwner := rn.SpaceOwnerOrManager(ctx)
 
 	// check we can write to the parent of the restore reference
 	pp, err := tb.fs.p.AssemblePermissions(ctx, parent)
 	switch {
 	case err != nil:
-		return err
+		return nil, err
 	case !pp.InitiateFileUpload:
 		// share receiver cannot restore to a shared resource to which she does not have write permissions.
 		if rp.Stat {
-			return errtypes.PermissionDenied(key)
+			return nil, errtypes.PermissionDenied(key)
 		}
-		return errtypes.NotFound(key)
+		return nil, errtypes.NotFound(key)
 	}
 
-	// Run the restore func
-	return restoreFunc()
+	if err := restoreFunc(); err != nil {
+		return nil, err
+	}
+	return &storage.RestoreRecycleItemResult{SpaceOwner: spaceOwner, SpaceID: rn.SpaceID}, nil
 }
 
 // PurgeRecycleItem purges the specified item, all its children and all their revisions

--- a/pkg/storage/utils/decomposedfs/recycle_test.go
+++ b/pkg/storage/utils/decomposedfs/recycle_test.go
@@ -110,7 +110,7 @@ var _ = Describe("Recycle", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(len(items)).To(Equal(2))
 
-				err = env.Fs.RestoreRecycleItem(env.Ctx, &provider.Reference{ResourceId: env.SpaceRootRes}, items[0].Key, "", nil)
+				_, err = env.Fs.RestoreRecycleItem(env.Ctx, &provider.Reference{ResourceId: env.SpaceRootRes}, items[0].Key, "", nil)
 				Expect(err).ToNot(HaveOccurred())
 
 				items, err = env.Fs.ListRecycle(env.Ctx, &provider.Reference{ResourceId: env.SpaceRootRes}, "", "")
@@ -223,10 +223,10 @@ var _ = Describe("Recycle", func() {
 					ctx2 = env.Ctx
 				}
 
-				err = env.Fs.RestoreRecycleItem(ctx1, &provider.Reference{ResourceId: env.SpaceRootRes}, items[0].Key, "", nil)
+				_, err = env.Fs.RestoreRecycleItem(ctx1, &provider.Reference{ResourceId: env.SpaceRootRes}, items[0].Key, "", nil)
 				Expect(err).ToNot(HaveOccurred())
 
-				err = env.Fs.RestoreRecycleItem(ctx2, &provider.Reference{ResourceId: env.SpaceRootRes}, items[1].Key, "", nil)
+				_, err = env.Fs.RestoreRecycleItem(ctx2, &provider.Reference{ResourceId: env.SpaceRootRes}, items[1].Key, "", nil)
 				Expect(err).ToNot(HaveOccurred())
 
 				items, err = env.Fs.ListRecycle(env.Ctx, &provider.Reference{ResourceId: env.SpaceRootRes}, "", "")
@@ -291,7 +291,7 @@ var _ = Describe("Recycle", func() {
 				_, err = env.CreateTestFile("largefile", "largefile-blobid", projectID.OpaqueId, projectID.SpaceId, 2000)
 				Expect(err).ToNot(HaveOccurred())
 
-				err = env.Fs.RestoreRecycleItem(env.Ctx, &provider.Reference{ResourceId: projectID}, items[0].Key, "", nil)
+				_, err = env.Fs.RestoreRecycleItem(env.Ctx, &provider.Reference{ResourceId: projectID}, items[0].Key, "", nil)
 				Expect(err).ToNot(HaveOccurred())
 
 				max, used, remaining, err := env.Fs.GetQuota(env.Ctx, &provider.Reference{ResourceId: projectID})
@@ -385,7 +385,7 @@ var _ = Describe("Recycle", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(len(items)).To(Equal(1))
 
-				err = env.Fs.RestoreRecycleItem(ctx, &provider.Reference{ResourceId: env.SpaceRootRes}, items[0].Key, "", nil)
+				_, err = env.Fs.RestoreRecycleItem(ctx, &provider.Reference{ResourceId: env.SpaceRootRes}, items[0].Key, "", nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("permission denied"))
 			})
@@ -444,7 +444,7 @@ var _ = Describe("Recycle", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("not found"))
 
-			err = env.Fs.RestoreRecycleItem(ctx, &provider.Reference{ResourceId: env.SpaceRootRes}, items[0].Key, "", nil)
+			_, err = env.Fs.RestoreRecycleItem(ctx, &provider.Reference{ResourceId: env.SpaceRootRes}, items[0].Key, "", nil)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("not found"))
 		})

--- a/pkg/storage/utils/decomposedfs/revisions.go
+++ b/pkg/storage/utils/decomposedfs/revisions.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/owncloud/reva/v2/pkg/appctx"
 	"github.com/owncloud/reva/v2/pkg/errtypes"
+	"github.com/owncloud/reva/v2/pkg/storage"
 	"github.com/owncloud/reva/v2/pkg/storage/utils/decomposedfs/metadata/prefixes"
 	"github.com/owncloud/reva/v2/pkg/storage/utils/decomposedfs/node"
 	"github.com/owncloud/reva/v2/pkg/storagespace"
@@ -189,7 +190,7 @@ func (fs *Decomposedfs) DownloadRevision(ctx context.Context, ref *provider.Refe
 }
 
 // RestoreRevision restores the specified revision of the resource
-func (fs *Decomposedfs) RestoreRevision(ctx context.Context, ref *provider.Reference, revisionKey string) (returnErr error) {
+func (fs *Decomposedfs) RestoreRevision(ctx context.Context, ref *provider.Reference, revisionKey string) (_ *storage.RestoreRevisionResult, returnErr error) {
 	_, span := tracer.Start(ctx, "RestoreRevision")
 	defer span.End()
 	log := appctx.GetLogger(ctx)
@@ -198,44 +199,43 @@ func (fs *Decomposedfs) RestoreRevision(ctx context.Context, ref *provider.Refer
 	kp := strings.SplitN(revisionKey, node.RevisionIDDelimiter, 2)
 	if len(kp) != 2 {
 		log.Error().Str("revisionKey", revisionKey).Msg("malformed revisionKey")
-		return errtypes.NotFound(revisionKey)
+		return nil, errtypes.NotFound(revisionKey)
 	}
 
 	spaceID := ref.ResourceId.SpaceId
 	// check if the node is available and has not been deleted
 	n, err := node.ReadNode(ctx, fs.lu, spaceID, kp[0], false, nil, false)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if !n.Exists {
 		err = errtypes.NotFound(filepath.Join(n.ParentID, n.Name))
-		return err
+		return nil, err
 	}
 
 	rp, err := fs.p.AssemblePermissions(ctx, n)
 	switch {
 	case err != nil:
-		return err
+		return nil, err
 	case !rp.RestoreFileVersion:
 		f, _ := storagespace.FormatReference(ref)
 		if rp.Stat {
-			return errtypes.PermissionDenied(f)
+			return nil, errtypes.PermissionDenied(f)
 		}
-		return errtypes.NotFound(f)
+		return nil, errtypes.NotFound(f)
 	}
 
-	// Set space owner in context
-	storagespace.ContextSendSpaceOwnerID(ctx, n.SpaceOwnerOrManager(ctx))
+	spaceOwner := n.SpaceOwnerOrManager(ctx)
 
 	// check lock
 	if err := n.CheckLock(ctx); err != nil {
-		return err
+		return nil, err
 	}
 
 	// write lock node before copying metadata
 	f, err := lockedfile.OpenFile(fs.lu.MetadataBackend().LockfilePath(n.InternalPath()), os.O_RDWR|os.O_CREATE, 0600)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer func() {
 		_ = f.Close()
@@ -247,7 +247,7 @@ func (fs *Decomposedfs) RestoreRevision(ctx context.Context, ref *provider.Refer
 	mtime, err := n.GetMTime(ctx)
 	if err != nil {
 		log.Error().Err(err).Interface("ref", ref).Str("originalnode", kp[0]).Str("revisionKey", revisionKey).Msg("cannot read mtime")
-		return err
+		return nil, err
 	}
 
 	// revisions are stored alongside the actual file, so a rename can be efficient and does not cross storage / partition boundaries
@@ -255,7 +255,7 @@ func (fs *Decomposedfs) RestoreRevision(ctx context.Context, ref *provider.Refer
 
 	// touch new revision
 	if _, err := os.Create(newRevisionPath); err != nil {
-		return err
+		return nil, err
 	}
 	defer func() {
 		if returnErr != nil {
@@ -277,12 +277,12 @@ func (fs *Decomposedfs) RestoreRevision(ctx context.Context, ref *provider.Refer
 			attributeName == prefixes.MTimeAttr // FIXME somewhere I mix up the revision time and the mtime, causing the restore to overwrite the other existing revisien
 	}, f, true)
 	if err != nil {
-		return errtypes.InternalError("failed to copy blob xattrs to version node: " + err.Error())
+		return nil, errtypes.InternalError("failed to copy blob xattrs to version node: " + err.Error())
 	}
 
 	// remember mtime from node as new revision mtime
 	if err = os.Chtimes(newRevisionPath, mtime, mtime); err != nil {
-		return errtypes.InternalError("failed to change mtime of version node")
+		return nil, errtypes.InternalError("failed to change mtime of version node")
 	}
 
 	// update blob id in node
@@ -296,7 +296,7 @@ func (fs *Decomposedfs) RestoreRevision(ctx context.Context, ref *provider.Refer
 			attributeName == prefixes.BlobsizeAttr
 	}, false)
 	if err != nil {
-		return errtypes.InternalError("failed to copy blob xattrs to old revision to node: " + err.Error())
+		return nil, errtypes.InternalError("failed to copy blob xattrs to old revision to node: " + err.Error())
 	}
 	// always set the node mtime to the current time
 	err = fs.lu.MetadataBackend().SetMultiple(ctx, nodePath,
@@ -305,12 +305,12 @@ func (fs *Decomposedfs) RestoreRevision(ctx context.Context, ref *provider.Refer
 		},
 		false)
 	if err != nil {
-		return errtypes.InternalError("failed to set mtime attribute on node: " + err.Error())
+		return nil, errtypes.InternalError("failed to set mtime attribute on node: " + err.Error())
 	}
 
 	revisionSize, err := fs.lu.MetadataBackend().GetInt64(ctx, restoredRevisionPath, prefixes.BlobsizeAttr)
 	if err != nil {
-		return errtypes.InternalError("failed to read blob size xattr from old revision")
+		return nil, errtypes.InternalError("failed to read blob size xattr from old revision")
 	}
 
 	// drop old revision
@@ -331,7 +331,10 @@ func (fs *Decomposedfs) RestoreRevision(ctx context.Context, ref *provider.Refer
 	// revision 10, current 5 (restore a bigger blob) -> 10-5 = +5
 	sizeDiff := revisionSize - n.Blobsize
 
-	return fs.tp.Propagate(ctx, n, sizeDiff)
+	if err := fs.tp.Propagate(ctx, n, sizeDiff); err != nil {
+		return nil, err
+	}
+	return &storage.RestoreRevisionResult{SpaceOwner: spaceOwner, SpaceID: n.SpaceID}, nil
 }
 
 // DeleteRevision deletes the specified revision of the resource
@@ -385,7 +388,7 @@ func (fs *Decomposedfs) getRevisionNode(ctx context.Context, ref *provider.Refer
 	}
 
 	// Set space owner in context
-	storagespace.ContextSendSpaceOwnerID(ctx, n.SpaceOwnerOrManager(ctx))
+	storagespace.ContextSetSpaceOwner(ctx, n.SpaceOwnerOrManager(ctx))
 
 	return n, nil
 }

--- a/pkg/storage/utils/decomposedfs/testhelpers/helpers.go
+++ b/pkg/storage/utils/decomposedfs/testhelpers/helpers.go
@@ -218,7 +218,7 @@ func (t *TestEnv) CreateTestDir(name string, parentRef *providerv1beta1.Referenc
 	ref := parentRef
 	ref.Path = name
 
-	err := t.Fs.CreateDir(t.Ctx, ref)
+	_, err := t.Fs.CreateDir(t.Ctx, ref)
 	if err != nil {
 		return nil, err
 	}
@@ -338,7 +338,7 @@ func (t *TestEnv) CreateTestStorageSpace(typ string, quota *providerv1beta1.Quot
 		CreateContainer: true,
 	}, nil).Times(1) // Permissions required for setup below
 	ref.Path = "./dir1/subdir1"
-	err = t.Fs.CreateDir(t.Ctx, ref)
+	_, err = t.Fs.CreateDir(t.Ctx, ref)
 	if err != nil {
 		return nil, err
 	}
@@ -354,7 +354,7 @@ func (t *TestEnv) CreateTestStorageSpace(typ string, quota *providerv1beta1.Quot
 		CreateContainer: true,
 	}, nil).Times(1) // Permissions required for setup below
 	ref.Path = "/emptydir"
-	err = t.Fs.CreateDir(t.Ctx, ref)
+	_, err = t.Fs.CreateDir(t.Ctx, ref)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/utils/decomposedfs/trashbin/trashbin.go
+++ b/pkg/storage/utils/decomposedfs/trashbin/trashbin.go
@@ -29,7 +29,7 @@ type Trashbin interface {
 	Setup(storage.FS) error
 
 	ListRecycle(ctx context.Context, ref *provider.Reference, key, relativePath string) ([]*provider.RecycleItem, error)
-	RestoreRecycleItem(ctx context.Context, ref *provider.Reference, key, relativePath string, restoreRef *provider.Reference) error
+	RestoreRecycleItem(ctx context.Context, ref *provider.Reference, key, relativePath string, restoreRef *provider.Reference) (*storage.RestoreRecycleItemResult, error)
 	PurgeRecycleItem(ctx context.Context, ref *provider.Reference, key, relativePath string) error
 	EmptyRecycle(ctx context.Context, ref *provider.Reference) error
 }

--- a/pkg/storage/utils/eosfs/eosfs.go
+++ b/pkg/storage/utils/eosfs/eosfs.go
@@ -40,6 +40,7 @@ import (
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	types "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
+	"github.com/jellydator/ttlcache/v2"
 	"github.com/owncloud/reva/v2/pkg/appctx"
 	"github.com/owncloud/reva/v2/pkg/conversions"
 	ctxpkg "github.com/owncloud/reva/v2/pkg/ctx"
@@ -57,7 +58,6 @@ import (
 	"github.com/owncloud/reva/v2/pkg/storage/utils/grants"
 	"github.com/owncloud/reva/v2/pkg/storage/utils/templates"
 	"github.com/owncloud/reva/v2/pkg/utils"
-	"github.com/jellydator/ttlcache/v2"
 	"github.com/pkg/errors"
 )
 
@@ -780,36 +780,36 @@ func (fs *eosfs) setLock(ctx context.Context, lock *provider.Lock, path string, 
 }
 
 // SetLock puts a lock on the given reference
-func (fs *eosfs) SetLock(ctx context.Context, ref *provider.Reference, l *provider.Lock) error {
+func (fs *eosfs) SetLock(ctx context.Context, ref *provider.Reference, l *provider.Lock) (*storage.SetLockResult, error) {
 	if l.Type == provider.LockType_LOCK_TYPE_SHARED {
-		return errtypes.NotSupported("shared lock not yet implemented")
+		return nil, errtypes.NotSupported("shared lock not yet implemented")
 	}
 
 	path, err := fs.resolve(ctx, ref)
 	if err != nil {
-		return errors.Wrap(err, "eosfs: error resolving reference")
+		return nil, errors.Wrap(err, "eosfs: error resolving reference")
 	}
 	path = fs.wrap(ctx, path)
 
 	user, err := getUser(ctx)
 	if err != nil {
-		return errors.Wrap(err, "eosfs: no user in ctx")
+		return nil, errors.Wrap(err, "eosfs: no user in ctx")
 	}
 	auth, err := fs.getUserAuth(ctx, user, path)
 	if err != nil {
-		return errors.Wrap(err, "eosfs: error getting uid and gid for user")
+		return nil, errors.Wrap(err, "eosfs: error getting uid and gid for user")
 	}
 
 	_, err = fs.getLock(ctx, auth, user, path, ref)
 	if err != nil {
 		// if the err is NotFound it is fine, otherwise we have to return
 		if _, ok := err.(errtypes.NotFound); !ok {
-			return err
+			return nil, err
 		}
 	}
 	if err == nil {
 		// the resource is already locked
-		return errtypes.BadRequest("resource already locked")
+		return nil, errtypes.BadRequest("resource already locked")
 	}
 
 	// the cs3apis require to have the write permission on the resource
@@ -818,10 +818,10 @@ func (fs *eosfs) SetLock(ctx context.Context, ref *provider.Reference, l *provid
 	// the request has it
 	has, err := fs.userHasWriteAccess(ctx, user, ref)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("eosfs: cannot check if user %s has write access on resource", user.Username))
+		return nil, errors.Wrap(err, fmt.Sprintf("eosfs: cannot check if user %s has write access on resource", user.Username))
 	}
 	if !has {
-		return errtypes.PermissionDenied(fmt.Sprintf("user %s has not write access on resource", user.Username))
+		return nil, errtypes.PermissionDenied(fmt.Sprintf("user %s has not write access on resource", user.Username))
 	}
 
 	// the user in the lock could differ from the user in the context
@@ -829,14 +829,17 @@ func (fs *eosfs) SetLock(ctx context.Context, ref *provider.Reference, l *provid
 	if l.User != nil && !utils.UserEqual(user.Id, l.User) {
 		has, err := fs.userIDHasWriteAccess(ctx, l.User, ref)
 		if err != nil {
-			return errors.Wrap(err, "eosfs: cannot check if user has write access on resource")
+			return nil, errors.Wrap(err, "eosfs: cannot check if user has write access on resource")
 		}
 		if !has {
-			return errtypes.PermissionDenied(fmt.Sprintf("user %s has not write access on resource", user.Username))
+			return nil, errtypes.PermissionDenied(fmt.Sprintf("user %s has not write access on resource", user.Username))
 		}
 	}
 
-	return fs.setLock(ctx, l, path, true)
+	if err := fs.setLock(ctx, l, path, true); err != nil {
+		return nil, err
+	}
+	return &storage.SetLockResult{}, nil
 }
 
 func (fs *eosfs) getUserFromID(ctx context.Context, userID *userpb.UserId) (*userpb.User, error) {
@@ -952,9 +955,9 @@ func sameHolder(l1, l2 *provider.Lock) bool {
 }
 
 // Unlock removes an existing lock from the given reference
-func (fs *eosfs) Unlock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) error {
+func (fs *eosfs) Unlock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) (*storage.UnlockResult, error) {
 	if lock.Type == provider.LockType_LOCK_TYPE_SHARED {
-		return errtypes.NotSupported("shared lock not yet implemented")
+		return nil, errtypes.NotSupported("shared lock not yet implemented")
 	}
 
 	oldLock, err := fs.GetLock(ctx, ref)
@@ -962,47 +965,50 @@ func (fs *eosfs) Unlock(ctx context.Context, ref *provider.Reference, lock *prov
 		switch err.(type) {
 		case errtypes.NotFound:
 			// the lock does not exist
-			return errtypes.BadRequest("file was not locked")
+			return nil, errtypes.BadRequest("file was not locked")
 		default:
-			return err
+			return nil, err
 		}
 	}
 
 	// check if the lock id of the lock corresponds to the stored lock
 	if oldLock.LockId != lock.LockId {
-		return errtypes.BadRequest("lock id does not match")
+		return nil, errtypes.BadRequest("lock id does not match")
 	}
 
 	if !sameHolder(oldLock, lock) {
-		return errtypes.BadRequest("caller does not hold the lock")
+		return nil, errtypes.BadRequest("caller does not hold the lock")
 	}
 
 	user, err := getUser(ctx)
 	if err != nil {
-		return errors.Wrap(err, "eosfs: error getting user")
+		return nil, errors.Wrap(err, "eosfs: error getting user")
 	}
 
 	// the cs3apis require to have the write permission on the resource
 	// to remove the lock
 	has, err := fs.userHasWriteAccess(ctx, user, ref)
 	if err != nil {
-		return errors.Wrap(err, "eosfs: cannot check if user has write access on resource")
+		return nil, errors.Wrap(err, "eosfs: cannot check if user has write access on resource")
 	}
 	if !has {
-		return errtypes.PermissionDenied(fmt.Sprintf("user %s has not write access on resource", user.Username))
+		return nil, errtypes.PermissionDenied(fmt.Sprintf("user %s has not write access on resource", user.Username))
 	}
 
 	path, err := fs.resolve(ctx, ref)
 	if err != nil {
-		return errors.Wrap(err, "eosfs: error resolving reference")
+		return nil, errors.Wrap(err, "eosfs: error resolving reference")
 	}
 	path = fs.wrap(ctx, path)
 
 	auth, err := fs.getRootAuth(ctx)
 	if err != nil {
-		return errors.Wrap(err, "eosfs: error getting uid and gid for user")
+		return nil, errors.Wrap(err, "eosfs: error getting uid and gid for user")
 	}
-	return fs.removeLockAttrs(ctx, auth, path)
+	if err := fs.removeLockAttrs(ctx, auth, path); err != nil {
+		return nil, err
+	}
+	return &storage.UnlockResult{}, nil
 }
 
 func (fs *eosfs) AddGrant(ctx context.Context, ref *provider.Reference, g *provider.Grant) error {
@@ -1642,44 +1648,49 @@ func (fs *eosfs) createUserDir(ctx context.Context, u *userpb.User, path string,
 	return nil
 }
 
-func (fs *eosfs) CreateDir(ctx context.Context, ref *provider.Reference) error {
+func (fs *eosfs) CreateDir(ctx context.Context, ref *provider.Reference) (*storage.CreateDirResult, error) {
 	log := appctx.GetLogger(ctx)
 	p, err := fs.resolve(ctx, ref)
 	if err != nil {
-		return errors.Wrap(err, "eosfs: error resolving reference")
+		return nil, errors.Wrap(err, "eosfs: error resolving reference")
 	}
 	if fs.isShareFolder(ctx, p) {
-		return errtypes.PermissionDenied("eosfs: cannot perform operation under the virtual share folder")
+		return nil, errtypes.PermissionDenied("eosfs: cannot perform operation under the virtual share folder")
 	}
 	fn := fs.wrap(ctx, p)
 
 	u, err := getUser(ctx)
 	if err != nil {
-		return errors.Wrap(err, "eosfs: no user in ctx")
+		return nil, errors.Wrap(err, "eosfs: no user in ctx")
 	}
 
 	// We need the auth corresponding to the parent directory
 	// as the file might not exist at the moment
 	auth, err := fs.getUserAuth(ctx, u, path.Dir(fn))
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	log.Info().Msgf("eosfs: createdir: path=%s", fn)
-	return fs.c.CreateDir(ctx, auth, fn)
+	if err := fs.c.CreateDir(ctx, auth, fn); err != nil {
+		return nil, err
+	}
+	return &storage.CreateDirResult{}, nil
 }
 
 // TouchFile as defined in the storage.FS interface
-func (fs *eosfs) TouchFile(ctx context.Context, ref *provider.Reference, _ bool, _ string) error {
+func (fs *eosfs) TouchFile(ctx context.Context, ref *provider.Reference, _ bool, _ string) (*storage.TouchFileResult, error) {
 	log := appctx.GetLogger(ctx)
 
 	fn, auth, err := fs.resolveRefAndGetAuth(ctx, ref)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	log.Info().Msgf("eosfs: touch file: path=%s", fn)
-
-	return fs.c.Touch(ctx, auth, fn)
+	if err := fs.c.Touch(ctx, auth, fn); err != nil {
+		return nil, err
+	}
+	return &storage.TouchFileResult{}, nil
 }
 
 func (fs *eosfs) CreateReference(ctx context.Context, p string, targetURI *url.URL) error {
@@ -1803,7 +1814,10 @@ func (fs *eosfs) Move(ctx context.Context, oldRef, newRef *provider.Reference) (
 		return nil, err
 	}
 
-	return nil, fs.c.Rename(ctx, auth, oldFn, newFn)
+	if err := fs.c.Rename(ctx, auth, oldFn, newFn); err != nil {
+		return nil, err
+	}
+	return &storage.MoveResult{}, nil
 }
 
 func (fs *eosfs) moveShadow(ctx context.Context, oldPath, newPath string) error {
@@ -1935,7 +1949,7 @@ func (fs *eosfs) DownloadRevision(ctx context.Context, ref *provider.Reference, 
 	return md, reader, err
 }
 
-func (fs *eosfs) RestoreRevision(ctx context.Context, ref *provider.Reference, revisionKey string) error {
+func (fs *eosfs) RestoreRevision(ctx context.Context, ref *provider.Reference, revisionKey string) (*storage.RestoreRevisionResult, error) {
 	var auth eosclient.Authorization
 	var fn string
 	var err error
@@ -1946,26 +1960,29 @@ func (fs *eosfs) RestoreRevision(ctx context.Context, ref *provider.Reference, r
 		// if we have access to it.
 		md, err := fs.GetMD(ctx, ref, nil, nil)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		fn = fs.wrap(ctx, md.Path)
 
 		if md.PermissionSet.RestoreFileVersion {
 			auth, err = fs.getUIDGateway(ctx, md.Owner)
 			if err != nil {
-				return err
+				return nil, err
 			}
 		} else {
-			return errtypes.PermissionDenied("eosfs: user doesn't have permissions to restore revisions")
+			return nil, errtypes.PermissionDenied("eosfs: user doesn't have permissions to restore revisions")
 		}
 	} else {
 		fn, auth, err = fs.resolveRefForbidShareFolder(ctx, ref)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 
-	return fs.c.RollbackToVersion(ctx, auth, fn, revisionKey)
+	if err := fs.c.RollbackToVersion(ctx, auth, fn, revisionKey); err != nil {
+		return nil, err
+	}
+	return &storage.RestoreRevisionResult{}, nil
 }
 
 func (fs *eosfs) PurgeRecycleItem(ctx context.Context, ref *provider.Reference, key, relativePath string) error {
@@ -2036,7 +2053,7 @@ func (fs *eosfs) ListRecycle(ctx context.Context, ref *provider.Reference, key, 
 	return recycleEntries, nil
 }
 
-func (fs *eosfs) RestoreRecycleItem(ctx context.Context, ref *provider.Reference, key, relativePath string, restoreRef *provider.Reference) error {
+func (fs *eosfs) RestoreRecycleItem(ctx context.Context, ref *provider.Reference, key, relativePath string, restoreRef *provider.Reference) (*storage.RestoreRecycleItemResult, error) {
 	var auth eosclient.Authorization
 
 	if !fs.conf.EnableHome && fs.conf.AllowPathRecycleOperations && ref.Path != "/" {
@@ -2045,29 +2062,32 @@ func (fs *eosfs) RestoreRecycleItem(ctx context.Context, ref *provider.Reference
 		// if we have access to it.
 		md, err := fs.GetMD(ctx, &provider.Reference{Path: ref.Path}, nil, nil)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if md.PermissionSet.RestoreRecycleItem {
 			auth, err = fs.getUIDGateway(ctx, md.Owner)
 			if err != nil {
-				return err
+				return nil, err
 			}
 		} else {
-			return errtypes.PermissionDenied("eosfs: user doesn't have permissions to restore recycled items")
+			return nil, errtypes.PermissionDenied("eosfs: user doesn't have permissions to restore recycled items")
 		}
 	} else {
 		// We just act on the logged-in user's recycle bin
 		u, err := getUser(ctx)
 		if err != nil {
-			return errors.Wrap(err, "eosfs: no user in ctx")
+			return nil, errors.Wrap(err, "eosfs: no user in ctx")
 		}
 		auth, err = fs.getUserAuth(ctx, u, "")
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 
-	return fs.c.RestoreDeletedEntry(ctx, auth, key)
+	if err := fs.c.RestoreDeletedEntry(ctx, auth, key); err != nil {
+		return nil, err
+	}
+	return &storage.RestoreRecycleItemResult{}, nil
 }
 
 func (fs *eosfs) convertToRecycleItem(ctx context.Context, eosDeletedItem *eosclient.DeletedEntry) (*provider.RecycleItem, error) {

--- a/pkg/storage/utils/localfs/localfs.go
+++ b/pkg/storage/utils/localfs/localfs.go
@@ -720,8 +720,8 @@ func (fs *localfs) GetLock(ctx context.Context, ref *provider.Reference) (*provi
 }
 
 // SetLock puts a lock on the given reference
-func (fs *localfs) SetLock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) error {
-	return errtypes.NotSupported("unimplemented")
+func (fs *localfs) SetLock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) (*storage.SetLockResult, error) {
+	return nil, errtypes.NotSupported("unimplemented")
 }
 
 // RefreshLock refreshes an existing lock on the given reference
@@ -730,8 +730,8 @@ func (fs *localfs) RefreshLock(ctx context.Context, ref *provider.Reference, loc
 }
 
 // Unlock removes an existing lock from the given reference
-func (fs *localfs) Unlock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) error {
-	return errtypes.NotSupported("unimplemented")
+func (fs *localfs) Unlock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) (*storage.UnlockResult, error) {
+	return nil, errtypes.NotSupported("unimplemented")
 }
 
 func (fs *localfs) GetHome(ctx context.Context) (string, error) {
@@ -779,35 +779,38 @@ func (fs *localfs) createHomeInternal(ctx context.Context, fn string) error {
 	return nil
 }
 
-func (fs *localfs) CreateDir(ctx context.Context, ref *provider.Reference) error {
+func (fs *localfs) CreateDir(ctx context.Context, ref *provider.Reference) (*storage.CreateDirResult, error) {
 
 	fn, err := fs.resolve(ctx, ref)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 
 	if fs.isShareFolder(ctx, fn) {
-		return errtypes.PermissionDenied("localfs: cannot create folder under the share folder")
+		return nil, errtypes.PermissionDenied("localfs: cannot create folder under the share folder")
 	}
 
 	fn = fs.wrap(ctx, fn)
 	if _, err := os.Stat(fn); err == nil {
-		return errtypes.AlreadyExists(fn)
+		return nil, errtypes.AlreadyExists(fn)
 	}
 	err = os.Mkdir(fn, 0700)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return errtypes.PreconditionFailed(fn)
+			return nil, errtypes.PreconditionFailed(fn)
 		}
-		return errors.Wrap(err, "localfs: error creating dir "+fn)
+		return nil, errors.Wrap(err, "localfs: error creating dir "+fn)
 	}
 
-	return fs.propagate(ctx, path.Dir(fn))
+	if err := fs.propagate(ctx, path.Dir(fn)); err != nil {
+		return nil, err
+	}
+	return &storage.CreateDirResult{}, nil
 }
 
 // TouchFile as defined in the storage.FS interface
-func (fs *localfs) TouchFile(ctx context.Context, ref *provider.Reference, _ bool, _ string) error {
-	return fmt.Errorf("unimplemented: TouchFile")
+func (fs *localfs) TouchFile(ctx context.Context, ref *provider.Reference, _ bool, _ string) (*storage.TouchFileResult, error) {
+	return nil, fmt.Errorf("unimplemented: TouchFile")
 }
 
 func (fs *localfs) Delete(ctx context.Context, ref *provider.Reference) error {
@@ -881,7 +884,7 @@ func (fs *localfs) Move(ctx context.Context, oldRef, newRef *provider.Reference)
 		return nil, err
 	}
 
-	return nil, nil
+	return &storage.MoveResult{}, nil
 }
 
 func (fs *localfs) moveReferences(ctx context.Context, oldName, newName string) error {
@@ -1172,14 +1175,14 @@ func (fs *localfs) DownloadRevision(ctx context.Context, ref *provider.Reference
 	return ri, r, nil
 }
 
-func (fs *localfs) RestoreRevision(ctx context.Context, ref *provider.Reference, revisionKey string) error {
+func (fs *localfs) RestoreRevision(ctx context.Context, ref *provider.Reference, revisionKey string) (*storage.RestoreRevisionResult, error) {
 	np, err := fs.resolve(ctx, ref)
 	if err != nil {
-		return errors.Wrap(err, "localfs: error resolving ref")
+		return nil, errors.Wrap(err, "localfs: error resolving ref")
 	}
 
 	if fs.isShareFolder(ctx, np) {
-		return errtypes.PermissionDenied("localfs: cannot restore revisions under the virtual share folder")
+		return nil, errtypes.PermissionDenied("localfs: cannot restore revisions under the virtual share folder")
 	}
 
 	versionsDir := fs.wrapVersions(ctx, np)
@@ -1190,24 +1193,27 @@ func (fs *localfs) RestoreRevision(ctx context.Context, ref *provider.Reference,
 	vs, err := os.Stat(vp)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return errtypes.NotFound(revisionKey)
+			return nil, errtypes.NotFound(revisionKey)
 		}
-		return errors.Wrap(err, "localfs: error stating "+vp)
+		return nil, errors.Wrap(err, "localfs: error stating "+vp)
 	}
 
 	if !vs.Mode().IsRegular() {
-		return fmt.Errorf("%s is not a regular file", vp)
+		return nil, fmt.Errorf("%s is not a regular file", vp)
 	}
 
 	if err := fs.archiveRevision(ctx, np); err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := os.Rename(vp, np); err != nil {
-		return errors.Wrap(err, "localfs: error renaming from "+vp+" to "+np)
+		return nil, errors.Wrap(err, "localfs: error renaming from "+vp+" to "+np)
 	}
 
-	return fs.propagate(ctx, np)
+	if err := fs.propagate(ctx, np); err != nil {
+		return nil, err
+	}
+	return &storage.RestoreRevisionResult{}, nil
 }
 
 func (fs *localfs) PurgeRecycleItem(ctx context.Context, ref *provider.Reference, key, relativePath string) error {
@@ -1279,16 +1285,16 @@ func (fs *localfs) ListRecycle(ctx context.Context, ref *provider.Reference, key
 	return items, nil
 }
 
-func (fs *localfs) RestoreRecycleItem(ctx context.Context, ref *provider.Reference, key, relativePath string, restoreRef *provider.Reference) error {
+func (fs *localfs) RestoreRecycleItem(ctx context.Context, ref *provider.Reference, key, relativePath string, restoreRef *provider.Reference) (*storage.RestoreRecycleItemResult, error) {
 
 	suffix := path.Ext(key)
 	if len(suffix) == 0 || !strings.HasPrefix(suffix, ".d") {
-		return errors.New("localfs: invalid trash item suffix")
+		return nil, errors.New("localfs: invalid trash item suffix")
 	}
 
 	filePath, err := fs.getRecycledEntry(ctx, key)
 	if err != nil {
-		return errors.Wrap(err, "localfs: invalid key")
+		return nil, errors.Wrap(err, "localfs: invalid key")
 	}
 
 	var localRestorePath string
@@ -1302,27 +1308,30 @@ func (fs *localfs) RestoreRecycleItem(ctx context.Context, ref *provider.Referen
 	}
 
 	if _, err = os.Stat(localRestorePath); err == nil {
-		return errors.New("localfs: can't restore - file already exists at original path")
+		return nil, errors.New("localfs: can't restore - file already exists at original path")
 	}
 
 	rp := fs.wrapRecycleBin(ctx, key)
 	if _, err = os.Stat(rp); err != nil {
 		if os.IsNotExist(err) {
-			return errtypes.NotFound(key)
+			return nil, errtypes.NotFound(key)
 		}
-		return errors.Wrap(err, "localfs: error stating "+rp)
+		return nil, errors.Wrap(err, "localfs: error stating "+rp)
 	}
 
 	if err := os.Rename(rp, localRestorePath); err != nil {
-		return errors.Wrap(err, "ocfs: could not restore item")
+		return nil, errors.Wrap(err, "ocfs: could not restore item")
 	}
 
 	err = fs.removeFromRecycledDB(ctx, key)
 	if err != nil {
-		return errors.Wrap(err, "localfs: error adding entry to DB")
+		return nil, errors.Wrap(err, "localfs: error adding entry to DB")
 	}
 
-	return fs.propagate(ctx, localRestorePath)
+	if err := fs.propagate(ctx, localRestorePath); err != nil {
+		return nil, err
+	}
+	return &storage.RestoreRecycleItemResult{}, nil
 }
 
 func (fs *localfs) ListStorageSpaces(ctx context.Context, filter []*provider.ListStorageSpacesRequest_Filter, unrestricted bool) ([]*provider.StorageSpace, error) {

--- a/pkg/storage/utils/middleware/middleware.go
+++ b/pkg/storage/utils/middleware/middleware.go
@@ -145,7 +145,7 @@ func (f *FS) CreateHome(ctx context.Context) error {
 	return res0
 }
 
-func (f *FS) CreateDir(ctx context.Context, ref *provider.Reference) error {
+func (f *FS) CreateDir(ctx context.Context, ref *provider.Reference) (*storage.CreateDirResult, error) {
 	var (
 		err     error
 		unhook  UnHook
@@ -154,25 +154,25 @@ func (f *FS) CreateDir(ctx context.Context, ref *provider.Reference) error {
 	for _, hook := range f.hooks {
 		ctx, unhook, err = hook("CreateDir", ctx, ref.GetResourceId().GetSpaceId())
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if unhook != nil {
 			unhooks = append(unhooks, unhook)
 		}
 	}
 
-	res0 := f.next.CreateDir(ctx, ref)
+	result, err := f.next.CreateDir(ctx, ref)
 
 	for _, unhook := range unhooks {
 		if err := unhook(); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
-	return res0
+	return result, err
 }
 
-func (f *FS) TouchFile(ctx context.Context, ref *provider.Reference, markprocessing bool, mtime string) error {
+func (f *FS) TouchFile(ctx context.Context, ref *provider.Reference, markprocessing bool, mtime string) (*storage.TouchFileResult, error) {
 	var (
 		err     error
 		unhook  UnHook
@@ -181,22 +181,22 @@ func (f *FS) TouchFile(ctx context.Context, ref *provider.Reference, markprocess
 	for _, hook := range f.hooks {
 		ctx, unhook, err = hook("TouchFile", ctx, ref.GetResourceId().GetSpaceId())
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if unhook != nil {
 			unhooks = append(unhooks, unhook)
 		}
 	}
 
-	res0 := f.next.TouchFile(ctx, ref, markprocessing, mtime)
+	result, err := f.next.TouchFile(ctx, ref, markprocessing, mtime)
 
 	for _, unhook := range unhooks {
 		if err := unhook(); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
-	return res0
+	return result, err
 }
 
 func (f *FS) Delete(ctx context.Context, ref *provider.Reference) error {
@@ -442,7 +442,7 @@ func (f *FS) DownloadRevision(ctx context.Context, ref *provider.Reference, key 
 	return res0, res1, res2
 }
 
-func (f *FS) RestoreRevision(ctx context.Context, ref *provider.Reference, key string) error {
+func (f *FS) RestoreRevision(ctx context.Context, ref *provider.Reference, key string) (*storage.RestoreRevisionResult, error) {
 	var (
 		err     error
 		unhook  UnHook
@@ -451,22 +451,22 @@ func (f *FS) RestoreRevision(ctx context.Context, ref *provider.Reference, key s
 	for _, hook := range f.hooks {
 		ctx, unhook, err = hook("RestoreRevision", ctx, ref.GetResourceId().GetSpaceId())
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if unhook != nil {
 			unhooks = append(unhooks, unhook)
 		}
 	}
 
-	res0 := f.next.RestoreRevision(ctx, ref, key)
+	result, err := f.next.RestoreRevision(ctx, ref, key)
 
 	for _, unhook := range unhooks {
 		if err := unhook(); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
-	return res0
+	return result, err
 }
 
 func (f *FS) ListRecycle(ctx context.Context, ref *provider.Reference, key, relativePath string) ([]*provider.RecycleItem, error) {
@@ -496,7 +496,7 @@ func (f *FS) ListRecycle(ctx context.Context, ref *provider.Reference, key, rela
 	return res0, res1
 }
 
-func (f *FS) RestoreRecycleItem(ctx context.Context, ref *provider.Reference, key, relativePath string, restoreRef *provider.Reference) error {
+func (f *FS) RestoreRecycleItem(ctx context.Context, ref *provider.Reference, key, relativePath string, restoreRef *provider.Reference) (*storage.RestoreRecycleItemResult, error) {
 	var (
 		err     error
 		unhook  UnHook
@@ -505,22 +505,22 @@ func (f *FS) RestoreRecycleItem(ctx context.Context, ref *provider.Reference, ke
 	for _, hook := range f.hooks {
 		ctx, unhook, err = hook("RestoreRecycleItem", ctx, ref.GetResourceId().GetSpaceId())
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if unhook != nil {
 			unhooks = append(unhooks, unhook)
 		}
 	}
 
-	res0 := f.next.RestoreRecycleItem(ctx, ref, key, relativePath, restoreRef)
+	result, err := f.next.RestoreRecycleItem(ctx, ref, key, relativePath, restoreRef)
 
 	for _, unhook := range unhooks {
 		if err := unhook(); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
-	return res0
+	return result, err
 }
 
 func (f *FS) PurgeRecycleItem(ctx context.Context, ref *provider.Reference, key, relativePath string) error {
@@ -870,7 +870,7 @@ func (f *FS) UnsetArbitraryMetadata(ctx context.Context, ref *provider.Reference
 	return res0
 }
 
-func (f *FS) SetLock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) error {
+func (f *FS) SetLock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) (*storage.SetLockResult, error) {
 	var (
 		err     error
 		unhook  UnHook
@@ -879,22 +879,22 @@ func (f *FS) SetLock(ctx context.Context, ref *provider.Reference, lock *provide
 	for _, hook := range f.hooks {
 		ctx, unhook, err = hook("SetLock", ctx, ref.GetResourceId().GetSpaceId())
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if unhook != nil {
 			unhooks = append(unhooks, unhook)
 		}
 	}
 
-	res0 := f.next.SetLock(ctx, ref, lock)
+	result, err := f.next.SetLock(ctx, ref, lock)
 
 	for _, unhook := range unhooks {
 		if err := unhook(); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
-	return res0
+	return result, err
 }
 
 func (f *FS) GetLock(ctx context.Context, ref *provider.Reference) (*provider.Lock, error) {
@@ -951,7 +951,7 @@ func (f *FS) RefreshLock(ctx context.Context, ref *provider.Reference, lock *pro
 	return res0
 }
 
-func (f *FS) Unlock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) error {
+func (f *FS) Unlock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) (*storage.UnlockResult, error) {
 	var (
 		err     error
 		unhook  UnHook
@@ -960,22 +960,22 @@ func (f *FS) Unlock(ctx context.Context, ref *provider.Reference, lock *provider
 	for _, hook := range f.hooks {
 		ctx, unhook, err = hook("Unlock", ctx, ref.GetResourceId().GetSpaceId())
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if unhook != nil {
 			unhooks = append(unhooks, unhook)
 		}
 	}
 
-	res0 := f.next.Unlock(ctx, ref, lock)
+	result, err := f.next.Unlock(ctx, ref, lock)
 
 	for _, unhook := range unhooks {
 		if err := unhook(); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
-	return res0
+	return result, err
 }
 
 func (f *FS) ListStorageSpaces(ctx context.Context, filter []*provider.ListStorageSpacesRequest_Filter, unrestricted bool) ([]*provider.StorageSpace, error) {

--- a/pkg/storagespace/context.go
+++ b/pkg/storagespace/context.go
@@ -29,39 +29,74 @@ import (
 type key int
 
 const (
-	sendOwnerChanKey  key = iota
-	moveResultSlotKey
+	spaceOwnerSlotKey key = iota
+	moveResultSlotKey key = iota
 )
 
-// ContextSendSpaceOwnerID stores the space owner in the context.
-func ContextSendSpaceOwnerID(ctx context.Context, id *userpb.UserId) {
-	ch, ok := ctx.Value(sendOwnerChanKey).(chan<- *userpb.UserId)
-	if ok {
-		go func() {
-			ch <- id
-			close(ch)
-		}()
+// --- space owner ---
+
+type spaceOwnerSlot struct {
+	ownerID *userpb.UserId
+}
+
+// ContextRegisterSpaceOwnerSlot installs an empty slot in ctx so that the
+// storage driver can write the space owner via ContextSetSpaceOwner and the
+// events middleware can read it via ContextGetSpaceOwner after the handler
+// returns. Subsequent registrations are no-ops; the first registration wins.
+func ContextRegisterSpaceOwnerSlot(ctx context.Context) context.Context {
+	if ctx.Value(spaceOwnerSlotKey) != nil {
+		return ctx
+	}
+	return context.WithValue(ctx, spaceOwnerSlotKey, &spaceOwnerSlot{})
+}
+
+// ContextSetSpaceOwner writes id into the slot. Subsequent writes overwrite
+// the previous value. Does nothing if no slot was registered.
+func ContextSetSpaceOwner(ctx context.Context, id *userpb.UserId) {
+	if slot, ok := ctx.Value(spaceOwnerSlotKey).(*spaceOwnerSlot); ok {
+		slot.ownerID = id
 	}
 }
 
-// ContextRegisterSendOwnerChan registers a channel to send the current space owner
-func ContextRegisterSendOwnerChan(ctx context.Context, ch chan<- *userpb.UserId) context.Context {
-	return context.WithValue(ctx, sendOwnerChanKey, ch)
+// ContextGetSpaceOwner returns the space owner written by the storage driver,
+// or nil if none was set.
+func ContextGetSpaceOwner(ctx context.Context) *userpb.UserId {
+	if slot, ok := ctx.Value(spaceOwnerSlotKey).(*spaceOwnerSlot); ok {
+		return slot.ownerID
+	}
+	return nil
 }
 
-// MoveResultSlot is a mutable container for a *storage.MoveResult.
-type MoveResultSlot struct {
-	Result *storage.MoveResult
+// --- move result ---
+
+type moveResultSlot struct {
+	result *storage.MoveResult
 }
 
-// ContextRegisterMoveResultSlot stores an empty slot in ctx so the handler can fill it.
-func ContextRegisterMoveResultSlot(ctx context.Context, slot *MoveResultSlot) context.Context {
-	return context.WithValue(ctx, moveResultSlotKey, slot)
+// ContextRegisterMoveResultSlot installs an empty slot in ctx so that the
+// storage driver can write move metadata via ContextSetMoveResult and the
+// events middleware can read it via ContextGetMoveResult after the handler
+// returns. Subsequent registrations are no-ops; the first registration wins.
+func ContextRegisterMoveResultSlot(ctx context.Context) context.Context {
+	if ctx.Value(moveResultSlotKey) != nil {
+		return ctx
+	}
+	return context.WithValue(ctx, moveResultSlotKey, &moveResultSlot{})
 }
 
-// ContextSetMoveResult fills the slot registered in ctx with the given result.
+// ContextSetMoveResult writes r into the slot. Subsequent writes overwrite
+// the previous value. Does nothing if no slot was registered.
 func ContextSetMoveResult(ctx context.Context, r *storage.MoveResult) {
-	if slot, ok := ctx.Value(moveResultSlotKey).(*MoveResultSlot); ok {
-		slot.Result = r
+	if slot, ok := ctx.Value(moveResultSlotKey).(*moveResultSlot); ok {
+		slot.result = r
 	}
+}
+
+// ContextGetMoveResult returns the move result written by the storage driver,
+// or nil if none was set.
+func ContextGetMoveResult(ctx context.Context) *storage.MoveResult {
+	if slot, ok := ctx.Value(moveResultSlotKey).(*moveResultSlot); ok {
+		return slot.result
+	}
+	return nil
 }

--- a/tests/integration/grpc/gateway_storageprovider_test.go
+++ b/tests/integration/grpc/gateway_storageprovider_test.go
@@ -282,7 +282,7 @@ var _ = Describe("gateway", func() {
 				Expect(rootEtag3).ToNot(Equal(rootEtag2))
 
 				By("creating a directory")
-				err = shard1Fs.CreateDir(ctx, &storagep.Reference{ResourceId: &storagep.ResourceId{StorageId: shard1Space.Id.OpaqueId}, Path: "/newdirectory"})
+				_, err = shard1Fs.CreateDir(ctx, &storagep.Reference{ResourceId: &storagep.ResourceId{StorageId: shard1Space.Id.OpaqueId}, Path: "/newdirectory"})
 				Expect(err).ToNot(HaveOccurred())
 
 				time.Sleep(time.Second) // cache must expire
@@ -526,7 +526,7 @@ var _ = Describe("gateway", func() {
 				Expect(statRes.Info.Size).To(Equal(uint64(13)))
 
 				By("Uploading a new file into a subdir")
-				err = fs.CreateDir(ctx, &storagep.Reference{ResourceId: &rid, Path: "/newdir"})
+				_, err = fs.CreateDir(ctx, &storagep.Reference{ResourceId: &rid, Path: "/newdir"})
 				Expect(err).ToNot(HaveOccurred())
 				err = helpers.Upload(ctx, fs, &storagep.Reference{ResourceId: &rid, Path: "/newdir/newfile.txt"}, []byte("1234567890"))
 				Expect(err).ToNot(HaveOccurred())
@@ -567,7 +567,7 @@ var _ = Describe("gateway", func() {
 				Expect(statRes.Info.Size).To(Equal(uint64(13)))
 
 				By("Uploading a new file into a subdir")
-				err = embeddedFs.CreateDir(ctx, &storagep.Reference{ResourceId: &rid, Path: "/newdir"})
+				_, err = embeddedFs.CreateDir(ctx, &storagep.Reference{ResourceId: &rid, Path: "/newdir"})
 				Expect(err).ToNot(HaveOccurred())
 				err = helpers.Upload(ctx, embeddedFs, &storagep.Reference{ResourceId: &rid, Path: "/newdir/newfile.txt"}, []byte("1234567890"))
 				Expect(err).ToNot(HaveOccurred())
@@ -609,8 +609,11 @@ var _ = Describe("gateway", func() {
 				Expect(newEtag).ToNot(Equal(etag))
 
 				By("Creating a new dir")
-				err = fs.CreateDir(ctx, &storagep.Reference{ResourceId: &ssid, Path: "/newdir"})
+				writeResult, err := fs.CreateDir(ctx, &storagep.Reference{ResourceId: &ssid, Path: "/newdir"})
 				Expect(err).ToNot(HaveOccurred())
+				Expect(writeResult).ToNot(BeNil())
+				Expect(writeResult.SpaceOwner).ToNot(BeNil())
+				Expect(writeResult.SpaceOwner.OpaqueId).To(Equal(user.Id.OpaqueId))
 
 				time.Sleep(time.Second) // cache must expire
 				statRes, err = serviceClient.Stat(ctx, &storagep.StatRequest{Ref: homeRef})
@@ -653,7 +656,7 @@ var _ = Describe("gateway", func() {
 				Expect(newEtag).ToNot(Equal(etag))
 
 				By("Creating a new dir")
-				err = embeddedFs.CreateDir(ctx, &storagep.Reference{ResourceId: &essid, Path: "/newdir"})
+				_, err = embeddedFs.CreateDir(ctx, &storagep.Reference{ResourceId: &essid, Path: "/newdir"})
 				Expect(err).ToNot(HaveOccurred())
 
 				time.Sleep(time.Second) // cache must expire
@@ -686,10 +689,17 @@ var _ = Describe("gateway", func() {
 				targetRef := &storagep.Reference{ResourceId: &hssid, Path: "./destination"}
 				dstRef := &storagep.Reference{ResourceId: &hssid, Path: "./destination/source"}
 
-				err = fs.CreateDir(ctx, sourceRef)
+				writeResult, err := fs.CreateDir(ctx, sourceRef)
 				Expect(err).ToNot(HaveOccurred())
-				err = fs.CreateDir(ctx, targetRef)
+				Expect(writeResult).ToNot(BeNil())
+				Expect(writeResult.SpaceOwner).ToNot(BeNil())
+				Expect(writeResult.SpaceOwner.OpaqueId).To(Equal(user.Id.OpaqueId))
+
+				writeResult, err = fs.CreateDir(ctx, targetRef)
 				Expect(err).ToNot(HaveOccurred())
+				Expect(writeResult).ToNot(BeNil())
+				Expect(writeResult.SpaceOwner).ToNot(BeNil())
+				Expect(writeResult.SpaceOwner.OpaqueId).To(Equal(user.Id.OpaqueId))
 
 				mvRes, err := serviceClient.Move(ctx, &storagep.MoveRequest{Source: sourceRef, Destination: dstRef})
 				Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
The goal is to move `storagespace.ContextSendSpaceOwnerID(ctx, rn.SpaceOwnerOrManager(ctx))` out of drivers, to make events driver independent & drivers don't implement event specific logic. Instead, this channel is populated in the storageprovider now. 

2 additional changes:
The channel had a race condition, so it's not guarenteed the ownerId got set. With refactoring, this race condition is happening more often. Race condition got fixed by using a buffered channel instead & making the sending blocking:
```sendOwnerChan := make(chan *user.UserId, 1)```

```
select {
case ch <- id:
default:
}
```

Additionally, conversion.go had a bug, that `FileLocked` & `FileUnlocked` event conversion did not pass the ownerId. 