### PR TITLE
fix: exempt service accounts from MFA enforcement in vault mode

### DIFF
--- a/changelog/unreleased/fix-exempt-service-accounts-from-mfa.md
+++ b/changelog/unreleased/fix-exempt-service-accounts-from-mfa.md
@@ -5,4 +5,4 @@ in the gRPC auth interceptor. Previously, internal services like userlog and
 notifications failed to stat vault resources because their service account
 tokens lacked MFA context, causing share notifications to be silently discarded.
 
-https://github.com/owncloud/reva/pull/TODO
+https://github.com/owncloud/reva/pull/624

--- a/changelog/unreleased/fix-exempt-service-accounts-from-mfa.md
+++ b/changelog/unreleased/fix-exempt-service-accounts-from-mfa.md
@@ -1,0 +1,8 @@
+Bugfix: Exempt service accounts from MFA enforcement in vault mode
+
+Service accounts (UserType_USER_TYPE_SERVICE) are now exempt from MFA checks
+in the gRPC auth interceptor. Previously, internal services like userlog and
+notifications failed to stat vault resources because their service account
+tokens lacked MFA context, causing share notifications to be silently discarded.
+
+https://github.com/owncloud/reva/pull/TODO

--- a/internal/grpc/interceptors/auth/auth.go
+++ b/internal/grpc/interceptors/auth/auth.go
@@ -159,7 +159,7 @@ func NewUnary(m map[string]interface{}, unprotected []string, tp trace.TracerPro
 		ctx = ctxpkg.ContextSetScopes(ctx, tokenScope)
 		// TODO: MFA enforcement should be moved to the individual service level, so each service can
 		// decide which endpoints require MFA and which are accessible without it.
-		if conf.MFAEnabled {
+		if conf.MFAEnabled && u.Id.Type != userpb.UserType_USER_TYPE_SERVICE {
 			if mfav := metadata.ValueFromIncomingContext(ctx, ctxpkg.MFAOutgoingHeader); !slices.Contains(mfav, "true") {
 				log.Warn().Str("user_id", u.Id.OpaqueId).Strs("mfa_values", mfav).Msg("MFA is required")
 				return mfaResponse(ctx, req, info)
@@ -256,7 +256,7 @@ func NewStream(m map[string]interface{}, unprotected []string, tp trace.TracerPr
 		ctx = ctxpkg.ContextSetScopes(ctx, tokenScope)
 		// TODO: MFA enforcement should be moved to the individual service level, so each service can
 		// decide which endpoints require MFA and which are accessible without it.
-		if conf.MFAEnabled {
+		if conf.MFAEnabled && u.Id.Type != userpb.UserType_USER_TYPE_SERVICE {
 			if mfav := metadata.ValueFromIncomingContext(ctx, ctxpkg.MFAOutgoingHeader); !slices.Contains(mfav, "true") {
 				log.Warn().Str("user_id", u.Id.OpaqueId).Strs("mfa_values", mfav).Msg("MFA is required")
 				return status.Errorf(codes.PermissionDenied, "MFA required to access vault storage")


### PR DESCRIPTION
## Description
Exempt service accounts (`UserType_USER_TYPE_SERVICE`) from MFA checks in the gRPC auth interceptor (both unary and stream).

## Related Issue
- Fixes [OCISDEV-967](https://kiteworks.atlassian.net/browse/OCISDEV-967)

## Motivation and Context
In vault mode, the storage provider enforces MFA via the gRPC auth interceptor. Internal services (userlog, notifications) use a service account to stat vault resources when composing share notifications. The service account token lacks MFA context, so the interceptor rejects the request with "permission denied." This causes share notifications to be silently discarded — the userlog converter treats the permission error as an "outdated" event and deletes it.

Service accounts authenticate via shared secrets, not user credentials. MFA (which verifies human presence) is meaningless for them.

## How Has This Been Tested?
- test environment: local oCIS with vault mode enabled
- test case 1: Create a share on a vault resource, verify the receiving user gets an in-app notification
- test case 2: Verify normal (non-vault) share notifications still work
- test case 3: Verify regular users still require MFA to access vault storage

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: N/A