### PR TITLE
fix(gateway): prevent setting an expiration on the last space manager

### DIFF
--- a/changelog/unreleased/fix-space-last-manager-expiration.md
+++ b/changelog/unreleased/fix-space-last-manager-expiration.md
@@ -1,0 +1,10 @@
+Bugfix: Prevent setting an expiration on the last space manager
+
+Setting an expiration date on the last permanent manager of a space was allowed.
+Once that grant expired the space would be left without any manager. The check
+that ensures at least one permanent manager remains was only run when a grant
+dropped the manager role; it now also runs when a manager grant is given an
+expiration, since an expiring manager is not a permanent manager.
+
+https://github.com/owncloud/reva/pull/631
+https://github.com/owncloud/ocis/issues/11205

--- a/internal/grpc/services/gateway/usershareprovider.go
+++ b/internal/grpc/services/gateway/usershareprovider.go
@@ -218,10 +218,10 @@ func (s *svc) updateSpaceShare(ctx context.Context, req *collaboration.UpdateSha
 			return &collaboration.UpdateShareResponse{Status: status.NewInvalid(ctx, "updating requires a received permission object")}, nil
 		}
 
-		if !grant.GetPermissions().GetRemoveGrant() {
-			// this request might remove Manager Permissions so we need to
-			// check if there is at least one manager remaining of the
-			// resource.
+		if mayRemoveLastPermanentManager(grant) {
+			// This request might drop the manager role or give the manager grant
+			// an expiration, either of which could leave the space without a
+			// permanent manager. Ensure at least one permanent manager remains.
 			if !isSpaceManagerRemaining(listGrantRes.GetGrants(), grant.GetGrantee()) {
 				return &collaboration.UpdateShareResponse{
 					Status: status.NewPermissionDenied(ctx, errtypes.PermissionDenied(""), "can't remove the last manager"),
@@ -810,6 +810,16 @@ func isSpaceManagerRemaining(grants []*provider.Grant, grantee *provider.Grantee
 		}
 	}
 	return false
+}
+
+// mayRemoveLastPermanentManager reports whether applying grant could leave the
+// space without a permanent (non-expiring) manager, so that the caller must
+// verify another permanent manager remains. This is the case when the grant
+// drops the manager role (RemoveGrant is the manager marker) or when a manager
+// grant is given an expiration, since an expiring manager does not count as a
+// permanent manager (see isSpaceManagerRemaining).
+func mayRemoveLastPermanentManager(grant *provider.Grant) bool {
+	return !grant.GetPermissions().GetRemoveGrant() || grant.GetExpiration() != nil
 }
 
 func (s *svc) checkLock(ctx context.Context, shareId *collaboration.ShareId) (*rpc.Status, error) {

--- a/internal/grpc/services/gateway/usershareprovider_test.go
+++ b/internal/grpc/services/gateway/usershareprovider_test.go
@@ -1,0 +1,106 @@
+// Copyright 2018-2024 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package gateway
+
+import (
+	"testing"
+
+	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	typesv1beta1 "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
+)
+
+func userGrantee(id string) *provider.Grantee {
+	return &provider.Grantee{
+		Type: provider.GranteeType_GRANTEE_TYPE_USER,
+		Id:   &provider.Grantee_UserId{UserId: &userpb.UserId{OpaqueId: id}},
+	}
+}
+
+func managerGrant(grantee *provider.Grantee, exp *typesv1beta1.Timestamp) *provider.Grant {
+	return &provider.Grant{
+		Grantee:     grantee,
+		Permissions: &provider.ResourcePermissions{RemoveGrant: true},
+		Expiration:  exp,
+	}
+}
+
+func viewerGrant(grantee *provider.Grantee, exp *typesv1beta1.Timestamp) *provider.Grant {
+	return &provider.Grant{
+		Grantee:     grantee,
+		Permissions: &provider.ResourcePermissions{RemoveGrant: false},
+		Expiration:  exp,
+	}
+}
+
+// TestMayRemoveLastPermanentManager covers the guard that prevents orphaning a
+// space: a manager grant that gains an expiration must be treated the same as a
+// manager that loses the role, because an expiring manager is not a permanent
+// manager.
+func TestMayRemoveLastPermanentManager(t *testing.T) {
+	alice := userGrantee("alice")
+	exp := &typesv1beta1.Timestamp{Seconds: 1}
+
+	tests := []struct {
+		name  string
+		grant *provider.Grant
+		want  bool
+	}{
+		{"permanent manager, unchanged", managerGrant(alice, nil), false},
+		{"manager gains an expiration", managerGrant(alice, exp), true},
+		{"manager role dropped", viewerGrant(alice, nil), true},
+		{"non-manager with expiration", viewerGrant(alice, exp), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mayRemoveLastPermanentManager(tt.grant); got != tt.want {
+				t.Errorf("mayRemoveLastPermanentManager() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIsSpaceManagerRemaining documents the invariant the guard relies on: only
+// another permanent (non-expiring), non-self manager keeps a space managed.
+func TestIsSpaceManagerRemaining(t *testing.T) {
+	alice := userGrantee("alice")
+	bob := userGrantee("bob")
+	exp := &typesv1beta1.Timestamp{Seconds: 1}
+
+	tests := []struct {
+		name     string
+		grants   []*provider.Grant
+		updating *provider.Grantee
+		want     bool
+	}{
+		{"another permanent manager remains", []*provider.Grant{managerGrant(alice, nil), managerGrant(bob, nil)}, alice, true},
+		{"only the updated grantee is manager", []*provider.Grant{managerGrant(alice, nil)}, alice, false},
+		{"the other manager is expiring", []*provider.Grant{managerGrant(alice, nil), managerGrant(bob, exp)}, alice, false},
+		{"the other grantee is only a viewer", []*provider.Grant{managerGrant(alice, nil), viewerGrant(bob, nil)}, alice, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isSpaceManagerRemaining(tt.grants, tt.updating); got != tt.want {
+				t.Errorf("isSpaceManagerRemaining() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Fixes the behaviour behind owncloud/ocis#11205: an expiration date can be set on the **last** Manager of a space. Once that grant expires, the space is left without any manager.

## Root cause

`updateSpaceShare` (`internal/grpc/services/gateway/usershareprovider.go`) guards against orphaning a space by calling `isSpaceManagerRemaining` before applying a grant. That guard was gated behind `if !grant.GetPermissions().GetRemoveGrant()` — i.e. it only ran when the grant was **dropping** the manager role. Setting an expiration on a grant that *keeps* the manager role (`RemoveGrant` stays `true`) skipped the check entirely, so an expiring grant could be written onto the only permanent manager.

`isSpaceManagerRemaining` already counts only **permanent** managers (`Expiration == nil`, excluding the grantee being updated), so it has everything it needs — it just wasn't being consulted in the expiration case.

## Fix

Run the remaining-manager check whenever the update could remove the last permanent manager — either by dropping the manager role **or** by giving a manager grant an expiration:

```go
func mayRemoveLastPermanentManager(grant *provider.Grant) bool {
    return !grant.GetPermissions().GetRemoveGrant() || grant.GetExpiration() != nil
}
```

The guard in `updateSpaceShare` now uses this predicate.

## Testing

- New `internal/grpc/services/gateway/usershareprovider_test.go`:
  - `TestMayRemoveLastPermanentManager` — a manager grant that gains an expiration is now treated like a manager-role drop (so the guard runs).
  - `TestIsSpaceManagerRemaining` — documents that expiring and self grants do not keep a space managed.
- `go test ./internal/grpc/services/gateway/` passes.

## Downstream

This is the reva-side fix for owncloud/ocis#11205. The oCIS dependency on `owncloud/reva/v2` will be bumped to pick it up once this merges.
