### PR TITLE
feat(OCISDEV-944): migrate Delete to typed DeleteResult

### DIFF
--- a/internal/grpc/interceptors/eventsmiddleware/conversion.go
+++ b/internal/grpc/interceptors/eventsmiddleware/conversion.go
@@ -266,17 +266,30 @@ func FileUnlocked(r *provider.UnlockResponse, req *provider.UnlockRequest, space
 }
 
 // ItemTrashed converts the response to an event
-func ItemTrashed(r *provider.DeleteResponse, req *provider.DeleteRequest, spaceOwner *user.UserId, executant *user.User) events.ItemTrashed {
-	opaqueID := utils.ReadPlainFromOpaque(r.Opaque, "opaque_id")
+func ItemTrashed(r *provider.DeleteResponse, req *provider.DeleteRequest, result *storage.DeleteResult, executant *user.User) events.ItemTrashed {
+	var spaceOwner *user.UserId
+	var id *provider.ResourceId
+	if result != nil {
+		spaceOwner = result.SpaceOwner
+		id = result.ResourceId
+	}
+	reqID := req.GetRef().GetResourceId()
+	if id == nil {
+		if reqID != nil {
+			id = &provider.ResourceId{
+				StorageId: reqID.GetStorageId(),
+				SpaceId:   reqID.GetSpaceId(),
+				OpaqueId:  reqID.GetOpaqueId(),
+			}
+		}
+	} else if id.GetStorageId() == "" {
+		id.StorageId = reqID.GetStorageId()
+	}
 	return events.ItemTrashed{
-		SpaceOwner: spaceOwner,
-		Executant:  executant.GetId(),
-		Ref:        req.Ref,
-		ID: &provider.ResourceId{
-			StorageId: req.Ref.GetResourceId().GetStorageId(),
-			SpaceId:   req.Ref.GetResourceId().GetSpaceId(),
-			OpaqueId:  opaqueID,
-		},
+		SpaceOwner:        spaceOwner,
+		Executant:         executant.GetId(),
+		Ref:               req.Ref,
+		ID:                id,
 		Timestamp:         utils.TSNow(),
 		ImpersonatingUser: extractImpersonator(executant),
 	}

--- a/internal/grpc/interceptors/eventsmiddleware/conversion_test.go
+++ b/internal/grpc/interceptors/eventsmiddleware/conversion_test.go
@@ -1,3 +1,21 @@
+// Copyright 2018-2021 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
 package eventsmiddleware
 
 import (
@@ -144,4 +162,108 @@ func TestItemMoved(t *testing.T) {
 	require.Equal(t, newRef, ev.Ref)
 	require.Equal(t, oldRef, ev.OldReference)
 	require.NotNil(t, ev.Timestamp)
+}
+func TestItemTrashed(t *testing.T) {
+	executant := &user.User{Id: &user.UserId{OpaqueId: "executant-id"}}
+	spaceOwner := &user.UserId{OpaqueId: "space-owner-id"}
+
+	reqRef := &provider.Reference{
+		ResourceId: &provider.ResourceId{
+			StorageId: "storage-1",
+			SpaceId:   "space-1",
+			OpaqueId:  "request-opaque-id",
+		},
+	}
+	req := &provider.DeleteRequest{Ref: reqRef}
+	res := &provider.DeleteResponse{}
+
+	tests := []struct {
+		name              string
+		result            *storage.DeleteResult
+		wantStorageId     string
+		wantSpaceId       string
+		wantOpaqueId      string
+		wantSpaceOwnerNil bool
+	}{
+		{
+			name: "decomposedfs flow: typed result has SpaceId/OpaqueId, StorageId is filled from request",
+			result: &storage.DeleteResult{
+				SpaceOwner: spaceOwner,
+				ResourceId: &provider.ResourceId{
+					SpaceId:  "space-from-result",
+					OpaqueId: "opaque-from-result",
+				},
+			},
+			wantStorageId: "storage-1",
+			wantSpaceId:   "space-from-result",
+			wantOpaqueId:  "opaque-from-result",
+		},
+		{
+			name:              "non-decomposedfs flow: empty result falls back to req.Ref.ResourceId",
+			result:            &storage.DeleteResult{},
+			wantStorageId:     "storage-1",
+			wantSpaceId:       "space-1",
+			wantOpaqueId:      "request-opaque-id",
+			wantSpaceOwnerNil: true,
+		},
+		{
+			name:              "nil result falls back to req.Ref.ResourceId",
+			result:            nil,
+			wantStorageId:     "storage-1",
+			wantSpaceId:       "space-1",
+			wantOpaqueId:      "request-opaque-id",
+			wantSpaceOwnerNil: true,
+		},
+		{
+			name: "typed result with StorageId already set is preserved",
+			result: &storage.DeleteResult{
+				SpaceOwner: spaceOwner,
+				ResourceId: &provider.ResourceId{
+					StorageId: "storage-from-result",
+					SpaceId:   "space-from-result",
+					OpaqueId:  "opaque-from-result",
+				},
+			},
+			wantStorageId: "storage-from-result",
+			wantSpaceId:   "space-from-result",
+			wantOpaqueId:  "opaque-from-result",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ev := ItemTrashed(res, req, tc.result, executant)
+
+			if ev.ID == nil {
+				t.Fatalf("event ID is nil, want non-nil")
+			}
+			if got := ev.ID.GetStorageId(); got != tc.wantStorageId {
+				t.Errorf("StorageId: got %q, want %q", got, tc.wantStorageId)
+			}
+			if got := ev.ID.GetSpaceId(); got != tc.wantSpaceId {
+				t.Errorf("SpaceId: got %q, want %q", got, tc.wantSpaceId)
+			}
+			if got := ev.ID.GetOpaqueId(); got != tc.wantOpaqueId {
+				t.Errorf("OpaqueId: got %q, want %q", got, tc.wantOpaqueId)
+			}
+
+			if tc.wantSpaceOwnerNil {
+				if ev.SpaceOwner != nil {
+					t.Errorf("SpaceOwner: got %v, want nil", ev.SpaceOwner)
+				}
+			} else if ev.SpaceOwner == nil || ev.SpaceOwner.GetOpaqueId() != spaceOwner.GetOpaqueId() {
+				t.Errorf("SpaceOwner: got %v, want %v", ev.SpaceOwner, spaceOwner)
+			}
+
+			if ev.Executant.GetOpaqueId() != executant.Id.OpaqueId {
+				t.Errorf("Executant: got %v, want %v", ev.Executant, executant.Id)
+			}
+			if ev.Ref != reqRef {
+				t.Errorf("Ref: got %v, want %v", ev.Ref, reqRef)
+			}
+			if ev.Timestamp == nil {
+				t.Errorf("Timestamp: got nil, want non-nil")
+			}
+		})
+	}
 }

--- a/internal/grpc/interceptors/eventsmiddleware/events.go
+++ b/internal/grpc/interceptors/eventsmiddleware/events.go
@@ -61,6 +61,8 @@ func NewUnary(m map[string]interface{}) (grpc.UnaryServerInterceptor, int, error
 		// the immutable context chain; values are read here after the handler returns.
 		ctx = storagespace.ContextRegisterSpaceOwnerSlot(ctx)
 		ctx = storagespace.ContextRegisterMoveResultSlot(ctx)
+		// Register a slot for typed Delete results
+		ctx = storagespace.ContextRegisterDeleteResultSlot(ctx)
 
 		res, err := handler(ctx, req)
 		if err != nil {
@@ -145,7 +147,7 @@ func NewUnary(m map[string]interface{}) (grpc.UnaryServerInterceptor, int, error
 			}
 		case *provider.DeleteResponse:
 			if isSuccess(v) {
-				ev = ItemTrashed(v, req.(*provider.DeleteRequest), spaceOwnerID, executant)
+				ev = ItemTrashed(v, req.(*provider.DeleteRequest), storagespace.ContextGetDeleteResult(ctx), executant)
 			}
 		case *provider.PurgeRecycleResponse:
 			if isSuccess(v) {

--- a/internal/grpc/services/storageprovider/storageprovider.go
+++ b/internal/grpc/services/storageprovider/storageprovider.go
@@ -749,36 +749,14 @@ func (s *Service) Delete(ctx context.Context, req *provider.DeleteRequest) (*pro
 		}
 	}
 
-	md, err := s.Storage.GetMD(ctx, req.Ref, []string{}, []string{"id", "status"})
-	if err != nil {
-		return &provider.DeleteResponse{
-			Status: status.NewStatusFromErrType(ctx, "can't stat resource to delete", err),
-		}, nil
-	}
+	result, err := s.Storage.Delete(ctx, req.Ref)
 
-	if utils.ReadPlainFromOpaque(md.GetOpaque(), "status") == "processing" {
-		return &provider.DeleteResponse{
-			Status: &rpc.Status{
-				Code:    rpc.Code_CODE_TOO_EARLY,
-				Message: "file is processing",
-			},
-			Opaque: &typesv1beta1.Opaque{
-				Map: map[string]*typesv1beta1.OpaqueEntry{
-					"status": {Decoder: "plain", Value: []byte("processing")},
-				},
-			},
-		}, nil
+	if err == nil && result != nil {
+		storagespace.ContextSetDeleteResult(ctx, result)
 	}
-
-	err = s.Storage.Delete(ctx, req.Ref)
 
 	return &provider.DeleteResponse{
 		Status: status.NewStatusFromErrType(ctx, "delete", err),
-		Opaque: &typesv1beta1.Opaque{
-			Map: map[string]*typesv1beta1.OpaqueEntry{
-				"opaque_id": {Decoder: "plain", Value: []byte(md.Id.OpaqueId)},
-			},
-		},
 	}, nil
 }
 

--- a/pkg/ocm/storage/received/ocm.go
+++ b/pkg/ocm/storage/received/ocm.go
@@ -224,12 +224,15 @@ func (d *driver) CreateDir(ctx context.Context, ref *provider.Reference) (*stora
 	return &storage.CreateDirResult{}, nil
 }
 
-func (d *driver) Delete(ctx context.Context, ref *provider.Reference) error {
+func (d *driver) Delete(ctx context.Context, ref *provider.Reference) (*storage.DeleteResult, error) {
 	client, _, rel, err := d.webdavClient(ctx, nil, ref)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return client.RemoveAll(rel)
+	if err := client.RemoveAll(rel); err != nil {
+		return nil, err
+	}
+	return &storage.DeleteResult{}, nil
 }
 
 func (d *driver) TouchFile(ctx context.Context, ref *provider.Reference, markprocessing bool, mtime string) (*storage.TouchFileResult, error) {

--- a/pkg/rgrpc/status/status.go
+++ b/pkg/rgrpc/status/status.go
@@ -170,6 +170,15 @@ func NewTooManyRequests(ctx context.Context, msg string) *rpc.Status {
 	}
 }
 
+// NewTooEarly returns a Status with CODE_TOO_EARLY.
+func NewTooEarly(ctx context.Context, msg string) *rpc.Status {
+	return &rpc.Status{
+		Code:    rpc.Code_CODE_TOO_EARLY,
+		Message: msg,
+		Trace:   getTrace(ctx),
+	}
+}
+
 // NewStatusFromErrType returns a status that corresponds to the given errtype
 func NewStatusFromErrType(ctx context.Context, msg string, err error) *rpc.Status {
 	switch e := err.(type) {
@@ -202,6 +211,8 @@ func NewStatusFromErrType(ctx context.Context, msg string, err error) *rpc.Statu
 		return NewInvalid(ctx, msg+":"+err.Error())
 	case errtypes.TooManyRequests:
 		return NewTooManyRequests(ctx, msg+": "+err.Error())
+	case errtypes.TooEarly:
+		return NewTooEarly(ctx, msg+": "+err.Error())
 	}
 
 	// map GRPC status codes coming from the auth middleware

--- a/pkg/storage/fs/cephfs/cephfs.go
+++ b/pkg/storage/fs/cephfs/cephfs.go
@@ -174,12 +174,12 @@ func (fs *cephfs) TouchFile(ctx context.Context, ref *provider.Reference, markpr
 	return nil, fmt.Errorf("unimplemented: TouchFile")
 }
 
-func (fs *cephfs) Delete(ctx context.Context, ref *provider.Reference) (err error) {
+func (fs *cephfs) Delete(ctx context.Context, ref *provider.Reference) (_ *storage.DeleteResult, err error) {
 	var path string
 	user := fs.makeUser(ctx)
 	path, err = user.resolveRef(ref)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	user.op(func(cv *cacheVal) {
@@ -192,10 +192,13 @@ func (fs *cephfs) Delete(ctx context.Context, ref *provider.Reference) (err erro
 
 	//has already been deleted by direct mount
 	if err != nil && err.Error() == errNotFound {
-		return nil
+		return &storage.DeleteResult{}, nil
 	}
 
-	return getRevaError(err)
+	if err != nil {
+		return nil, getRevaError(err)
+	}
+	return &storage.DeleteResult{}, nil
 }
 
 func (fs *cephfs) Move(ctx context.Context, oldRef, newRef *provider.Reference) (*storage.MoveResult, error) {

--- a/pkg/storage/fs/hello/unimplemented.go
+++ b/pkg/storage/fs/hello/unimplemented.go
@@ -65,8 +65,8 @@ func (fs *hellofs) TouchFile(ctx context.Context, ref *provider.Reference, _ boo
 
 // Delete deletes a resource.
 // If the storage driver supports a recycle bin it should moves it to the recycle bin
-func (fs *hellofs) Delete(ctx context.Context, ref *provider.Reference) error {
-	return errtypes.NotSupported("unimplemented")
+func (fs *hellofs) Delete(ctx context.Context, ref *provider.Reference) (*storage.DeleteResult, error) {
+	return nil, errtypes.NotSupported("unimplemented")
 }
 
 // Move changes the path of a resource

--- a/pkg/storage/fs/nextcloud/nextcloud.go
+++ b/pkg/storage/fs/nextcloud/nextcloud.go
@@ -278,16 +278,19 @@ func (nc *StorageDriver) TouchFile(ctx context.Context, ref *provider.Reference,
 }
 
 // Delete as defined in the storage.FS interface
-func (nc *StorageDriver) Delete(ctx context.Context, ref *provider.Reference) error {
+func (nc *StorageDriver) Delete(ctx context.Context, ref *provider.Reference) (*storage.DeleteResult, error) {
 	bodyStr, err := json.Marshal(ref)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	log := appctx.GetLogger(ctx)
 	log.Info().Msgf("Delete %s", bodyStr)
 
 	_, _, err = nc.do(ctx, Action{"Delete", string(bodyStr)})
-	return err
+	if err != nil {
+		return nil, err
+	}
+	return &storage.DeleteResult{}, nil
 }
 
 // Move as defined in the storage.FS interface

--- a/pkg/storage/fs/nextcloud/nextcloud_test.go
+++ b/pkg/storage/fs/nextcloud/nextcloud_test.go
@@ -178,7 +178,7 @@ var _ = Describe("Nextcloud", func() {
 				},
 				Path: "/some/path",
 			}
-			err := nc.Delete(ctx, ref)
+			_, err := nc.Delete(ctx, ref)
 			Expect(err).ToNot(HaveOccurred())
 			checkCalled(called, `POST /apps/sciencemesh/~tester/api/storage/Delete {"resource_id":{"storage_id":"storage-id","opaque_id":"opaque-id"},"path":"/some/path"}`)
 		})

--- a/pkg/storage/fs/owncloudsql/owncloudsql.go
+++ b/pkg/storage/fs/owncloudsql/owncloudsql.go
@@ -1170,40 +1170,40 @@ func (fs *owncloudsqlfs) Unlock(ctx context.Context, ref *provider.Reference, lo
 // versions were not.
 // We will live with that compromise since this storage driver will be
 // deprecated soon.
-func (fs *owncloudsqlfs) Delete(ctx context.Context, ref *provider.Reference) (err error) {
+func (fs *owncloudsqlfs) Delete(ctx context.Context, ref *provider.Reference) (_ *storage.DeleteResult, err error) {
 	var ip string
 	if ip, err = fs.resolve(ctx, ref); err != nil {
-		return errors.Wrap(err, "owncloudsql: error resolving reference")
+		return nil, errors.Wrap(err, "owncloudsql: error resolving reference")
 	}
 
 	// check permissions
 	if perm, err := fs.readPermissions(ctx, ip); err == nil {
 		if !perm.Delete {
-			return errtypes.PermissionDenied("")
+			return nil, errtypes.PermissionDenied("")
 		}
 	} else {
 		if isNotFound(err) {
-			return errtypes.NotFound(fs.toStoragePath(ctx, filepath.Dir(ip)))
+			return nil, errtypes.NotFound(fs.toStoragePath(ctx, filepath.Dir(ip)))
 		}
-		return errors.Wrap(err, "owncloudsql: error reading permissions")
+		return nil, errors.Wrap(err, "owncloudsql: error reading permissions")
 	}
 
 	_, err = os.Stat(ip)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return errtypes.NotFound(fs.toStoragePath(ctx, ip))
+			return nil, errtypes.NotFound(fs.toStoragePath(ctx, ip))
 		}
-		return errors.Wrap(err, "owncloudsql: error stating "+ip)
+		return nil, errors.Wrap(err, "owncloudsql: error stating "+ip)
 	}
 
 	// Delete file into the owner's trash, not the user's (in case of shares)
 	rp, err := fs.getRecyclePathForUser(fs.getOwner(ip))
 	if err != nil {
-		return errors.Wrap(err, "owncloudsql: error resolving recycle path")
+		return nil, errors.Wrap(err, "owncloudsql: error resolving recycle path")
 	}
 
 	if err := os.MkdirAll(rp, 0700); err != nil {
-		return errors.Wrap(err, "owncloudsql: error creating trashbin dir "+rp)
+		return nil, errors.Wrap(err, "owncloudsql: error creating trashbin dir "+rp)
 	}
 
 	// ip is the path on disk ... we need only the path relative to root
@@ -1211,9 +1211,9 @@ func (fs *owncloudsqlfs) Delete(ctx context.Context, ref *provider.Reference) (e
 
 	err = fs.trash(ctx, ip, rp, origin)
 	if err != nil {
-		return errors.Wrapf(err, "owncloudsql: error deleting file %s", ip)
+		return nil, errors.Wrapf(err, "owncloudsql: error deleting file %s", ip)
 	}
-	return nil
+	return &storage.DeleteResult{}, nil
 }
 
 func (fs *owncloudsqlfs) trash(ctx context.Context, ip string, rp string, origin string) error {

--- a/pkg/storage/fs/s3/s3.go
+++ b/pkg/storage/fs/s3/s3.go
@@ -353,12 +353,12 @@ func (fs *s3FS) TouchFile(ctx context.Context, ref *provider.Reference, markproc
 	return nil, fmt.Errorf("unimplemented: TouchFile")
 }
 
-func (fs *s3FS) Delete(ctx context.Context, ref *provider.Reference) error {
+func (fs *s3FS) Delete(ctx context.Context, ref *provider.Reference) (*storage.DeleteResult, error) {
 	log := appctx.GetLogger(ctx)
 
 	fn, err := fs.resolve(ctx, ref)
 	if err != nil {
-		return errors.Wrap(err, "error resolving ref")
+		return nil, errors.Wrap(err, "error resolving ref")
 	}
 
 	// first we need to find out if fn is a dir or a file
@@ -373,7 +373,7 @@ func (fs *s3FS) Delete(ctx context.Context, ref *provider.Reference) error {
 			switch aerr.Code() {
 			case s3.ErrCodeNoSuchBucket:
 			case s3.ErrCodeNoSuchKey:
-				return errtypes.NotFound(fn)
+				return nil, errtypes.NotFound(fn)
 			}
 		}
 		// it might be a directory, so we can batch delete the prefix + /
@@ -383,10 +383,10 @@ func (fs *s3FS) Delete(ctx context.Context, ref *provider.Reference) error {
 		})
 		batcher := s3manager.NewBatchDeleteWithClient(fs.client)
 		if err := batcher.Delete(aws.BackgroundContext(), iter); err != nil {
-			return err
+			return nil, err
 		}
 		// ok, we are done
-		return nil
+		return &storage.DeleteResult{}, nil
 	}
 
 	// we found an object, let's get rid of it
@@ -400,14 +400,14 @@ func (fs *s3FS) Delete(ctx context.Context, ref *provider.Reference) error {
 			switch aerr.Code() {
 			case s3.ErrCodeNoSuchBucket:
 			case s3.ErrCodeNoSuchKey:
-				return errtypes.NotFound(fn)
+				return nil, errtypes.NotFound(fn)
 			}
 		}
-		return errors.Wrap(err, "s3fs: error deleting "+fn)
+		return nil, errors.Wrap(err, "s3fs: error deleting "+fn)
 	}
 
 	log.Debug().Interface("result", result)
-	return nil
+	return &storage.DeleteResult{}, nil
 }
 
 // CreateStorageSpace creates a storage space

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -105,8 +105,9 @@ type FS interface {
 	// FIXME the mtime should either be a time.Time or a CS3 Timestamp, not a string
 	TouchFile(ctx context.Context, ref *provider.Reference, markprocessing bool, mtime string) (*TouchFileResult, error)
 	// Delete deletes a resource.
-	// If the storage driver supports a recycle bin it should moves it to the recycle bin
-	Delete(ctx context.Context, ref *provider.Reference) error
+	// If the storage driver supports a recycle bin it should move it to the recycle bin
+	// On success, returns a DeleteResult used by the wrapper to publish ItemTrashed.
+	Delete(ctx context.Context, ref *provider.Reference) (*DeleteResult, error)
 	// Move changes the path of a resource
 	Move(ctx context.Context, oldRef, newRef *provider.Reference) (*MoveResult, error)
 	// InitiateUpload returns a list of protocols with urls that can be used to append bytes to a new upload session
@@ -182,6 +183,15 @@ type FS interface {
 	// GetHome returns the path to the users home
 	// Deprecated: use ListStorageSpaces with type personal
 	GetHome(ctx context.Context) (string, error)
+}
+
+// DeleteResult is returned by FS.Delete on success. It carries the data the
+// storageprovider wrapper needs to publish the ItemTrashed event.
+type DeleteResult struct {
+	// SpaceOwner is the owner of the space the deleted resource belonged to.
+	SpaceOwner *userpb.UserId
+	// ResourceId is the stable identifier of the deleted resource, used as ItemTrashed.ID in the published event.
+	ResourceId *provider.ResourceId
 }
 
 // UnscopeFunc is a function that unscopes a user

--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -1084,37 +1084,47 @@ func (fs *Decomposedfs) ListFolder(ctx context.Context, ref *provider.Reference,
 }
 
 // Delete deletes the specified resource
-func (fs *Decomposedfs) Delete(ctx context.Context, ref *provider.Reference) (err error) {
+func (fs *Decomposedfs) Delete(ctx context.Context, ref *provider.Reference) (dr *storage.DeleteResult, err error) {
 	ctx, span := tracer.Start(ctx, "Delete")
 	defer span.End()
 	var node *node.Node
 	if node, err = fs.lu.NodeFromResource(ctx, ref); err != nil {
-		return
+		return nil, err
 	}
 	if !node.Exists {
-		return errtypes.NotFound(filepath.Join(node.ParentID, node.Name))
+		return nil, errtypes.NotFound(filepath.Join(node.ParentID, node.Name))
+	}
+
+	if node.IsProcessing(ctx) {
+		return nil, errtypes.TooEarly("file is processing")
 	}
 
 	rp, err := fs.p.AssemblePermissions(ctx, node)
 	switch {
 	case err != nil:
-		return err
+		return nil, err
 	case !rp.Delete:
 		f, _ := storagespace.FormatReference(ref)
 		if rp.Stat {
-			return errtypes.PermissionDenied(f)
+			return nil, errtypes.PermissionDenied(f)
 		}
-		return errtypes.NotFound(f)
+		return nil, errtypes.NotFound(f)
 	}
-
-	// Set space owner in context
-	storagespace.ContextSetSpaceOwner(ctx, node.SpaceOwnerOrManager(ctx))
 
 	if err := node.CheckLock(ctx); err != nil {
-		return err
+		return nil, err
 	}
 
-	return fs.tp.Delete(ctx, node)
+	if err := fs.tp.Delete(ctx, node); err != nil {
+		return nil, err
+	}
+	return &storage.DeleteResult{
+		SpaceOwner: node.SpaceOwnerOrManager(ctx),
+		ResourceId: &provider.ResourceId{
+			SpaceId:  node.SpaceID,
+			OpaqueId: node.ID,
+		},
+	}, nil
 }
 
 // Download returns a reader to the specified resource

--- a/pkg/storage/utils/decomposedfs/decomposedfs_test.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs_test.go
@@ -149,7 +149,7 @@ var _ = Describe("Decomposed", func() {
 			It("returns an error", func() {
 				env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(&provider.ResourcePermissions{}, nil)
 
-				err := env.Fs.Delete(env.Ctx, ref)
+				_, err := env.Fs.Delete(env.Ctx, ref)
 
 				Expect(err).To(MatchError(ContainSubstring("not found")))
 			})
@@ -162,7 +162,7 @@ var _ = Describe("Decomposed", func() {
 					Delete: false,
 				}, nil)
 
-				err := env.Fs.Delete(env.Ctx, ref)
+				_, err := env.Fs.Delete(env.Ctx, ref)
 
 				Expect(err).To(MatchError(ContainSubstring("permission denied")))
 			})
@@ -177,10 +177,21 @@ var _ = Describe("Decomposed", func() {
 			})
 
 			It("does not (yet) delete the blob from the blobstore", func() {
-				err := env.Fs.Delete(env.Ctx, ref)
+				_, err := env.Fs.Delete(env.Ctx, ref)
 
 				Expect(err).ToNot(HaveOccurred())
 				env.Blobstore.AssertNotCalled(GinkgoT(), "Delete", mock.AnythingOfType("string"))
+			})
+
+			It("returns a populated DeleteResult", func() {
+				result, err := env.Fs.Delete(env.Ctx, ref)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).NotTo(BeNil())
+				Expect(result.SpaceOwner).NotTo(BeNil())
+				Expect(result.ResourceId).NotTo(BeNil())
+				Expect(result.ResourceId.SpaceId).NotTo(BeEmpty())
+				Expect(result.ResourceId.OpaqueId).NotTo(BeEmpty())
 			})
 		})
 	})

--- a/pkg/storage/utils/decomposedfs/events_test.go
+++ b/pkg/storage/utils/decomposedfs/events_test.go
@@ -148,7 +148,7 @@ var _ = Describe("Storage event SpaceOwner propagation", func() {
 				RestoreRecycleItem: true,
 			})
 
-			err := env.Fs.Delete(env.Ctx, &provider.Reference{
+			_, err := env.Fs.Delete(env.Ctx, &provider.Reference{
 				ResourceId: env.SpaceRootRes,
 				Path:       "/dir1/file1",
 			})

--- a/pkg/storage/utils/decomposedfs/recycle_test.go
+++ b/pkg/storage/utils/decomposedfs/recycle_test.go
@@ -23,11 +23,11 @@ import (
 
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	ctxpkg "github.com/owncloud/reva/v2/pkg/ctx"
 	"github.com/owncloud/reva/v2/pkg/storage/utils/decomposedfs/permissions/mocks"
 	helpers "github.com/owncloud/reva/v2/pkg/storage/utils/decomposedfs/testhelpers"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -59,13 +59,13 @@ var _ = Describe("Recycle", func() {
 			})
 
 			JustBeforeEach(func() {
-				err := env.Fs.Delete(env.Ctx, &provider.Reference{
+				_, err := env.Fs.Delete(env.Ctx, &provider.Reference{
 					ResourceId: env.SpaceRootRes,
 					Path:       "/dir1/file1",
 				})
 				Expect(err).ToNot(HaveOccurred())
 
-				err = env.Fs.Delete(env.Ctx, &provider.Reference{
+				_, err = env.Fs.Delete(env.Ctx, &provider.Reference{
 					ResourceId: env.SpaceRootRes,
 					Path:       "/dir1/subdir1",
 				})
@@ -152,13 +152,13 @@ var _ = Describe("Recycle", func() {
 			})
 
 			JustBeforeEach(func() {
-				err := env.Fs.Delete(env.Ctx, &provider.Reference{
+				_, err := env.Fs.Delete(env.Ctx, &provider.Reference{
 					ResourceId: env.SpaceRootRes,
 					Path:       "/dir1/file1",
 				})
 				Expect(err).ToNot(HaveOccurred())
 
-				err = env.Fs.Delete(ctx, &provider.Reference{
+				_, err = env.Fs.Delete(ctx, &provider.Reference{
 					ResourceId: env.SpaceRootRes,
 					Path:       "/dir1/subdir1",
 				})
@@ -255,13 +255,13 @@ var _ = Describe("Recycle", func() {
 			})
 
 			JustBeforeEach(func() {
-				err := env.Fs.Delete(env.Ctx, &provider.Reference{
+				_, err := env.Fs.Delete(env.Ctx, &provider.Reference{
 					ResourceId: env.SpaceRootRes,
 					Path:       "/dir1/file1",
 				})
 				Expect(err).ToNot(HaveOccurred())
 
-				err = env.Fs.Delete(env.Ctx, &provider.Reference{
+				_, err = env.Fs.Delete(env.Ctx, &provider.Reference{
 					ResourceId: projectID,
 					Path:       "/dir1/file1",
 				})
@@ -334,7 +334,7 @@ var _ = Describe("Recycle", func() {
 			})
 
 			It("can list the trashbin", func() {
-				err := env.Fs.Delete(env.Ctx, &provider.Reference{
+				_, err := env.Fs.Delete(env.Ctx, &provider.Reference{
 					ResourceId: env.SpaceRootRes,
 					Path:       "/dir1/file1",
 				})
@@ -346,7 +346,7 @@ var _ = Describe("Recycle", func() {
 			})
 
 			It("cannot delete files", func() {
-				err := env.Fs.Delete(ctx, &provider.Reference{
+				_, err := env.Fs.Delete(ctx, &provider.Reference{
 					ResourceId: env.SpaceRootRes,
 					Path:       "/dir1/file1",
 				})
@@ -359,7 +359,7 @@ var _ = Describe("Recycle", func() {
 			})
 
 			It("cannot purge files from trashbin", func() {
-				err := env.Fs.Delete(env.Ctx, &provider.Reference{
+				_, err := env.Fs.Delete(env.Ctx, &provider.Reference{
 					ResourceId: env.SpaceRootRes,
 					Path:       "/dir1/file1",
 				})
@@ -375,7 +375,7 @@ var _ = Describe("Recycle", func() {
 			})
 
 			It("cannot restore files from trashbin", func() {
-				err := env.Fs.Delete(env.Ctx, &provider.Reference{
+				_, err := env.Fs.Delete(env.Ctx, &provider.Reference{
 					ResourceId: env.SpaceRootRes,
 					Path:       "/dir1/file1",
 				})
@@ -419,14 +419,14 @@ var _ = Describe("Recycle", func() {
 		})
 
 		It("cannot delete, list, purge or restore", func() {
-			err := env.Fs.Delete(ctx, &provider.Reference{
+			_, err := env.Fs.Delete(ctx, &provider.Reference{
 				ResourceId: env.SpaceRootRes,
 				Path:       "/dir1/file1",
 			})
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("not found"))
 
-			err = env.Fs.Delete(env.Ctx, &provider.Reference{
+			_, err = env.Fs.Delete(env.Ctx, &provider.Reference{
 				ResourceId: env.SpaceRootRes,
 				Path:       "/dir1/file1",
 			})

--- a/pkg/storage/utils/decomposedfs/spaces.go
+++ b/pkg/storage/utils/decomposedfs/spaces.go
@@ -700,7 +700,7 @@ func (fs *Decomposedfs) UpdateStorageSpace(ctx context.Context, req *provider.Up
 				},
 			}
 			// delete old image after new image was successfully set
-			_ = fs.Delete(ctx, delRef)
+			_, _ = fs.Delete(ctx, delRef)
 			// silently ignore failed deletion
 		}
 	}

--- a/pkg/storage/utils/eosfs/eosfs.go
+++ b/pkg/storage/utils/eosfs/eosfs.go
@@ -1741,28 +1741,34 @@ func (fs *eosfs) CreateReference(ctx context.Context, p string, targetURI *url.U
 	return nil
 }
 
-func (fs *eosfs) Delete(ctx context.Context, ref *provider.Reference) error {
+func (fs *eosfs) Delete(ctx context.Context, ref *provider.Reference) (*storage.DeleteResult, error) {
 	p, err := fs.resolve(ctx, ref)
 	if err != nil {
-		return errors.Wrap(err, "eosfs: error resolving reference")
+		return nil, errors.Wrap(err, "eosfs: error resolving reference")
 	}
 
 	if fs.isShareFolder(ctx, p) {
-		return fs.deleteShadow(ctx, p)
+		if err = fs.deleteShadow(ctx, p); err != nil {
+			return nil, err
+		}
+		return &storage.DeleteResult{}, nil
 	}
 
 	fn := fs.wrap(ctx, p)
 
 	u, err := getUser(ctx)
 	if err != nil {
-		return errors.Wrap(err, "eosfs: no user in ctx")
+		return nil, errors.Wrap(err, "eosfs: no user in ctx")
 	}
 	auth, err := fs.getUserAuth(ctx, u, fn)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return fs.c.Remove(ctx, auth, fn, false)
+	if err := fs.c.Remove(ctx, auth, fn, false); err != nil {
+		return nil, err
+	}
+	return &storage.DeleteResult{}, nil
 }
 
 func (fs *eosfs) deleteShadow(ctx context.Context, p string) error {

--- a/pkg/storage/utils/localfs/localfs.go
+++ b/pkg/storage/utils/localfs/localfs.go
@@ -813,14 +813,14 @@ func (fs *localfs) TouchFile(ctx context.Context, ref *provider.Reference, _ boo
 	return nil, fmt.Errorf("unimplemented: TouchFile")
 }
 
-func (fs *localfs) Delete(ctx context.Context, ref *provider.Reference) error {
+func (fs *localfs) Delete(ctx context.Context, ref *provider.Reference) (*storage.DeleteResult, error) {
 	fn, err := fs.resolve(ctx, ref)
 	if err != nil {
-		return errors.Wrap(err, "localfs: error resolving ref")
+		return nil, errors.Wrap(err, "localfs: error resolving ref")
 	}
 
 	if fs.isShareFolderRoot(ctx, fn) {
-		return errtypes.PermissionDenied("localfs: cannot delete the virtual share folder")
+		return nil, errtypes.PermissionDenied("localfs: cannot delete the virtual share folder")
 	}
 
 	var fp string
@@ -833,22 +833,25 @@ func (fs *localfs) Delete(ctx context.Context, ref *provider.Reference) error {
 	_, err = os.Stat(fp)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return errtypes.NotFound(fn)
+			return nil, errtypes.NotFound(fn)
 		}
-		return errors.Wrap(err, "localfs: error stating "+fp)
+		return nil, errors.Wrap(err, "localfs: error stating "+fp)
 	}
 
 	key := fmt.Sprintf("%s.d%d", path.Base(fn), time.Now().UnixNano()/int64(time.Millisecond))
 	if err := os.Rename(fp, fs.wrapRecycleBin(ctx, key)); err != nil {
-		return errors.Wrap(err, "localfs: could not delete item")
+		return nil, errors.Wrap(err, "localfs: could not delete item")
 	}
 
 	err = fs.addToRecycledDB(ctx, key, fn)
 	if err != nil {
-		return errors.Wrap(err, "localfs: error adding entry to DB")
+		return nil, errors.Wrap(err, "localfs: error adding entry to DB")
 	}
 
-	return fs.propagate(ctx, path.Dir(fp))
+	if err := fs.propagate(ctx, path.Dir(fp)); err != nil {
+		return nil, err
+	}
+	return &storage.DeleteResult{}, nil
 }
 
 func (fs *localfs) Move(ctx context.Context, oldRef, newRef *provider.Reference) (*storage.MoveResult, error) {

--- a/pkg/storage/utils/middleware/middleware.go
+++ b/pkg/storage/utils/middleware/middleware.go
@@ -199,7 +199,7 @@ func (f *FS) TouchFile(ctx context.Context, ref *provider.Reference, markprocess
 	return result, err
 }
 
-func (f *FS) Delete(ctx context.Context, ref *provider.Reference) error {
+func (f *FS) Delete(ctx context.Context, ref *provider.Reference) (*storage.DeleteResult, error) {
 	var (
 		err     error
 		unhook  UnHook
@@ -208,22 +208,22 @@ func (f *FS) Delete(ctx context.Context, ref *provider.Reference) error {
 	for _, hook := range f.hooks {
 		ctx, unhook, err = hook("Delete", ctx, ref.GetResourceId().GetSpaceId())
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if unhook != nil {
 			unhooks = append(unhooks, unhook)
 		}
 	}
 
-	res0 := f.next.Delete(ctx, ref)
+	res0, err := f.next.Delete(ctx, ref)
 
 	for _, unhook := range unhooks {
 		if err := unhook(); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
-	return res0
+	return res0, err
 }
 
 func (f *FS) Move(ctx context.Context, oldRef, newRef *provider.Reference) (*storage.MoveResult, error) {

--- a/pkg/storagespace/context.go
+++ b/pkg/storagespace/context.go
@@ -29,14 +29,9 @@ type key int
 
 const (
 	spaceOwnerSlotKey key = iota
-	moveResultSlotKey key = iota
-	deleteResultSlotKey key = iota
+	moveResultSlotKey
+	deleteResultSlotKey
 )
-
-// DeleteResultSlot is a mutable container for a *storage.DeleteResult.
-type DeleteResultSlot struct {
-	Result *storage.DeleteResult
-}
 
 // --- space owner ---
 

--- a/pkg/storagespace/context.go
+++ b/pkg/storagespace/context.go
@@ -22,7 +22,6 @@ import (
 	"context"
 
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
-
 	"github.com/owncloud/reva/v2/pkg/storage"
 )
 
@@ -31,7 +30,13 @@ type key int
 const (
 	spaceOwnerSlotKey key = iota
 	moveResultSlotKey key = iota
+	deleteResultSlotKey key = iota
 )
+
+// DeleteResultSlot is a mutable container for a *storage.DeleteResult.
+type DeleteResultSlot struct {
+	Result *storage.DeleteResult
+}
 
 // --- space owner ---
 
@@ -96,6 +101,40 @@ func ContextSetMoveResult(ctx context.Context, r *storage.MoveResult) {
 // or nil if none was set.
 func ContextGetMoveResult(ctx context.Context) *storage.MoveResult {
 	if slot, ok := ctx.Value(moveResultSlotKey).(*moveResultSlot); ok {
+		return slot.result
+	}
+	return nil
+}
+
+// --- delete result ---
+
+type deleteResultSlot struct {
+	result *storage.DeleteResult
+}
+
+// ContextRegisterDeleteResultSlot installs an empty slot in ctx so that the
+// storage driver can write delete metadata via ContextSetDeleteResult and the
+// events middleware can read it via ContextGetDeleteResult after the handler
+// returns. Subsequent registrations are no-ops; the first registration wins.
+func ContextRegisterDeleteResultSlot(ctx context.Context) context.Context {
+	if ctx.Value(deleteResultSlotKey) != nil {
+		return ctx
+	}
+	return context.WithValue(ctx, deleteResultSlotKey, &deleteResultSlot{})
+}
+
+// ContextSetDeleteResult writes r into the slot. Subsequent writes overwrite
+// the previous value. Does nothing if no slot was registered.
+func ContextSetDeleteResult(ctx context.Context, r *storage.DeleteResult) {
+	if slot, ok := ctx.Value(deleteResultSlotKey).(*deleteResultSlot); ok {
+		slot.result = r
+	}
+}
+
+// ContextGetDeleteResult returns the delete result written by the storage
+// driver, or nil if none was set.
+func ContextGetDeleteResult(ctx context.Context) *storage.DeleteResult {
+	if slot, ok := ctx.Value(deleteResultSlotKey).(*deleteResultSlot); ok {
 		return slot.result
 	}
 	return nil


### PR DESCRIPTION
## Summary

  The `Delete` flow previously relied on a couple of awkward patterns to ferry data from the storage driver up to the events interceptor — the deleted file's id was stuffed into `DeleteResponse.Opaque["opaque_id"]`, and the space owner traveled through a context channel
  (`ContextSendSpaceOwnerID`). Both worked, but they were stringly-typed and easy to lose track of. This PR replaces them with a typed return value.

  `storage.FS.Delete` now returns a `*storage.DeleteResult` alongside the error. The struct carries the two pieces of information the events interceptor needs:

  ```go
  type DeleteResult struct {
      SpaceOwner *userpb.UserId
      ResourceId *provider.ResourceId
  }
```
  Drivers that have rich data (decomposedfs) populate the result; drivers that don't (s3, eosfs, localfs, ...) return an empty &DeleteResult{} and the conversion layer falls back to req.Ref when building the event. Either way, the published ItemTrashed payload stays
  structurally identical to before.

  To get the typed result from the driver to the events interceptor without changing the gRPC protobuf, the storageprovider writes it into a DeleteResultSlot registered in the context — a small mutable container the interceptor allocates before the handler runs and reads
  back after. Same trick as the existing sendOwnerChan pattern, but typed and one-shot.

  A few related cleanups come along for the ride:

  - The GetMD pre-flight in storageprovider.Delete is gone. Its only remaining purpose was the "is this file still processing?" check, which now lives inside decomposedfs.Delete (the only driver that has a notion of "processing"). The gRPC service stops paying for an
  extra round-trip on every delete across every backend.
  - The processing check returns errtypes.TooEarly, which is now wired through NewStatusFromErrType to map cleanly to CODE_TOO_EARLY on the wire — same response code as before, just produced from a typed error instead of an inline Status construction.
  - The ContextSendSpaceOwnerID call inside decomposedfs.Delete is removed; the owner is now part of the typed return.

  Acceptance criteria

  - [x] GetMD call in storageprovider.Delete() removed
  - [x] DeleteResponse.Opaque["opaque_id"] smuggling removed
  - [x] ContextSendSpaceOwnerID no longer called from the driver for Delete

  Test plan

  - [x] go build ./... and go vet ./... pass
  - [x] Existing decomposedfs Delete tests still pass; a new test asserts that DeleteResult is populated
  - [x] New eventsmiddleware/conversion_test.go covers the four scenarios ItemTrashed can encounter (typed result, empty result, nil result, driver supplies a full ResourceId)
  - [x] Verified end-to-end against ocis: deleting a file produces an ItemTrashed event whose payload (SpaceOwner, Executant, ID.{storage_id, space_id, opaque_id}, Ref) matches the pre-PR baseline