### PR TITLE
Autoprop

### DIFF
--- a/internal/grpc/interceptors/auth/auth.go
+++ b/internal/grpc/interceptors/auth/auth.go
@@ -20,7 +20,6 @@ package auth
 
 import (
 	"context"
-	"slices"
 	"sync"
 	"time"
 
@@ -43,7 +42,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
 
@@ -160,8 +158,8 @@ func NewUnary(m map[string]interface{}, unprotected []string, tp trace.TracerPro
 		// TODO: MFA enforcement should be moved to the individual service level, so each service can
 		// decide which endpoints require MFA and which are accessible without it.
 		if conf.MFAEnabled && u.Id.Type != userpb.UserType_USER_TYPE_SERVICE {
-			if mfav := metadata.ValueFromIncomingContext(ctx, ctxpkg.MFAOutgoingHeader); !slices.Contains(mfav, "true") {
-				log.Warn().Str("user_id", u.Id.OpaqueId).Strs("mfa_values", mfav).Msg("MFA is required")
+			if !ctxpkg.HasMFA(ctx) {
+				log.Warn().Str("user_id", u.Id.OpaqueId).Msg("MFA is required")
 				return mfaResponse(ctx, req, info)
 			}
 		}
@@ -257,8 +255,8 @@ func NewStream(m map[string]interface{}, unprotected []string, tp trace.TracerPr
 		// TODO: MFA enforcement should be moved to the individual service level, so each service can
 		// decide which endpoints require MFA and which are accessible without it.
 		if conf.MFAEnabled && u.Id.Type != userpb.UserType_USER_TYPE_SERVICE {
-			if mfav := metadata.ValueFromIncomingContext(ctx, ctxpkg.MFAOutgoingHeader); !slices.Contains(mfav, "true") {
-				log.Warn().Str("user_id", u.Id.OpaqueId).Strs("mfa_values", mfav).Msg("MFA is required")
+			if !ctxpkg.HasMFA(ctx) {
+				log.Warn().Str("user_id", u.Id.OpaqueId).Msg("MFA is required")
 				return status.Errorf(codes.PermissionDenied, "MFA required to access vault storage")
 			}
 		}

--- a/internal/http/interceptors/auth/auth.go
+++ b/internal/http/interceptors/auth/auth.go
@@ -355,13 +355,6 @@ func ctxWithUserInfo(ctx context.Context, r *http.Request, user *userpb.User, to
 	ctx = metadata.AppendToOutgoingContext(ctx, ctxpkg.InitiatorHeader, initiatorid)
 	ctx = ctxpkg.ContextSetScopes(ctx, tokenScope)
 
-	// Forward MFA status from the proxy's HTTP header into outgoing gRPC metadata.
-	// Using the autoprop-prefixed key causes the metadata interceptor to propagate
-	// it automatically at every subsequent gRPC hop.
-	if mfaVal := r.Header.Get(ctxpkg.MFAHeader); mfaVal != "" {
-		ctx = metadata.AppendToOutgoingContext(ctx, ctxpkg.MFAOutgoingHeader, mfaVal)
-	}
-
 	return ctx
 }
 

--- a/pkg/auth/manager/publicshares/bruteforceprotection.go
+++ b/pkg/auth/manager/publicshares/bruteforceprotection.go
@@ -9,10 +9,10 @@ import (
 	"time"
 
 	"github.com/owncloud/reva/v2/pkg/appctx"
+	"github.com/owncloud/reva/v2/pkg/autoprop"
 	"github.com/owncloud/reva/v2/pkg/rgrpc"
 	"github.com/rs/zerolog"
 	microstore "go-micro.dev/v4/store"
-	"google.golang.org/grpc/metadata"
 )
 
 const (
@@ -303,7 +303,7 @@ const outgoingContextKey = rgrpc.AutoPropPrefix + "bfp-skip"
 // assuming the metadata interceptors are in place (check
 // internal/grpc/interceptors/metadata/metadata.go)
 func MarkSkipAttemptContext(ctx context.Context, shareToken string) context.Context {
-	return metadata.AppendToOutgoingContext(ctx, outgoingContextKey, shareToken)
+	return autoprop.AppendMetaToContext(ctx, "bfp-skip", shareToken)
 }
 
 // CheckSkipAttempt will check whether we should skip the brute force
@@ -315,8 +315,12 @@ func MarkSkipAttemptContext(ctx context.Context, shareToken string) context.Cont
 // share token as "to skip" (from the MarkSkipAttemptContext method). If there
 // is no such data, it will return false.
 func CheckSkipAttempt(ctx context.Context, shareToken string) bool {
-	possibleValues := metadata.ValueFromIncomingContext(ctx, outgoingContextKey)
-	if possibleValues == nil || len(possibleValues) < 1 {
+	meta := autoprop.GetMetaFromContext(ctx)
+	if meta == nil {
+		return false
+	}
+	possibleValues, exists := meta.GetMetaWithExists("bfp-skip")
+	if !exists || len(possibleValues) < 1 {
 		return false
 	}
 

--- a/pkg/autoprop/gogrpc.go
+++ b/pkg/autoprop/gogrpc.go
@@ -1,0 +1,74 @@
+package autoprop
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+)
+
+// GetGoGRPCUnaryClientInterceptor will create a new UnaryClientInterceptor
+// that will include the oCIS metadata present in the context. The keys from
+// the metadata will have the AutoPropPrefix prepended so they can be easily
+// identified and propagated.
+func GetGoGRPCUnaryClientInterceptor() grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		outCtx := moveOcisMetaToOutgoingContext(ctx)
+		return invoker(outCtx, method, req, reply, cc, opts...)
+	}
+}
+
+// GetGoGRPCStreamClientInterceptor will create a new StreamClientInterceptor
+// that will include the oCIS metadata present in the context. The keys from
+// the metadata will have the AutoPropPrefix prepended so they can be easily
+// identified and propagated.
+func GetGoGRPCStreamClientInterceptor() grpc.StreamClientInterceptor {
+	return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+		outCtx := moveOcisMetaToOutgoingContext(ctx)
+		return streamer(outCtx, desc, cc, method, opts...)
+	}
+}
+
+// GetGoGRPCUnaryServerInterceptor will create a new UnaryServerInterceptor
+// that will copy the incoming context values to the oCIS metadata. Only the
+// keys prepended with the AutoPropPrefix will be copied.
+// This method also set the oCIS metadata in the context.
+// NOTE: keys without the AutoPropPrefix will still be available (in the
+// incoming context, not in the oCIS metadata).
+func GetGoGRPCUnaryServerInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		newCtx := moveIncomingContextToOcisMeta(ctx)
+		return handler(newCtx, req)
+	}
+}
+
+// GetGoGRPCStreamServerInterceptor will create a new StreamServerInterceptor
+// that will copy the incoming context values to the oCIS metadata. Only the
+// keys prepended with the AutoPropPrefix will be copied.
+// This method also set the oCIS metadata in the context.
+// NOTE: keys without the AutoPropPrefix will still be available (in the
+// incoming context, not in the oCIS metadata).
+func GetGoGRPCStreamServerInterceptor() grpc.StreamServerInterceptor {
+	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		ctx := ss.Context()
+		newCtx := moveIncomingContextToOcisMeta(ctx)
+
+		wrapped := newWrappedServerStream(newCtx, ss)
+		return handler(srv, wrapped)
+	}
+}
+
+// newWrappedServerStream returns a wrapped server stream in order to customize
+// the GRPC server stream's context. It will use the one provided.
+func newWrappedServerStream(ctx context.Context, ss grpc.ServerStream) *wrappedServerStream {
+	return &wrappedServerStream{ServerStream: ss, newCtx: ctx}
+}
+
+type wrappedServerStream struct {
+	grpc.ServerStream
+	newCtx context.Context
+}
+
+// Context returns the context of the server stream
+func (ss *wrappedServerStream) Context() context.Context {
+	return ss.newCtx
+}

--- a/pkg/autoprop/gohttp.go
+++ b/pkg/autoprop/gohttp.go
@@ -27,8 +27,9 @@ type autoPropRoundTripper struct {
 // the autopropagation data from the context into the request headers before
 // sending the modified request to the base RoundTripper
 func (rt *autoPropRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
-	moveOcisMetaToHttpHeaders(r, r.Context())
-	return rt.base.RoundTrip(r)
+	r2 := r.Clone(r.Context())
+	moveOcisMetaToHttpHeaders(r2, r.Context())
+	return rt.base.RoundTrip(r2)
 }
 
 // NewHttpRoundTripper creates a new instance of the autoPropRoundTripper.

--- a/pkg/autoprop/gohttp.go
+++ b/pkg/autoprop/gohttp.go
@@ -1,0 +1,47 @@
+package autoprop
+
+import (
+	"context"
+	"net/http"
+)
+
+// NewHttpHandler creates a new HTTP server handler to inject the custom
+// HTTP autoprogation headers in the request context.
+func NewHttpHandler() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := moveHttpHeadersToOcisMeta(r, r.Context())
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+// autoPropRoundTripper will inject the autopropagation data in the context
+// inside the HTTP headers. A base RoundTripper is needed, so use
+// NewHttpRoundTripper with a base RoundTripper to create an instance
+type autoPropRoundTripper struct {
+	base http.RoundTripper
+}
+
+// RoundTrip implements the RoundTripper interface. This method will inject
+// the autopropagation data from the context into the request headers before
+// sending the modified request to the base RoundTripper
+func (rt *autoPropRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	moveOcisMetaToHttpHeaders(r, r.Context())
+	return rt.base.RoundTrip(r)
+}
+
+// NewHttpRoundTripper creates a new instance of the autoPropRoundTripper.
+// This is used by the HTTP clients to inject the autopropagation headers
+// in the HTTP requests.
+func NewHttpRoundTripper(base http.RoundTripper) http.RoundTripper {
+	return &autoPropRoundTripper{
+		base: base,
+	}
+}
+
+// AppendToHttpRequest adds the autopropagation data as HTTP headers in the
+// provided request.
+func AppendToHttpRequest(r *http.Request, ctx context.Context) {
+	moveOcisMetaToHttpHeaders(r, ctx)
+}

--- a/pkg/autoprop/gomicro.go
+++ b/pkg/autoprop/gomicro.go
@@ -1,0 +1,64 @@
+package autoprop
+
+import (
+	"context"
+
+	"go-micro.dev/v4/client"
+	"go-micro.dev/v4/registry"
+	"go-micro.dev/v4/server"
+)
+
+func NewGoMicroClientCallWrapper() client.CallWrapper {
+	return func(cf client.CallFunc) client.CallFunc {
+		return func(ctx context.Context, node *registry.Node, req client.Request, rsp interface{}, opts client.CallOptions) error {
+			newCtx := moveOcisMetaToOutgoingContext(ctx)
+			return cf(newCtx, node, req, rsp, opts)
+		}
+	}
+}
+
+func NewGoMicroServerHandlerWrapper() server.HandlerWrapper {
+	return func(h server.HandlerFunc) server.HandlerFunc {
+		return func(ctx context.Context, req server.Request, rsp interface{}) error {
+			newCtx := moveIncomingContextToOcisMeta(ctx)
+			return h(newCtx, req, rsp)
+		}
+	}
+}
+
+func NewGoMicroServerSubscriberWrapper() server.SubscriberWrapper {
+	return func(next server.SubscriberFunc) server.SubscriberFunc {
+		return func(ctx context.Context, msg server.Message) error {
+			newCtx := moveIncomingContextToOcisMeta(ctx)
+			return next(newCtx, msg)
+		}
+	}
+}
+
+func NewGoMicroClientWrapper() client.Wrapper {
+	return func(c client.Client) client.Client {
+		w := &clientWrapper{
+			Client: c,
+		}
+		return w
+	}
+}
+
+type clientWrapper struct {
+	client.Client
+}
+
+func (w *clientWrapper) Call(ctx context.Context, req client.Request, rsp interface{}, opts ...client.CallOption) error {
+	newCtx := moveOcisMetaToOutgoingContext(ctx)
+	return w.Client.Call(newCtx, req, rsp, opts...)
+}
+
+func (w *clientWrapper) Stream(ctx context.Context, req client.Request, opts ...client.CallOption) (client.Stream, error) {
+	newCtx := moveOcisMetaToOutgoingContext(ctx)
+	return w.Client.Stream(newCtx, req, opts...)
+}
+
+func (w *clientWrapper) Publish(ctx context.Context, p client.Message, opts ...client.PublishOption) error {
+	newCtx := moveOcisMetaToOutgoingContext(ctx)
+	return w.Client.Publish(newCtx, p, opts...)
+}

--- a/pkg/autoprop/gomicro.go
+++ b/pkg/autoprop/gomicro.go
@@ -11,7 +11,7 @@ import (
 func NewGoMicroClientCallWrapper() client.CallWrapper {
 	return func(cf client.CallFunc) client.CallFunc {
 		return func(ctx context.Context, node *registry.Node, req client.Request, rsp interface{}, opts client.CallOptions) error {
-			newCtx := moveOcisMetaToOutgoingContext(ctx)
+			newCtx := moveOcisMetaToGoMicroMetadata(ctx)
 			return cf(newCtx, node, req, rsp, opts)
 		}
 	}
@@ -20,7 +20,7 @@ func NewGoMicroClientCallWrapper() client.CallWrapper {
 func NewGoMicroServerHandlerWrapper() server.HandlerWrapper {
 	return func(h server.HandlerFunc) server.HandlerFunc {
 		return func(ctx context.Context, req server.Request, rsp interface{}) error {
-			newCtx := moveIncomingContextToOcisMeta(ctx)
+			newCtx := moveGoMicroMetadataToOcisMeta(ctx)
 			return h(newCtx, req, rsp)
 		}
 	}
@@ -29,7 +29,7 @@ func NewGoMicroServerHandlerWrapper() server.HandlerWrapper {
 func NewGoMicroServerSubscriberWrapper() server.SubscriberWrapper {
 	return func(next server.SubscriberFunc) server.SubscriberFunc {
 		return func(ctx context.Context, msg server.Message) error {
-			newCtx := moveIncomingContextToOcisMeta(ctx)
+			newCtx := moveGoMicroMetadataToOcisMeta(ctx)
 			return next(newCtx, msg)
 		}
 	}
@@ -49,16 +49,16 @@ type clientWrapper struct {
 }
 
 func (w *clientWrapper) Call(ctx context.Context, req client.Request, rsp interface{}, opts ...client.CallOption) error {
-	newCtx := moveOcisMetaToOutgoingContext(ctx)
+	newCtx := moveOcisMetaToGoMicroMetadata(ctx)
 	return w.Client.Call(newCtx, req, rsp, opts...)
 }
 
 func (w *clientWrapper) Stream(ctx context.Context, req client.Request, opts ...client.CallOption) (client.Stream, error) {
-	newCtx := moveOcisMetaToOutgoingContext(ctx)
+	newCtx := moveOcisMetaToGoMicroMetadata(ctx)
 	return w.Client.Stream(newCtx, req, opts...)
 }
 
 func (w *clientWrapper) Publish(ctx context.Context, p client.Message, opts ...client.PublishOption) error {
-	newCtx := moveOcisMetaToOutgoingContext(ctx)
+	newCtx := moveOcisMetaToGoMicroMetadata(ctx)
 	return w.Client.Publish(newCtx, p, opts...)
 }

--- a/pkg/autoprop/meta.go
+++ b/pkg/autoprop/meta.go
@@ -1,0 +1,189 @@
+package autoprop
+
+import (
+	"context"
+	"encoding/json"
+	"slices"
+	"sync"
+)
+
+// Meta contains generic metadata that should be kept in the context
+// It's stored in thread-safe, key-value map
+type Meta struct {
+	rwmutex  sync.RWMutex
+	metadata map[string][]string
+}
+
+// NewMeta creates a new empty instance of Meta
+func NewMeta() *Meta {
+	return &Meta{
+		// rwmutex is autoinitialized
+		metadata: make(map[string][]string),
+	}
+}
+
+// NewMetaFromJsonString creates a new instance of Meta from the provided
+// string.
+// This is just a convenient method for a NewMeta + FromJsonString. As such,
+// if the json string can't be unmarshalled, an empty Meta instance will be
+// returned.
+func NewMetaFromJsonString(j string) *Meta {
+	meta := NewMeta()
+	meta.FromJsonString(j)
+	return meta
+}
+
+// AppendMeta appends a new value for the key.
+func (m *Meta) AppendMeta(key, value string) {
+	m.rwmutex.Lock()
+	defer m.rwmutex.Unlock()
+
+	_, ok := m.metadata[key]
+	if ok {
+		m.metadata[key] = append(m.metadata[key], value)
+	} else {
+		m.metadata[key] = []string{value}
+	}
+}
+
+// GetMeta gets the values for the provided key, or a list containing just
+// the default value (def) if the key doesn't exists
+func (m *Meta) GetMeta(key, def string) []string {
+	m.rwmutex.RLock()
+	defer m.rwmutex.RUnlock()
+
+	val, ok := m.metadata[key]
+	if !ok {
+		return []string{def}
+	}
+	return val
+}
+
+// GetMetaWithExists gets the values of a key and "true" if the key exists, or
+// an empty string list and "false" if the key doesn't exist.
+// The `GetMeta` method should be preferred.
+func (m *Meta) GetMetaWithExists(key string) ([]string, bool) {
+	m.rwmutex.RLock()
+	defer m.rwmutex.RUnlock()
+
+	val, ok := m.metadata[key]
+	return val, ok
+}
+
+// Create a new Meta instance. All the keys and values will be copied over,
+// and the new instance will be completely separated (both the old and new
+// instances can be modified separately)
+func (m *Meta) CreateCopy() *Meta {
+	m.rwmutex.Lock()
+	defer m.rwmutex.Unlock()
+
+	data := make(map[string][]string, len(m.metadata))
+	for k, v := range m.metadata {
+		data[k] = slices.Clone(v)
+	}
+
+	newMeta := &Meta{
+		// rwmutex is autoinitialized
+		metadata: data,
+	}
+	return newMeta
+}
+
+// CreateCopyAsMap creates a copy of the data in this instance and returns
+// it as a map[string][]string.
+// The returned instance can be modified independently
+func (m *Meta) CreateCopyAsMap(prefix string) map[string][]string {
+	m.rwmutex.Lock()
+	defer m.rwmutex.Unlock()
+
+	data := make(map[string][]string, len(m.metadata))
+	for k, v := range m.metadata {
+		data[prefix+k] = slices.Clone(v)
+	}
+	return data
+}
+
+// ToJsonString returns a json string of the metadata currently stored
+// inside the instance.
+// It might return an empty string if there are problems with the marshalling
+func (m *Meta) ToJsonString() string {
+	m.rwmutex.RLock()
+	defer m.rwmutex.RUnlock()
+
+	jsonBytes, _ := json.Marshal(m.metadata)
+	return string(jsonBytes)
+}
+
+// FromJsonString uses the passed string as json and, if successful, it
+// overwrites the stored metadata information of this instance.
+// FromJsonString is expected to be used along with ToJsonString in order
+// to serialize the information.
+func (m *Meta) FromJsonString(j string) {
+	m.rwmutex.Lock()
+	defer m.rwmutex.Unlock()
+
+	var metaCopy map[string][]string
+	if json.Unmarshal([]byte(j), &metaCopy) == nil {
+		m.metadata = metaCopy
+	}
+}
+
+type ctxMetaKey struct{}
+
+// GetMetaFromContext gets the Meta from the context or nil if there is no
+// Meta in the context.
+// NOTE: a pointer to the instance is returned. This means that the instance
+// can be dynamically modified in different parts of the code. This is
+// intentional because we don't want to create new contexts whenever we update
+// the metadata.
+func GetMetaFromContext(ctx context.Context) *Meta {
+	meta := ctx.Value(ctxMetaKey{})
+	if meta == nil {
+		return nil
+	}
+	return meta.(*Meta)
+}
+
+// SetMetaToContext creates a new context with the provided metadata.
+// The old context can still access to the old metadata.
+func SetMetaToContext(ctx context.Context, meta *Meta) context.Context {
+	return context.WithValue(ctx, ctxMetaKey{}, meta)
+}
+
+// CopyMetaToContext copies the metadata from the old context to the newly
+// created one (new context is derived from the old). The metadata from the
+// old context and the metadata from the new one are completely different
+// and can be modified independently.
+// If the old context doesn't have associated metadata, a new Meta instance
+// will be used.
+//
+// This can be used right before starting new goroutines: we don't want
+// different goroutines to modify the metadata of eachother.
+func CopyMetaToContext(ctx context.Context) context.Context {
+	meta := GetMetaFromContext(ctx)
+	if meta == nil {
+		meta = NewMeta()
+	}
+
+	copiedMeta := meta.CreateCopy()
+	return SetMetaToContext(ctx, copiedMeta)
+}
+
+// AppendMetaToContext will add a new key-value to the meta in the context.
+// If the meta doesn't exist, a new one will be created and included in
+// the returned context.
+// Note that if the provided context already has a meta in it, no new
+// context will be created, and the provided one will be returned (with
+// the data appended in the meta).
+// This method will use the meta.AppendMeta function, so if the key is
+// already present, the value will be appended instead of replacing the
+// existing value.
+func AppendMetaToContext(ctx context.Context, key, value string) context.Context {
+	meta := GetMetaFromContext(ctx)
+	if meta == nil {
+		meta = NewMeta()
+		ctx = SetMetaToContext(ctx, meta)
+	}
+	meta.AppendMeta(key, value)
+	return ctx
+}

--- a/pkg/autoprop/meta.go
+++ b/pkg/autoprop/meta.go
@@ -99,8 +99,8 @@ func (m *Meta) Len() int {
 // and the new instance will be completely separated (both the old and new
 // instances can be modified separately)
 func (m *Meta) CreateCopy() *Meta {
-	m.rwmutex.Lock()
-	defer m.rwmutex.Unlock()
+	m.rwmutex.RLock()
+	defer m.rwmutex.RUnlock()
 
 	data := make(map[string][]string, len(m.metadata))
 	for k, v := range m.metadata {
@@ -118,8 +118,8 @@ func (m *Meta) CreateCopy() *Meta {
 // it as a map[string][]string.
 // The returned instance can be modified independently
 func (m *Meta) CreateCopyAsMap(prefix string) map[string][]string {
-	m.rwmutex.Lock()
-	defer m.rwmutex.Unlock()
+	m.rwmutex.RLock()
+	defer m.rwmutex.RUnlock()
 
 	data := make(map[string][]string, len(m.metadata))
 	for k, v := range m.metadata {

--- a/pkg/autoprop/meta.go
+++ b/pkg/autoprop/meta.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"slices"
+	"strings"
 	"sync"
 )
 
@@ -34,25 +35,40 @@ func NewMetaFromJsonString(j string) *Meta {
 }
 
 // AppendMeta appends a new value for the key.
+// The key will be converted to lowercase.
 func (m *Meta) AppendMeta(key, value string) {
 	m.rwmutex.Lock()
 	defer m.rwmutex.Unlock()
 
-	_, ok := m.metadata[key]
+	internalKey := strings.ToLower(key)
+	_, ok := m.metadata[internalKey]
 	if ok {
-		m.metadata[key] = append(m.metadata[key], value)
+		m.metadata[internalKey] = append(m.metadata[internalKey], value)
 	} else {
-		m.metadata[key] = []string{value}
+		m.metadata[internalKey] = []string{value}
 	}
 }
 
+// DeleteMeta deletes the provided key. All the values associated to the
+// key will be deleted.
+// The key will be converted to lowercase.
+func (m *Meta) DeleteMeta(key string) {
+	m.rwmutex.Lock()
+	defer m.rwmutex.Unlock()
+
+	internalKey := strings.ToLower(key)
+	delete(m.metadata, internalKey)
+}
+
 // GetMeta gets the values for the provided key, or a list containing just
-// the default value (def) if the key doesn't exists
+// the default value (def) if the key doesn't exists.
+// The key will be converted to lowercase.
 func (m *Meta) GetMeta(key, def string) []string {
 	m.rwmutex.RLock()
 	defer m.rwmutex.RUnlock()
 
-	val, ok := m.metadata[key]
+	internalKey := strings.ToLower(key)
+	val, ok := m.metadata[internalKey]
 	if !ok {
 		return []string{def}
 	}
@@ -61,13 +77,22 @@ func (m *Meta) GetMeta(key, def string) []string {
 
 // GetMetaWithExists gets the values of a key and "true" if the key exists, or
 // an empty string list and "false" if the key doesn't exist.
-// The `GetMeta` method should be preferred.
+// The key will be converted to lowercase.
 func (m *Meta) GetMetaWithExists(key string) ([]string, bool) {
 	m.rwmutex.RLock()
 	defer m.rwmutex.RUnlock()
 
-	val, ok := m.metadata[key]
+	internalKey := strings.ToLower(key)
+	val, ok := m.metadata[internalKey]
 	return val, ok
+}
+
+// Len gets the number of elements keys in the metadata.
+func (m *Meta) Len() int {
+	m.rwmutex.RLock()
+	defer m.rwmutex.RUnlock()
+
+	return len(m.metadata)
 }
 
 // Create a new Meta instance. All the keys and values will be copied over,
@@ -160,13 +185,24 @@ func SetMetaToContext(ctx context.Context, meta *Meta) context.Context {
 // This can be used right before starting new goroutines: we don't want
 // different goroutines to modify the metadata of eachother.
 func CopyMetaToContext(ctx context.Context) context.Context {
-	meta := GetMetaFromContext(ctx)
+	return CopyMetaFromContextToContext(ctx, ctx)
+}
+
+// CopyMetaFromContextToContext copies the meta from the "in" context to
+// the "out" context. The meta from both contexts can be modified
+// independently.
+// The returned context will be derived from the "out" context.
+// If the "in" context doesn't have a meta, a new meta instance will be
+// used, so the returned context is guaranteed to have a meta, although
+// it could be empty.
+func CopyMetaFromContextToContext(in, out context.Context) context.Context {
+	meta := GetMetaFromContext(in)
 	if meta == nil {
 		meta = NewMeta()
 	}
 
 	copiedMeta := meta.CreateCopy()
-	return SetMetaToContext(ctx, copiedMeta)
+	return SetMetaToContext(out, copiedMeta)
 }
 
 // AppendMetaToContext will add a new key-value to the meta in the context.

--- a/pkg/autoprop/utils.go
+++ b/pkg/autoprop/utils.go
@@ -1,0 +1,99 @@
+package autoprop
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"google.golang.org/grpc/metadata"
+)
+
+const (
+	GRPCAutoPropPrefix = "autoprop-"
+	HTTPAutoPropPrefix = "X-OCIS-Autoprop-"
+)
+
+// moveOcisMetaToOutgoingContext will copy the values from the oCIS meta to
+// the outgoing context so the data is sent through the GRPC call.
+// Keys from the oCIS metadata will have the AutoPropPrefix prepended so
+// they're easier to identify.
+func moveOcisMetaToOutgoingContext(ctx context.Context) context.Context {
+	md := metadata.Pairs()
+
+	meta := GetMetaFromContext(ctx)
+	if meta != nil {
+		for key, values := range meta.CreateCopyAsMap(GRPCAutoPropPrefix) {
+			md.Set(key, values...)
+		}
+	}
+
+	md2, exists := metadata.FromOutgoingContext(ctx)
+	if exists {
+		md = metadata.Join(md, md2)
+	}
+
+	return metadata.NewOutgoingContext(ctx, md)
+}
+
+// moveIncomingContextToOcisMeta will copy the incoming GRPC context values to
+// the oCIS meta. The oCIS meta will be set in the new returned context.
+// Only keys with the AutoPropPrefix will be copied.
+func moveIncomingContextToOcisMeta(ctx context.Context) context.Context {
+	meta, isNew := GetMetaFromContext(ctx), false
+	if meta == nil {
+		meta = NewMeta()
+		isNew = true
+	}
+
+	md, ok := metadata.FromIncomingContext(ctx)
+	if ok {
+		for key, values := range md {
+			if unprefixedKey, hasPrefix := strings.CutPrefix(key, GRPCAutoPropPrefix); hasPrefix {
+				for _, value := range values {
+					meta.AppendMeta(unprefixedKey, value)
+				}
+			}
+		}
+	}
+
+	if isNew {
+		return SetMetaToContext(ctx, meta)
+	}
+	// No need to create new context if there is metadata in the context
+	// because it's already updated. Just return the previous context
+	return ctx
+}
+
+func moveOcisMetaToHttpHeaders(r *http.Request, ctx context.Context) {
+	meta := GetMetaFromContext(ctx)
+	if meta != nil {
+		for key, values := range meta.CreateCopyAsMap(HTTPAutoPropPrefix) {
+			for _, value := range values {
+				r.Header.Add(key, value)
+			}
+		}
+	}
+}
+
+func moveHttpHeadersToOcisMeta(r *http.Request, ctx context.Context) context.Context {
+	meta, isNew := GetMetaFromContext(ctx), false
+	if meta == nil {
+		meta = NewMeta()
+		isNew = true
+	}
+
+	for key, values := range r.Header {
+		if unprefixedKey, hasPrefix := strings.CutPrefix(key, HTTPAutoPropPrefix); hasPrefix {
+			for _, value := range values {
+				meta.AppendMeta(unprefixedKey, value)
+			}
+		}
+	}
+
+	if isNew {
+		return SetMetaToContext(ctx, meta)
+	}
+	// No need to create new context if there is metadata in the context
+	// because it's already updated. Just return the same request
+	return ctx
+}

--- a/pkg/autoprop/utils.go
+++ b/pkg/autoprop/utils.go
@@ -5,12 +5,14 @@ import (
 	"net/http"
 	"strings"
 
+	micrometa "go-micro.dev/v4/metadata"
 	"google.golang.org/grpc/metadata"
 )
 
 const (
-	GRPCAutoPropPrefix = "autoprop-"
-	HTTPAutoPropPrefix = "X-OCIS-Autoprop-"
+	GRPCAutoPropPrefix  = "autoprop-"
+	HTTPAutoPropPrefix  = "X-Ocis-Autoprop-"
+	MicroAutoPropPrefix = "M-Ocis-Autoprop-"
 )
 
 // moveOcisMetaToOutgoingContext will copy the values from the oCIS meta to
@@ -69,6 +71,7 @@ func moveOcisMetaToHttpHeaders(r *http.Request, ctx context.Context) {
 	if meta != nil {
 		for key, values := range meta.CreateCopyAsMap(HTTPAutoPropPrefix) {
 			for _, value := range values {
+				// http.CanonicalHeaderKey(...) is done while adding the key-value
 				r.Header.Add(key, value)
 			}
 		}
@@ -82,8 +85,9 @@ func moveHttpHeadersToOcisMeta(r *http.Request, ctx context.Context) context.Con
 		isNew = true
 	}
 
+	canonicalPrefix := http.CanonicalHeaderKey(HTTPAutoPropPrefix)
 	for key, values := range r.Header {
-		if unprefixedKey, hasPrefix := strings.CutPrefix(key, HTTPAutoPropPrefix); hasPrefix {
+		if unprefixedKey, hasPrefix := strings.CutPrefix(key, canonicalPrefix); hasPrefix {
 			for _, value := range values {
 				meta.AppendMeta(unprefixedKey, value)
 			}
@@ -95,5 +99,43 @@ func moveHttpHeadersToOcisMeta(r *http.Request, ctx context.Context) context.Con
 	}
 	// No need to create new context if there is metadata in the context
 	// because it's already updated. Just return the same request
+	return ctx
+}
+
+func moveOcisMetaToGoMicroMetadata(ctx context.Context) context.Context {
+	meta := GetMetaFromContext(ctx)
+	if meta != nil {
+		md := make(micrometa.Metadata, meta.Len())
+		for key, values := range meta.CreateCopyAsMap(MicroAutoPropPrefix) {
+			md.Set(key, strings.Join(values, "|||"))
+		}
+		return micrometa.MergeContext(ctx, md, true)
+	}
+	return ctx
+}
+
+func moveGoMicroMetadataToOcisMeta(ctx context.Context) context.Context {
+	meta, isNew := GetMetaFromContext(ctx), false
+	if meta == nil {
+		meta = NewMeta()
+		isNew = true
+	}
+
+	md, ok := micrometa.FromContext(ctx)
+	if ok {
+		for key, values := range md {
+			if unprefixedKey, hasPrefix := strings.CutPrefix(key, MicroAutoPropPrefix); hasPrefix {
+				for _, value := range strings.Split(values, "|||") {
+					meta.AppendMeta(unprefixedKey, value)
+				}
+			}
+		}
+	}
+
+	if isNew {
+		return SetMetaToContext(ctx, meta)
+	}
+	// No need to create new context if there is metadata in the context
+	// because it's already updated. Just return the previous context
 	return ctx
 }

--- a/pkg/ctx/mfactx.go
+++ b/pkg/ctx/mfactx.go
@@ -27,9 +27,10 @@ func SetMFA(ctx context.Context) context.Context {
 
 // RemoveMFA removes the MFA status from the context.
 // The meta associated to the provided context will be copied, and the MFA
-// status will be removed from the copied context. Previous MFA status
-// will still be available in the old context if needed.
-// The copied context will be returned.
+// status will be removed from the copied context. The copied context
+// will be returned.
+//
+// WARNING: Previous MFA status will still be available in the old context.
 func RemoveMFA(ctx context.Context) context.Context {
 	ctx2 := autoprop.CopyMetaToContext(ctx) // ensures ctx2 to have a meta
 	meta := autoprop.GetMetaFromContext(ctx2)

--- a/pkg/ctx/mfactx.go
+++ b/pkg/ctx/mfactx.go
@@ -2,25 +2,52 @@ package ctx
 
 import (
 	"context"
+	"slices"
 
-	"google.golang.org/grpc/metadata"
+	"github.com/owncloud/reva/v2/pkg/autoprop"
 )
 
-// MFAOutgoingHeader is the gRPC metadata key used to propagate MFA status across
-// service boundaries. The "autoprop-" prefix causes the metadata interceptor
-// (internal/grpc/interceptors/metadata) to forward it automatically at every
-// gRPC hop, so no manual re-forwarding is required.
-// Using rgrpc.AutoPropPrefix here would cause a cyclic import.
-const MFAOutgoingHeader = "autoprop-mfa-authenticated"
+const (
+	// key to use for auto-propagation. This key is exclusive to this package
+	autopropKey = "mfa-authenticated"
+)
 
-// The corresponding HTTP header set by the proxy is "X-Multi-Factor-Authentication".
-const MFAHeader = "X-Multi-Factor-Authentication"
-
-// AppendMFAToOutgoingContext adds the MFA status to the outgoing gRPC metadata.
-func AppendMFAToOutgoingContext(ctx context.Context, hasMFA bool) context.Context {
-	mfaVal := "false"
-	if hasMFA {
-		mfaVal = "true"
+// SetMFA sets the MFA status in the context and ensures it autopropagate
+// across service boundaries.
+// If the MFA is already set, this method will just return the passed context,
+// otherwise a new context (from the provided one) containing the MFA status
+// will be returned
+func SetMFA(ctx context.Context) context.Context {
+	// just return the same context if already set
+	if HasMFA(ctx) {
+		return ctx
 	}
-	return metadata.AppendToOutgoingContext(ctx, MFAOutgoingHeader, mfaVal)
+	return autoprop.AppendMetaToContext(ctx, autopropKey, "true")
+}
+
+// RemoveMFA removes the MFA status from the context.
+// The meta associated to the provided context will be copied, and the MFA
+// status will be removed from the copied context. Previous MFA status
+// will still be available in the old context if needed.
+// The copied context will be returned.
+func RemoveMFA(ctx context.Context) context.Context {
+	ctx2 := autoprop.CopyMetaToContext(ctx) // ensures ctx2 to have a meta
+	meta := autoprop.GetMetaFromContext(ctx2)
+	meta.DeleteMeta(autopropKey)
+	return ctx2
+}
+
+// HasMFA checks if the context has the MFA status. Use SetMFA to set it.
+func HasMFA(ctx context.Context) bool {
+	meta := autoprop.GetMetaFromContext(ctx)
+	if meta == nil {
+		return false
+	}
+
+	if values, exists := meta.GetMetaWithExists(autopropKey); exists {
+		if slices.Contains(values, "true") {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -23,10 +23,13 @@ import (
 	"log"
 	"reflect"
 
-	ctxpkg "github.com/owncloud/reva/v2/pkg/ctx"
 	"github.com/google/uuid"
+	"github.com/owncloud/reva/v2/pkg/autoprop"
+	ctxpkg "github.com/owncloud/reva/v2/pkg/ctx"
 	"go-micro.dev/v4/events"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
 )
 
 var (
@@ -47,6 +50,11 @@ var (
 
 	// MetadatakeyInitiatorID is the key used for the initiator id in the metadata map of the event
 	MetadatakeyInitiatorID = "initiatorid"
+
+	// MetadatakeyExtraInfo is the key used for the extra information associated to the event.
+	// This usually includes information that should be propagated across services.
+	// The information is a map[string][]string encoded as a JSON string
+	MetadatakeyExtraInfo = "extrainfo"
 )
 
 type (
@@ -77,6 +85,7 @@ type (
 		ID          string
 		TraceParent string
 		InitiatorID string
+		ExtraInfo   *autoprop.Meta
 		Event       interface{}
 	}
 )
@@ -112,11 +121,13 @@ func Consume(s Consumer, group string, evs ...Unmarshaller) (<-chan Event, error
 				continue
 			}
 
+			extraInfo := autoprop.NewMetaFromJsonString(e.Metadata[MetadatakeyExtraInfo])
 			outchan <- Event{
 				Type:        et,
 				ID:          e.Metadata[MetadatakeyEventID],
 				TraceParent: e.Metadata[MetadatakeyTraceParent],
 				InitiatorID: e.Metadata[MetadatakeyInitiatorID],
+				ExtraInfo:   extraInfo,
 				Event:       event,
 			}
 		}
@@ -135,11 +146,13 @@ func ConsumeAll(s Consumer, group string) (<-chan Event, error) {
 	go func() {
 		for {
 			e := <-c
+			extraInfo := autoprop.NewMetaFromJsonString(e.Metadata[MetadatakeyExtraInfo])
 			outchan <- Event{
 				Type:        e.Metadata[MetadatakeyEventType],
 				ID:          e.Metadata[MetadatakeyEventID],
 				TraceParent: e.Metadata[MetadatakeyTraceParent],
 				InitiatorID: e.Metadata[MetadatakeyInitiatorID],
+				ExtraInfo:   extraInfo,
 				Event:       e.Payload,
 			}
 		}
@@ -150,14 +163,23 @@ func ConsumeAll(s Consumer, group string) (<-chan Event, error) {
 // Publish publishes the ev to the MainQueue from where it is distributed to all subscribers
 // NOTE: needs to use reflect on runtime
 func Publish(ctx context.Context, s Publisher, ev interface{}) error {
+	prevSpan := trace.SpanFromContext(ctx)
+	ctx2, span := TraceEventProducer(ctx, prevSpan.TracerProvider(), ev)
+	defer span.End()
+
 	evName := reflect.TypeOf(ev).String()
-	traceParent := getTraceParentFromCtx(ctx)
-	iid, _ := ctxpkg.ContextGetInitiator(ctx)
+	traceParent := getTraceParentFromCtx(ctx2)
+	iid, _ := ctxpkg.ContextGetInitiator(ctx2)
+	meta := autoprop.GetMetaFromContext(ctx2)
+	if meta == nil {
+		meta = autoprop.NewMeta()
+	}
 	return s.Publish(MainQueueName, ev, events.WithMetadata(map[string]string{
 		MetadatakeyEventType:   evName,
 		MetadatakeyEventID:     uuid.New().String(),
 		MetadatakeyTraceParent: traceParent,
 		MetadatakeyInitiatorID: iid,
+		MetadatakeyExtraInfo:   meta.ToJsonString(),
 	}))
 }
 
@@ -177,4 +199,56 @@ func getTraceParentFromCtx(ctx context.Context) string {
 	tc := propagation.TraceContext{}
 	tc.Inject(ctx, &mc)
 	return mc["traceparent"]
+}
+
+// TraceEventProducer will add a span to trace an event producer.
+// The returned span needs to end manually (span.End()).
+// This is currently used in the Publish method, any published event will
+// be tracked. You shouldn't care about calling this method.
+func TraceEventProducer(ctx context.Context, tp trace.TracerProvider, evPayload interface{}) (context.Context, trace.Span) {
+	tracer := tp.Tracer("github.com/owncloud/reva/pkg/events")
+	evType := reflect.TypeOf(evPayload).String()
+	iid, _ := ctxpkg.ContextGetInitiator(ctx)
+
+	newCtx, span := tracer.Start(
+		ctx,
+		"Event "+evType,
+		trace.WithSpanKind(trace.SpanKindProducer),
+		trace.WithAttributes(
+			attribute.String("ocis.event.type", evType),
+			attribute.String("ocis.event.initiator", iid),
+		),
+	)
+	return newCtx, span
+}
+
+// TraceEventConsumer will trace an event consumer. Every event consumer needs
+// to call this method so the consumer is linked with the producer. The event
+// information is used to know who produced the event and link the traces.
+// The returned span needs to be closed manually.
+func TraceEventConsumer(ctx context.Context, tp trace.TracerProvider, ev Event) (context.Context, trace.Span) {
+	tracer := tp.Tracer("github.com/owncloud/reva/pkg/events")
+	return TraceEventConsumerWithTracer(ctx, tracer, ev)
+}
+
+// TraceEventConsumerWithTracer does the same as TraceEventConsumer, but using
+// a tracer instead of a tracerProvider
+func TraceEventConsumerWithTracer(ctx context.Context, tracer trace.Tracer, ev Event) (context.Context, trace.Span) {
+	evCtx := ev.GetTraceContext(ctx)
+
+	newCtx, span := tracer.Start(
+		ctx,
+		"Event "+ev.Type,
+		trace.WithNewRoot(),
+		trace.WithSpanKind(trace.SpanKindConsumer),
+		trace.WithAttributes(
+			attribute.String("ocis.event.type", ev.Type),
+			attribute.String("ocis.event.id", ev.ID),
+			attribute.String("ocis.event.initiator", ev.InitiatorID),
+		),
+		trace.WithLinks(
+			trace.LinkFromContext(evCtx),
+		),
+	)
+	return newCtx, span
 }

--- a/pkg/micro/ocdav/service.go
+++ b/pkg/micro/ocdav/service.go
@@ -22,19 +22,20 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+	httpServer "github.com/go-micro/plugins/v4/server/http"
+	"github.com/owncloud/ocis/v2/ocis-pkg/registry"
 	"github.com/owncloud/reva/v2/internal/http/interceptors/appctx"
 	"github.com/owncloud/reva/v2/internal/http/interceptors/auth"
 	cors2 "github.com/owncloud/reva/v2/internal/http/interceptors/cors"
 	revaLogMiddleware "github.com/owncloud/reva/v2/internal/http/interceptors/log"
 	"github.com/owncloud/reva/v2/internal/http/services/owncloud/ocdav"
+	"github.com/owncloud/reva/v2/pkg/autoprop"
 	"github.com/owncloud/reva/v2/pkg/rgrpc/todo/pool"
 	"github.com/owncloud/reva/v2/pkg/rhttp/global"
 	"github.com/owncloud/reva/v2/pkg/storage/favorite/memory"
 	rtrace "github.com/owncloud/reva/v2/pkg/trace"
-	"github.com/go-chi/chi/v5"
-	"github.com/go-chi/chi/v5/middleware"
-	httpServer "github.com/go-micro/plugins/v4/server/http"
-	"github.com/owncloud/ocis/v2/ocis-pkg/registry"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -159,6 +160,9 @@ func setDefaults(sopts *Options) error {
 }
 
 func useMiddlewares(r *chi.Mux, sopts *Options, svc global.Service, tp trace.TracerProvider) error {
+	// autoprop
+	autopropMid := autoprop.NewHttpHandler()
+
 	// auth
 	for _, v := range svc.Unprotected() {
 		sopts.Logger.Info().Str("url", v).Msg("unprotected URL")
@@ -226,7 +230,7 @@ func useMiddlewares(r *chi.Mux, sopts *Options, svc global.Service, tp trace.Tra
 	rm := middleware.RequestID
 
 	// actually register
-	r.Use(pm, tm, lm, authMiddle, rm, cm, cors)
+	r.Use(autopropMid, pm, tm, lm, authMiddle, rm, cm, cors)
 	return nil
 }
 

--- a/pkg/rgrpc/rgrpc.go
+++ b/pkg/rgrpc/rgrpc.go
@@ -30,10 +30,10 @@ import (
 	"github.com/owncloud/reva/v2/internal/grpc/interceptors/appctx"
 	"github.com/owncloud/reva/v2/internal/grpc/interceptors/auth"
 	"github.com/owncloud/reva/v2/internal/grpc/interceptors/log"
-	"github.com/owncloud/reva/v2/internal/grpc/interceptors/metadata"
 	"github.com/owncloud/reva/v2/internal/grpc/interceptors/recovery"
 	"github.com/owncloud/reva/v2/internal/grpc/interceptors/token"
 	"github.com/owncloud/reva/v2/internal/grpc/interceptors/useragent"
+	"github.com/owncloud/reva/v2/pkg/autoprop"
 	"github.com/owncloud/reva/v2/pkg/sharedconf"
 	rtrace "github.com/owncloud/reva/v2/pkg/trace"
 	"github.com/pkg/errors"
@@ -342,7 +342,7 @@ func (s *Server) getInterceptors(unprotected []string) ([]grpc.ServerOption, err
 		log.NewUnary(),
 		recovery.NewUnary(),
 		authUnary,
-		metadata.NewUnary(AutoPropPrefix),
+		autoprop.GetGoGRPCUnaryServerInterceptor(),
 	}
 
 	for _, t := range unaryTriples {
@@ -385,7 +385,7 @@ func (s *Server) getInterceptors(unprotected []string) ([]grpc.ServerOption, err
 		log.NewStream(),
 		recovery.NewStream(),
 		authStream,
-		metadata.NewStream(AutoPropPrefix),
+		autoprop.GetGoGRPCStreamServerInterceptor(),
 	}
 
 	for _, t := range streamTriples {

--- a/pkg/rgrpc/rgrpc.go
+++ b/pkg/rgrpc/rgrpc.go
@@ -336,13 +336,13 @@ func (s *Server) getInterceptors(unprotected []string) ([]grpc.ServerOption, err
 	}
 
 	unaryInterceptors := []grpc.UnaryServerInterceptor{
+		autoprop.GetGoGRPCUnaryServerInterceptor(),
 		appctx.NewUnary(s.log, s.tracerProvider),
 		token.NewUnary(),
 		useragent.NewUnary(),
 		log.NewUnary(),
 		recovery.NewUnary(),
 		authUnary,
-		autoprop.GetGoGRPCUnaryServerInterceptor(),
 	}
 
 	for _, t := range unaryTriples {
@@ -379,13 +379,13 @@ func (s *Server) getInterceptors(unprotected []string) ([]grpc.ServerOption, err
 	}
 
 	streamInterceptors := []grpc.StreamServerInterceptor{
+		autoprop.GetGoGRPCStreamServerInterceptor(),
 		appctx.NewStream(s.log, s.tracerProvider),
 		token.NewStream(),
 		useragent.NewStream(),
 		log.NewStream(),
 		recovery.NewStream(),
 		authStream,
-		autoprop.GetGoGRPCStreamServerInterceptor(),
 	}
 
 	for _, t := range streamTriples {

--- a/pkg/rgrpc/todo/pool/connection.go
+++ b/pkg/rgrpc/todo/pool/connection.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/owncloud/reva/v2/pkg/autoprop"
 	rtrace "github.com/owncloud/reva/v2/pkg/trace"
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
@@ -112,6 +113,12 @@ func NewConn(target string, opts ...Option) (*grpc.ClientConn, error) {
 			]
 		}`),
 		*/
+		grpc.WithChainUnaryInterceptor(
+			autoprop.GetGoGRPCUnaryClientInterceptor(),
+		),
+		grpc.WithChainStreamInterceptor(
+			autoprop.GetGoGRPCStreamClientInterceptor(),
+		),
 		grpc.WithStatsHandler(otelgrpc.NewClientHandler(
 			otelgrpc.WithTracerProvider(
 				options.tracerProvider,

--- a/pkg/rhttp/client.go
+++ b/pkg/rhttp/client.go
@@ -67,7 +67,6 @@ func NewRequest(ctx context.Context, method, url string, body io.Reader) (*http.
 		httpReq.Header.Set(ctxpkg.TokenHeader, tkn)
 	}
 
-	autoprop.AppendToHttpRequest(httpReq, ctx)
 	httpReq = httpReq.WithContext(ctx)
 	return httpReq, nil
 }

--- a/pkg/rhttp/client.go
+++ b/pkg/rhttp/client.go
@@ -26,6 +26,7 @@ import (
 
 	"go.opencensus.io/plugin/ochttp"
 
+	"github.com/owncloud/reva/v2/pkg/autoprop"
 	ctxpkg "github.com/owncloud/reva/v2/pkg/ctx"
 	"github.com/pkg/errors"
 )
@@ -45,7 +46,7 @@ func GetHTTPClient(opts ...Option) *http.Client {
 	httpClient := &http.Client{
 		Timeout: options.Timeout,
 		Transport: &ochttp.Transport{
-			Base: tr,
+			Base: autoprop.NewHttpRoundTripper(tr),
 		},
 	}
 
@@ -65,6 +66,7 @@ func NewRequest(ctx context.Context, method, url string, body io.Reader) (*http.
 		httpReq.Header.Set(ctxpkg.TokenHeader, tkn)
 	}
 
+	autoprop.AppendToHttpRequest(httpReq, ctx)
 	httpReq = httpReq.WithContext(ctx)
 	return httpReq, nil
 }

--- a/pkg/rhttp/client.go
+++ b/pkg/rhttp/client.go
@@ -40,6 +40,7 @@ func GetHTTPClient(opts ...Option) *http.Client {
 	tr := http.DefaultTransport.(*http.Transport).Clone()
 	tr.DisableKeepAlives = options.DisableKeepAlive
 	tr.TLSClientConfig = &tls.Config{
+		MinVersion:         options.MinVersion,
 		InsecureSkipVerify: options.Insecure,
 	}
 

--- a/pkg/rhttp/option.go
+++ b/pkg/rhttp/option.go
@@ -32,6 +32,7 @@ type Options struct {
 	Timeout          time.Duration
 	Insecure         bool
 	DisableKeepAlive bool
+	MinVersion       uint16
 }
 
 // newOptions initializes the available default options.
@@ -70,5 +71,13 @@ func Timeout(t time.Duration) Option {
 func DisableKeepAlive(disable bool) Option {
 	return func(o *Options) {
 		o.DisableKeepAlive = disable
+	}
+}
+
+// MinVersion sets the minimum TLS version to use
+// Use tls.VersionTLS10 to tls.VersionTLS13
+func MinVersion(version uint16) Option {
+	return func(o *Options) {
+		o.MinVersion = version
 	}
 }

--- a/pkg/rhttp/rhttp.go
+++ b/pkg/rhttp/rhttp.go
@@ -286,6 +286,7 @@ func (s *Server) getHandler() (http.Handler, error) {
 	// add always the logctx middleware as most priority, this middleware is internal
 	// and cannot be configured from the configuration.
 	coreMiddlewares := []*middlewareTriple{}
+	coreMiddlewares = append(coreMiddlewares, &middlewareTriple{Middleware: autoprop.NewHttpHandler(), Name: "autoprop"})
 
 	providerAuthMiddle, err := addProviderAuthMiddleware(s.conf, s.unprotected)
 	if err != nil {
@@ -298,7 +299,6 @@ func (s *Server) getHandler() (http.Handler, error) {
 	coreMiddlewares = append(coreMiddlewares, &middlewareTriple{Middleware: authMiddle, Name: "auth"})
 	coreMiddlewares = append(coreMiddlewares, &middlewareTriple{Middleware: log.New(), Name: "log"})
 	coreMiddlewares = append(coreMiddlewares, &middlewareTriple{Middleware: appctx.New(s.log, s.tracerProvider), Name: "appctx"})
-	coreMiddlewares = append(coreMiddlewares, &middlewareTriple{Middleware: autoprop.NewHttpHandler(), Name: "autoprop"})
 
 	for _, triple := range coreMiddlewares {
 		handler = triple.Middleware(traceHandler(triple.Name, handler, s.tracerProvider))

--- a/pkg/rhttp/rhttp.go
+++ b/pkg/rhttp/rhttp.go
@@ -32,6 +32,7 @@ import (
 	"github.com/owncloud/reva/v2/internal/http/interceptors/auth"
 	"github.com/owncloud/reva/v2/internal/http/interceptors/log"
 	"github.com/owncloud/reva/v2/internal/http/interceptors/providerauthorizer"
+	"github.com/owncloud/reva/v2/pkg/autoprop"
 	"github.com/owncloud/reva/v2/pkg/rhttp/global"
 	"github.com/owncloud/reva/v2/pkg/rhttp/router"
 	rtrace "github.com/owncloud/reva/v2/pkg/trace"
@@ -297,6 +298,7 @@ func (s *Server) getHandler() (http.Handler, error) {
 	coreMiddlewares = append(coreMiddlewares, &middlewareTriple{Middleware: authMiddle, Name: "auth"})
 	coreMiddlewares = append(coreMiddlewares, &middlewareTriple{Middleware: log.New(), Name: "log"})
 	coreMiddlewares = append(coreMiddlewares, &middlewareTriple{Middleware: appctx.New(s.log, s.tracerProvider), Name: "appctx"})
+	coreMiddlewares = append(coreMiddlewares, &middlewareTriple{Middleware: autoprop.NewHttpHandler(), Name: "autoprop"})
 
 	for _, triple := range coreMiddlewares {
 		handler = triple.Middleware(traceHandler(triple.Name, handler, s.tracerProvider))

--- a/pkg/share/manager/jsoncs3/jsoncs3.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3.go
@@ -29,7 +29,10 @@ import (
 	rpcv1beta1 "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	collaboration "github.com/cs3org/go-cs3apis/cs3/sharing/collaboration/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
 	"github.com/owncloud/reva/v2/pkg/appctx"
+	"github.com/owncloud/reva/v2/pkg/autoprop"
 	ctxpkg "github.com/owncloud/reva/v2/pkg/ctx"
 	"github.com/owncloud/reva/v2/pkg/errtypes"
 	"github.com/owncloud/reva/v2/pkg/events"
@@ -44,9 +47,8 @@ import (
 	"github.com/owncloud/reva/v2/pkg/share/manager/registry"
 	"github.com/owncloud/reva/v2/pkg/storage/utils/metadata" // nolint:staticcheck // we need the legacy package to convert V1 to V2 messages
 	"github.com/owncloud/reva/v2/pkg/storagespace"
+	revatrace "github.com/owncloud/reva/v2/pkg/trace"
 	"github.com/owncloud/reva/v2/pkg/utils"
-	"github.com/google/uuid"
-	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel/codes"
 	"golang.org/x/sync/errgroup"
@@ -278,7 +280,13 @@ func (m *Manager) ProcessEvents(ch <-chan events.Event) {
 
 		if ev, ok := event.Event.(events.SpaceDeleted); ok {
 			log.Debug().Msgf("space deleted event: %v", ev)
-			go func() { m.purgeSpace(ctx, ev.ID) }()
+			go func() {
+				ctx2, span := events.TraceEventConsumer(ctx, revatrace.DefaultProvider(), event)
+				defer span.End()
+				ctx2 = autoprop.SetMetaToContext(ctx2, event.ExtraInfo)
+
+				m.purgeSpace(ctx2, ev.ID)
+			}()
 		}
 	}
 }

--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -43,6 +43,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/owncloud/reva/v2/pkg/appctx"
+	"github.com/owncloud/reva/v2/pkg/autoprop"
 	ctxpkg "github.com/owncloud/reva/v2/pkg/ctx"
 	"github.com/owncloud/reva/v2/pkg/errtypes"
 	"github.com/owncloud/reva/v2/pkg/events"
@@ -278,326 +279,332 @@ func New(o *options.Options, aspects aspects.Aspects, log *zerolog.Logger) (stor
 
 // Postprocessing starts the postprocessing result collector
 func (fs *Decomposedfs) Postprocessing(ch <-chan events.Event) {
-	ctx := context.TODO() // we should pass the trace id in the event and initialize the trace provider here
-	ctx, span := tracer.Start(ctx, "Postprocessing")
-	defer span.End()
 	log := logger.New()
 	for event := range ch {
-		switch ev := event.Event.(type) {
-		case events.PostprocessingFinished:
-			sublog := log.With().Str("event", "PostprocessingFinished").Str("uploadid", ev.UploadID).Logger()
-			if ev.ResourceID != nil && ev.ResourceID.GetStorageId() != "" && ev.ResourceID.GetStorageId() != fs.o.MountID {
-				sublog.Debug().Msg("ignoring event for different storage")
-				continue
-			}
-			session, err := fs.sessionStore.Get(ctx, ev.UploadID)
-			if err != nil {
-				sublog.Error().Err(err).Msg("Failed to get upload")
-				continue // NOTE: since we can't get the upload, we can't delete the blob
-			}
+		evCtx := context.Background()
+		fs.processEvent(evCtx, event, log)
+	}
+}
 
-			ctx = session.Context(ctx)
+func (fs *Decomposedfs) processEvent(evCtx context.Context, event events.Event, log *zerolog.Logger) {
+	ctx, span := events.TraceEventConsumerWithTracer(evCtx, tracer, event)
+	ctx = autoprop.SetMetaToContext(ctx, event.ExtraInfo)
+	defer span.End()
 
-			n, err := session.Node(ctx)
-			if err != nil {
-				sublog.Error().Err(err).Msg("could not read node")
-				continue
-			}
-			sublog = log.With().Str("spaceid", session.SpaceID()).Str("nodeid", session.NodeID()).Logger()
-			if !n.Exists {
-				sublog.Debug().Msg("node no longer exists")
-				session.Cleanup(false, true, true, false)
-				continue
-			}
+	switch ev := event.Event.(type) {
+	case events.PostprocessingFinished:
+		sublog := log.With().Str("event", "PostprocessingFinished").Str("uploadid", ev.UploadID).Logger()
+		if ev.ResourceID != nil && ev.ResourceID.GetStorageId() != "" && ev.ResourceID.GetStorageId() != fs.o.MountID {
+			sublog.Debug().Msg("ignoring event for different storage")
+			return
+		}
+		session, err := fs.sessionStore.Get(ctx, ev.UploadID)
+		if err != nil {
+			sublog.Error().Err(err).Msg("Failed to get upload")
+			return // NOTE: since we can't get the upload, we can't delete the blob
+		}
 
-			var (
-				failed             bool
-				revertNodeMetadata bool
-				keepUpload         bool
-			)
-			unmarkPostprocessing := true
+		ctx = session.Context(ctx)
 
-			switch ev.Outcome {
-			default:
-				sublog.Error().Str("outcome", string(ev.Outcome)).Msg("unknown postprocessing outcome - aborting")
-				fallthrough
-			case events.PPOutcomeAbort:
+		n, err := session.Node(ctx)
+		if err != nil {
+			sublog.Error().Err(err).Msg("could not read node")
+			return
+		}
+		sublog = log.With().Str("spaceid", session.SpaceID()).Str("nodeid", session.NodeID()).Logger()
+		if !n.Exists {
+			sublog.Debug().Msg("node no longer exists")
+			session.Cleanup(false, true, true, false)
+			return
+		}
+
+		var (
+			failed             bool
+			revertNodeMetadata bool
+			keepUpload         bool
+		)
+		unmarkPostprocessing := true
+
+		switch ev.Outcome {
+		default:
+			sublog.Error().Str("outcome", string(ev.Outcome)).Msg("unknown postprocessing outcome - aborting")
+			fallthrough
+		case events.PPOutcomeAbort:
+			failed = true
+			revertNodeMetadata = true
+			keepUpload = true
+			metrics.UploadSessionsAborted.Inc()
+		case events.PPOutcomeContinue:
+			if err := session.Finalize(ctx); err != nil {
+				sublog.Error().Err(err).Msg("could not finalize upload")
 				failed = true
-				revertNodeMetadata = true
+				revertNodeMetadata = false
 				keepUpload = true
-				metrics.UploadSessionsAborted.Inc()
-			case events.PPOutcomeContinue:
-				if err := session.Finalize(ctx); err != nil {
-					sublog.Error().Err(err).Msg("could not finalize upload")
-					failed = true
-					revertNodeMetadata = false
-					keepUpload = true
-					// keep postprocessing status so the upload is not deleted during housekeeping
-					unmarkPostprocessing = false
-				} else {
-					metrics.UploadSessionsFinalized.Inc()
-				}
-			case events.PPOutcomeDelete:
-				failed = true
-				revertNodeMetadata = true
-				metrics.UploadSessionsDeleted.Inc()
+				// keep postprocessing status so the upload is not deleted during housekeeping
+				unmarkPostprocessing = false
+			} else {
+				metrics.UploadSessionsFinalized.Inc()
 			}
+		case events.PPOutcomeDelete:
+			failed = true
+			revertNodeMetadata = true
+			metrics.UploadSessionsDeleted.Inc()
+		}
 
-			getParent := func() *node.Node {
-				p, err := n.Parent(ctx)
-				if err != nil {
-					sublog.Error().Err(err).Msg("could not read parent")
-					return nil
-				}
-				return p
+		getParent := func() *node.Node {
+			p, err := n.Parent(ctx)
+			if err != nil {
+				sublog.Error().Err(err).Msg("could not read parent")
+				return nil
 			}
+			return p
+		}
 
-			now := time.Now()
-			if failed {
-				// if no other upload session is in progress (processing id != session id) or has finished (processing id == "")
-				latestSession, err := n.ProcessingID(ctx)
-				if err != nil {
-					sublog.Error().Err(err).Msg("reading node for session failed")
-				}
-				if latestSession == session.ID() {
-					// propagate reverted sizeDiff after failed postprocessing
-					if err := fs.tp.Propagate(ctx, n, -session.SizeDiff()); err != nil {
-						sublog.Error().Err(err).Msg("could not propagate tree size change")
-					}
-				}
-			} else if p := getParent(); p != nil {
-				// update parent tmtime to propagate etag change after successful postprocessing
-				_ = p.SetTMTime(ctx, &now)
-				if err := fs.tp.Propagate(ctx, p, 0); err != nil {
-					sublog.Error().Err(err).Msg("could not propagate etag change")
+		now := time.Now()
+		if failed {
+			// if no other upload session is in progress (processing id != session id) or has finished (processing id == "")
+			latestSession, err := n.ProcessingID(ctx)
+			if err != nil {
+				sublog.Error().Err(err).Msg("reading node for session failed")
+			}
+			if latestSession == session.ID() {
+				// propagate reverted sizeDiff after failed postprocessing
+				if err := fs.tp.Propagate(ctx, n, -session.SizeDiff()); err != nil {
+					sublog.Error().Err(err).Msg("could not propagate tree size change")
 				}
 			}
-
-			session.Cleanup(revertNodeMetadata, !keepUpload, !keepUpload, unmarkPostprocessing)
-
-			var isVersion bool
-			if session.NodeExists() {
-				info, err := session.GetInfo(ctx)
-				if err == nil && info.MetaData["versionsPath"] != "" {
-					isVersion = true
-				}
+		} else if p := getParent(); p != nil {
+			// update parent tmtime to propagate etag change after successful postprocessing
+			_ = p.SetTMTime(ctx, &now)
+			if err := fs.tp.Propagate(ctx, p, 0); err != nil {
+				sublog.Error().Err(err).Msg("could not propagate etag change")
 			}
+		}
 
-			if err := events.Publish(
-				ctx,
-				fs.stream,
-				events.UploadReady{
-					UploadID:      ev.UploadID,
-					Failed:        failed,
-					ExecutingUser: ev.ExecutingUser,
-					Filename:      ev.Filename,
-					FileRef: &provider.Reference{
-						ResourceId: &provider.ResourceId{
-							StorageId: session.ProviderID(),
-							SpaceId:   session.SpaceID(),
-							OpaqueId:  session.SpaceID(),
-						},
-						Path: utils.MakeRelativePath(filepath.Join(session.Dir(), session.Filename())),
-					},
-					ResourceID: &provider.ResourceId{
+		session.Cleanup(revertNodeMetadata, !keepUpload, !keepUpload, unmarkPostprocessing)
+
+		var isVersion bool
+		if session.NodeExists() {
+			info, err := session.GetInfo(ctx)
+			if err == nil && info.MetaData["versionsPath"] != "" {
+				isVersion = true
+			}
+		}
+
+		if err := events.Publish(
+			ctx,
+			fs.stream,
+			events.UploadReady{
+				UploadID:      ev.UploadID,
+				Failed:        failed,
+				ExecutingUser: ev.ExecutingUser,
+				Filename:      ev.Filename,
+				FileRef: &provider.Reference{
+					ResourceId: &provider.ResourceId{
 						StorageId: session.ProviderID(),
 						SpaceId:   session.SpaceID(),
-						OpaqueId:  session.NodeID(),
+						OpaqueId:  session.SpaceID(),
 					},
-					Timestamp:         utils.TimeToTS(now),
-					SpaceOwner:        n.SpaceOwnerOrManager(ctx),
-					IsVersion:         isVersion,
-					ImpersonatingUser: ev.ImpersonatingUser,
+					Path: utils.MakeRelativePath(filepath.Join(session.Dir(), session.Filename())),
 				},
-			); err != nil {
-				sublog.Error().Err(err).Msg("Failed to publish UploadReady event")
-			}
-		case events.RestartPostprocessing:
-			sublog := log.With().Str("event", "RestartPostprocessing").Str("uploadid", ev.UploadID).Logger()
-			session, err := fs.sessionStore.Get(ctx, ev.UploadID)
+				ResourceID: &provider.ResourceId{
+					StorageId: session.ProviderID(),
+					SpaceId:   session.SpaceID(),
+					OpaqueId:  session.NodeID(),
+				},
+				Timestamp:         utils.TimeToTS(now),
+				SpaceOwner:        n.SpaceOwnerOrManager(ctx),
+				IsVersion:         isVersion,
+				ImpersonatingUser: ev.ImpersonatingUser,
+			},
+		); err != nil {
+			sublog.Error().Err(err).Msg("Failed to publish UploadReady event")
+		}
+	case events.RestartPostprocessing:
+		sublog := log.With().Str("event", "RestartPostprocessing").Str("uploadid", ev.UploadID).Logger()
+		session, err := fs.sessionStore.Get(ctx, ev.UploadID)
+		if err != nil {
+			sublog.Error().Err(err).Msg("Failed to get upload")
+			return
+		}
+		n, err := session.Node(ctx)
+		if err != nil {
+			sublog.Error().Err(err).Msg("could not read node")
+			return
+		}
+		sublog = log.With().Str("spaceid", session.SpaceID()).Str("nodeid", session.NodeID()).Logger()
+		s, err := session.URL(ctx)
+		if err != nil {
+			sublog.Error().Err(err).Msg("could not create url")
+			return
+		}
+
+		metrics.UploadSessionsRestarted.Inc()
+
+		// restart postprocessing
+		if err := events.Publish(ctx, fs.stream, events.BytesReceived{
+			UploadID:      session.ID(),
+			URL:           s,
+			SpaceOwner:    n.SpaceOwnerOrManager(ctx),
+			ExecutingUser: &user.User{Id: &user.UserId{OpaqueId: "postprocessing-restart"}}, // send nil instead?
+			ResourceID:    &provider.ResourceId{SpaceId: n.SpaceID, OpaqueId: n.ID},
+			Filename:      session.Filename(),
+			Filesize:      uint64(session.Size()),
+		}); err != nil {
+			sublog.Error().Err(err).Msg("Failed to publish BytesReceived event")
+		}
+	case events.CleanUpload:
+		sublog := log.With().Str("event", "CleanUpload").Str("uploadid", ev.UploadID).Logger()
+		session, err := fs.sessionStore.Get(ctx, ev.UploadID)
+		if err != nil {
+			sublog.Error().Err(err).Msg("Failed to get upload")
+			return // NOTE: since we can't get the upload, we can't delete the blob
+		}
+		session.Cleanup(true, !ev.KeepUpload, !ev.KeepUpload, true)
+	case events.RevertRevision:
+		sublog := log.With().Str("event", "RevertRevision").Interface("nodeid", ev.ResourceID).Logger()
+		if ev.ResourceID != nil && ev.ResourceID.GetStorageId() != "" && ev.ResourceID.GetStorageId() != fs.o.MountID {
+			sublog.Debug().Msg("ignoring event for different storage")
+			return
+		}
+		n, err := fs.lu.NodeFromID(ctx, ev.ResourceID)
+		if err != nil {
+			sublog.Error().Err(err).Msg("Failed to get node")
+			return
+		}
+
+		if err := n.RevertCurrentRevision(ctx); err != nil {
+			sublog.Error().Err(err).Msg("Failed to revert revision")
+			return
+		}
+	case events.PostprocessingStepFinished:
+		sublog := log.With().Str("event", "PostprocessingStepFinished").Str("uploadid", ev.UploadID).Logger()
+		if ev.ResourceID != nil && ev.ResourceID.GetStorageId() != "" && ev.ResourceID.GetStorageId() != fs.o.MountID {
+			sublog.Debug().Msg("ignoring event for different storage")
+			return
+		}
+		if ev.FinishedStep != events.PPStepAntivirus {
+			// atm we are only interested in antivirus results
+			return
+		}
+
+		res := ev.Result.(events.VirusscanResult)
+		if res.ErrorMsg != "" {
+			// scan failed somehow
+			// Should we handle this here?
+			return
+		}
+		sublog = log.With().Str("scan_description", res.Description).Bool("infected", res.Infected).Logger()
+
+		var n *node.Node
+		switch ev.UploadID {
+		case "":
+			// uploadid is empty -> this was an on-demand scan
+			/* ON DEMAND SCANNING NOT SUPPORTED ATM
+			ctx := ctxpkg.ContextSetUser(context.Background(), ev.ExecutingUser)
+			ref := &provider.Reference{ResourceId: ev.ResourceID}
+
+			no, err := fs.lu.NodeFromResource(ctx, ref)
 			if err != nil {
-				sublog.Error().Err(err).Msg("Failed to get upload")
+				log.Error().Err(err).Interface("resourceID", ev.ResourceID).Msg("Failed to get node after scan")
 				continue
+
 			}
-			n, err := session.Node(ctx)
-			if err != nil {
-				sublog.Error().Err(err).Msg("could not read node")
-				continue
-			}
-			sublog = log.With().Str("spaceid", session.SpaceID()).Str("nodeid", session.NodeID()).Logger()
-			s, err := session.URL(ctx)
-			if err != nil {
-				sublog.Error().Err(err).Msg("could not create url")
-				continue
-			}
+			n = no
+			if ev.Outcome == events.PPOutcomeDelete {
+				// antivir wants us to delete the file. We must obey and need to
 
-			metrics.UploadSessionsRestarted.Inc()
-
-			// restart postprocessing
-			if err := events.Publish(ctx, fs.stream, events.BytesReceived{
-				UploadID:      session.ID(),
-				URL:           s,
-				SpaceOwner:    n.SpaceOwnerOrManager(ctx),
-				ExecutingUser: &user.User{Id: &user.UserId{OpaqueId: "postprocessing-restart"}}, // send nil instead?
-				ResourceID:    &provider.ResourceId{SpaceId: n.SpaceID, OpaqueId: n.ID},
-				Filename:      session.Filename(),
-				Filesize:      uint64(session.Size()),
-			}); err != nil {
-				sublog.Error().Err(err).Msg("Failed to publish BytesReceived event")
-			}
-		case events.CleanUpload:
-			sublog := log.With().Str("event", "CleanUpload").Str("uploadid", ev.UploadID).Logger()
-			session, err := fs.sessionStore.Get(ctx, ev.UploadID)
-			if err != nil {
-				sublog.Error().Err(err).Msg("Failed to get upload")
-				continue // NOTE: since we can't get the upload, we can't delete the blob
-			}
-			session.Cleanup(true, !ev.KeepUpload, !ev.KeepUpload, true)
-		case events.RevertRevision:
-			sublog := log.With().Str("event", "RevertRevision").Interface("nodeid", ev.ResourceID).Logger()
-			if ev.ResourceID != nil && ev.ResourceID.GetStorageId() != "" && ev.ResourceID.GetStorageId() != fs.o.MountID {
-				sublog.Debug().Msg("ignoring event for different storage")
-				continue
-			}
-			n, err := fs.lu.NodeFromID(ctx, ev.ResourceID)
-			if err != nil {
-				sublog.Error().Err(err).Msg("Failed to get node")
-				continue
-			}
-
-			if err := n.RevertCurrentRevision(ctx); err != nil {
-				sublog.Error().Err(err).Msg("Failed to revert revision")
-				continue
-			}
-		case events.PostprocessingStepFinished:
-			sublog := log.With().Str("event", "PostprocessingStepFinished").Str("uploadid", ev.UploadID).Logger()
-			if ev.ResourceID != nil && ev.ResourceID.GetStorageId() != "" && ev.ResourceID.GetStorageId() != fs.o.MountID {
-				sublog.Debug().Msg("ignoring event for different storage")
-				continue
-			}
-			if ev.FinishedStep != events.PPStepAntivirus {
-				// atm we are only interested in antivirus results
-				continue
-			}
-
-			res := ev.Result.(events.VirusscanResult)
-			if res.ErrorMsg != "" {
-				// scan failed somehow
-				// Should we handle this here?
-				continue
-			}
-			sublog = log.With().Str("scan_description", res.Description).Bool("infected", res.Infected).Logger()
-
-			var n *node.Node
-			switch ev.UploadID {
-			case "":
-				// uploadid is empty -> this was an on-demand scan
-				/* ON DEMAND SCANNING NOT SUPPORTED ATM
-				ctx := ctxpkg.ContextSetUser(context.Background(), ev.ExecutingUser)
-				ref := &provider.Reference{ResourceId: ev.ResourceID}
-
-				no, err := fs.lu.NodeFromResource(ctx, ref)
-				if err != nil {
-					log.Error().Err(err).Interface("resourceID", ev.ResourceID).Msg("Failed to get node after scan")
-					continue
-
-				}
-				n = no
-				if ev.Outcome == events.PPOutcomeDelete {
-					// antivir wants us to delete the file. We must obey and need to
-
-					// check if there a previous versions existing
-					revs, err := fs.ListRevisions(ctx, ref)
-					if len(revs) == 0 {
-						if err != nil {
-							log.Error().Err(err).Interface("resourceID", ev.ResourceID).Msg("Failed to list revisions. Fallback to delete file")
-						}
-
-						// no versions -> trash file
-						err := fs.Delete(ctx, ref)
-						if err != nil {
-							log.Error().Err(err).Interface("resourceID", ev.ResourceID).Msg("Failed to delete infected resource")
-							continue
-						}
-
-						// now purge it from the recycle bin
-						if err := fs.PurgeRecycleItem(ctx, &provider.Reference{ResourceId: &provider.ResourceId{SpaceId: n.SpaceID, OpaqueId: n.SpaceID}}, n.ID, "/"); err != nil {
-							log.Error().Err(err).Interface("resourceID", ev.ResourceID).Msg("Failed to purge infected resource from trash")
-						}
-
-						// remove cache entry in gateway
-						fs.cache.RemoveStatContext(ctx, ev.ExecutingUser.GetId(), &provider.ResourceId{SpaceId: n.SpaceID, OpaqueId: n.ID})
-						continue
-					}
-
-					// we have versions - find the newest
-					versions := make(map[uint64]string) // remember all versions - we need them later
-					var nv uint64
-					for _, v := range revs {
-						versions[v.Mtime] = v.Key
-						if v.Mtime > nv {
-							nv = v.Mtime
-						}
-					}
-
-					// restore newest version
-					if err := fs.RestoreRevision(ctx, ref, versions[nv]); err != nil {
-						log.Error().Err(err).Interface("resourceID", ev.ResourceID).Str("revision", versions[nv]).Msg("Failed to restore revision")
-						continue
-					}
-
-					// now find infected version
-					revs, err = fs.ListRevisions(ctx, ref)
+				// check if there a previous versions existing
+				revs, err := fs.ListRevisions(ctx, ref)
+				if len(revs) == 0 {
 					if err != nil {
-						log.Error().Err(err).Interface("resourceID", ev.ResourceID).Msg("Error listing revisions after restore")
+						log.Error().Err(err).Interface("resourceID", ev.ResourceID).Msg("Failed to list revisions. Fallback to delete file")
 					}
 
-					for _, v := range revs {
-						// we looking for a version that was previously not there
-						if _, ok := versions[v.Mtime]; ok {
-							continue
-						}
+					// no versions -> trash file
+					err := fs.Delete(ctx, ref)
+					if err != nil {
+						log.Error().Err(err).Interface("resourceID", ev.ResourceID).Msg("Failed to delete infected resource")
+						continue
+					}
 
-						if err := fs.DeleteRevision(ctx, ref, v.Key); err != nil {
-							log.Error().Err(err).Interface("resourceID", ev.ResourceID).Str("revision", v.Key).Msg("Failed to delete revision")
-						}
+					// now purge it from the recycle bin
+					if err := fs.PurgeRecycleItem(ctx, &provider.Reference{ResourceId: &provider.ResourceId{SpaceId: n.SpaceID, OpaqueId: n.SpaceID}}, n.ID, "/"); err != nil {
+						log.Error().Err(err).Interface("resourceID", ev.ResourceID).Msg("Failed to purge infected resource from trash")
 					}
 
 					// remove cache entry in gateway
 					fs.cache.RemoveStatContext(ctx, ev.ExecutingUser.GetId(), &provider.ResourceId{SpaceId: n.SpaceID, OpaqueId: n.ID})
 					continue
 				}
-				*/
-			default:
-				// uploadid is not empty -> this is an async upload
-				session, err := fs.sessionStore.Get(ctx, ev.UploadID)
-				if err != nil {
-					sublog.Error().Err(err).Msg("Failed to get upload")
+
+				// we have versions - find the newest
+				versions := make(map[uint64]string) // remember all versions - we need them later
+				var nv uint64
+				for _, v := range revs {
+					versions[v.Mtime] = v.Key
+					if v.Mtime > nv {
+						nv = v.Mtime
+					}
+				}
+
+				// restore newest version
+				if err := fs.RestoreRevision(ctx, ref, versions[nv]); err != nil {
+					log.Error().Err(err).Interface("resourceID", ev.ResourceID).Str("revision", versions[nv]).Msg("Failed to restore revision")
 					continue
 				}
 
-				n, err = session.Node(ctx)
+				// now find infected version
+				revs, err = fs.ListRevisions(ctx, ref)
 				if err != nil {
-					sublog.Error().Err(err).Msg("Failed to get node after scan")
-					continue
+					log.Error().Err(err).Interface("resourceID", ev.ResourceID).Msg("Error listing revisions after restore")
 				}
-				sublog = log.With().Str("spaceid", session.SpaceID()).Str("nodeid", session.NodeID()).Logger()
 
-				session.SetScanData(res.Description, res.Scandate)
-				if err := session.Persist(ctx); err != nil {
-					sublog.Error().Err(err).Msg("Failed to persist scan results")
+				for _, v := range revs {
+					// we looking for a version that was previously not there
+					if _, ok := versions[v.Mtime]; ok {
+						continue
+					}
+
+					if err := fs.DeleteRevision(ctx, ref, v.Key); err != nil {
+						log.Error().Err(err).Interface("resourceID", ev.ResourceID).Str("revision", v.Key).Msg("Failed to delete revision")
+					}
 				}
-			}
 
-			if err := n.SetScanData(ctx, res.Description, res.Scandate); err != nil {
-				sublog.Error().Err(err).Msg("Failed to set scan results")
+				// remove cache entry in gateway
+				fs.cache.RemoveStatContext(ctx, ev.ExecutingUser.GetId(), &provider.ResourceId{SpaceId: n.SpaceID, OpaqueId: n.ID})
 				continue
 			}
-
-			metrics.UploadSessionsScanned.Inc()
+			*/
 		default:
-			log.Error().Interface("event", ev).Msg("Unknown event")
+			// uploadid is not empty -> this is an async upload
+			session, err := fs.sessionStore.Get(ctx, ev.UploadID)
+			if err != nil {
+				sublog.Error().Err(err).Msg("Failed to get upload")
+				return
+			}
+
+			n, err = session.Node(ctx)
+			if err != nil {
+				sublog.Error().Err(err).Msg("Failed to get node after scan")
+				return
+			}
+			sublog = log.With().Str("spaceid", session.SpaceID()).Str("nodeid", session.NodeID()).Logger()
+
+			session.SetScanData(res.Description, res.Scandate)
+			if err := session.Persist(ctx); err != nil {
+				sublog.Error().Err(err).Msg("Failed to persist scan results")
+			}
 		}
+
+		if err := n.SetScanData(ctx, res.Description, res.Scandate); err != nil {
+			sublog.Error().Err(err).Msg("Failed to set scan results")
+			return
+		}
+
+		metrics.UploadSessionsScanned.Inc()
+	default:
+		log.Error().Interface("event", ev).Msg("Unknown event")
 	}
 }
 


### PR DESCRIPTION
Autopropagation of contextual metadata, so information can flow across multiple services.

The "autoprop" package contains middlewares / interceptors for all the microservices to include. The autopropagation relies on those middlewares. Note that both clients and servers must use those middlewares.
This PR includes middlewares for HTTP, GRPC and events.

At the moment, "brute force protection" and "vault mode" work with autopropagation (note that some pieces of the feature are in the oCIS repo).

-----

### Checking for MFA / vault mode
First, make sure all the involved microservices have the autopropagation middleware set up. **Not all the microservices have the middlewares, so autopropagation might not reach your service**
If everything is properly setup, just `revactx.HasMFA(ctx)` is enough.

Additional considerations:
* Make sure your clients also have the autopropagation wrappers so the information if propagated from your service. Requests to external sites might need a different client to avoid potential leaks.
* Consider the information to be autopropagated as "public". Any confidential information that might need to be autopropagated through this approach MUST be encrypted or secured separately.
* Event tracing is also included in the PR