### PR TITLE
fix: vault: prevent empty storage id in a postprocessing

### DIFF
--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -438,7 +438,7 @@ func (fs *Decomposedfs) Postprocessing(ch <-chan events.Event) {
 				URL:           s,
 				SpaceOwner:    n.SpaceOwnerOrManager(ctx),
 				ExecutingUser: &user.User{Id: &user.UserId{OpaqueId: "postprocessing-restart"}}, // send nil instead?
-				ResourceID:    &provider.ResourceId{SpaceId: n.SpaceID, OpaqueId: n.ID},
+				ResourceID:    &provider.ResourceId{StorageId: session.ProviderID(), SpaceId: n.SpaceID, OpaqueId: n.ID},
 				Filename:      session.Filename(),
 				Filesize:      uint64(session.Size()),
 			}); err != nil {

--- a/pkg/storage/utils/decomposedfs/upload_async_test.go
+++ b/pkg/storage/utils/decomposedfs/upload_async_test.go
@@ -323,6 +323,39 @@ var _ = Describe("Async file uploads", Ordered, func() {
 		})
 	})
 
+	When("postprocessing is restarted", func() {
+		It("publishes a BytesReceived event whose ResourceID has the StorageId set", func() {
+			// initiate an upload that carries a providerID, mirroring how the
+			// storageprovider passes its mount id down to the session.
+			const providerID = "the-provider-id"
+			uploadIds, err := fs.InitiateUpload(ctx, ref, 10, map[string]string{"providerID": providerID})
+			Expect(err).ToNot(HaveOccurred())
+
+			uploadRef := &provider.Reference{Path: "/" + uploadIds["simple"]}
+			_, err = fs.Upload(ctx, storage.UploadRequest{
+				Ref:    uploadRef,
+				Body:   io.NopCloser(bytes.NewReader(firstContent)),
+				Length: int64(len(firstContent)),
+			}, nil)
+			Expect(err).ToNot(HaveOccurred())
+
+			restartID := uploadIds["simple"]
+
+			// drain the BytesReceived event emitted by the upload itself
+			_, ok := (<-pub).(events.BytesReceived)
+			Expect(ok).To(BeTrue())
+
+			// restart postprocessing, as `ocis storage-users uploads sessions --restart` does
+			con <- events.RestartPostprocessing{UploadID: restartID}
+
+			ev, ok := (<-pub).(events.BytesReceived)
+			Expect(ok).To(BeTrue())
+			Expect(ev.ResourceID).ToNot(BeNil())
+			Expect(ev.ResourceID.GetStorageId()).To(Equal(providerID),
+				"restart must propagate the storage/mount id so downstream events can be routed to the owning provider")
+		})
+	})
+
 	When("the uploaded file creates a new version", func() {
 		JustBeforeEach(func() {
 			succeedPostprocessing(uploadID)


### PR DESCRIPTION
fix: vault: prevent empty storage id in a postprocessing