### PR TITLE
feat: [OCISDEV-949] add option to disable direct (user/group) sharing

### DIFF
--- a/changelog/unreleased/add-enable-public-sharing-toggle.md
+++ b/changelog/unreleased/add-enable-public-sharing-toggle.md
@@ -1,0 +1,10 @@
+Enhancement: Add config option to disable public link sharing
+
+Added an `enable_public_sharing` config option to the publicshareprovider
+service. When set to `false`, creating new public links is rejected
+(internal links, which carry no permissions, are unaffected), and the
+`files_sharing.public.enabled` capability reports `false`. A hardcoded
+override that always forced `files_sharing.public.enabled` to `true` was
+also removed so the capability reflects the actual configured value.
+
+https://github.com/owncloud/reva/pull/651

--- a/changelog/unreleased/add-enable-user-sharing-toggle.md
+++ b/changelog/unreleased/add-enable-user-sharing-toggle.md
@@ -6,4 +6,4 @@ or federated shares is rejected, the `sharees` search endpoint returns
 empty results, and the `files_sharing.user.enabled` capability reports
 `false`. Public link sharing is unaffected.
 
-https://github.com/owncloud/reva/pull/XXXX
+https://github.com/owncloud/reva/pull/651

--- a/changelog/unreleased/add-enable-user-sharing-toggle.md
+++ b/changelog/unreleased/add-enable-user-sharing-toggle.md
@@ -1,0 +1,9 @@
+Enhancement: Add config option to disable direct (user/group) sharing
+
+Added an `enable_user_sharing` config option to the ocs, usershareprovider
+and ocmshareprovider services. When set to `false`, creating user, group
+or federated shares is rejected, the `sharees` search endpoint returns
+empty results, and the `files_sharing.user.enabled` capability reports
+`false`. Public link sharing is unaffected.
+
+https://github.com/owncloud/reva/pull/XXXX

--- a/internal/grpc/services/ocmshareprovider/ocmshareprovider.go
+++ b/internal/grpc/services/ocmshareprovider/ocmshareprovider.go
@@ -59,14 +59,15 @@ func init() {
 }
 
 type config struct {
-	Driver         string                            `mapstructure:"driver"`
-	Drivers        map[string]map[string]interface{} `mapstructure:"drivers"`
-	ClientTimeout  int                               `mapstructure:"client_timeout"`
-	ClientInsecure bool                              `mapstructure:"client_insecure"`
-	GatewaySVC     string                            `mapstructure:"gatewaysvc"      validate:"required"`
-	ProviderDomain string                            `mapstructure:"provider_domain" validate:"required" docs:"The same domain registered in the provider authorizer"`
-	WebDAVEndpoint string                            `mapstructure:"webdav_endpoint" validate:"required"`
-	WebappTemplate string                            `mapstructure:"webapp_template"`
+	Driver            string                            `mapstructure:"driver"`
+	Drivers           map[string]map[string]interface{} `mapstructure:"drivers"`
+	ClientTimeout     int                               `mapstructure:"client_timeout"`
+	ClientInsecure    bool                              `mapstructure:"client_insecure"`
+	GatewaySVC        string                            `mapstructure:"gatewaysvc"      validate:"required"`
+	ProviderDomain    string                            `mapstructure:"provider_domain" validate:"required" docs:"The same domain registered in the provider authorizer"`
+	WebDAVEndpoint    string                            `mapstructure:"webdav_endpoint" validate:"required"`
+	WebappTemplate    string                            `mapstructure:"webapp_template"`
+	EnableUserSharing bool                              `mapstructure:"enable_user_sharing"`
 }
 
 type service struct {
@@ -105,7 +106,7 @@ func getShareRepository(c *config) (share.Repository, error) {
 
 // New creates a new ocm share provider svc.
 func New(m map[string]interface{}, ss *grpc.Server, _ *zerolog.Logger) (rgrpc.Service, error) {
-	var c config
+	c := config{EnableUserSharing: true}
 	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
@@ -254,6 +255,12 @@ func (s *service) getProtocols(ctx context.Context, share *ocm.Share) ocmd.Proto
 }
 
 func (s *service) CreateOCMShare(ctx context.Context, req *ocm.CreateOCMShareRequest) (*ocm.CreateOCMShareResponse, error) {
+	if !s.conf.EnableUserSharing {
+		return &ocm.CreateOCMShareResponse{
+			Status: status.NewPermissionDenied(ctx, nil, "direct sharing is disabled"),
+		}, nil
+	}
+
 	gatewayClient, err := s.gatewaySelector.Next()
 	if err != nil {
 		return nil, err

--- a/internal/grpc/services/ocmshareprovider/ocmshareprovider.go
+++ b/internal/grpc/services/ocmshareprovider/ocmshareprovider.go
@@ -106,7 +106,7 @@ func getShareRepository(c *config) (share.Repository, error) {
 
 // New creates a new ocm share provider svc.
 func New(m map[string]interface{}, ss *grpc.Server, _ *zerolog.Logger) (rgrpc.Service, error) {
-	c := config{EnableUserSharing: true}
+	var c config
 	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}

--- a/internal/grpc/services/publicshareprovider/publicshareprovider.go
+++ b/internal/grpc/services/publicshareprovider/publicshareprovider.go
@@ -67,6 +67,7 @@ type config struct {
 	WriteableShareMustHavePassword bool                              `mapstructure:"writeable_share_must_have_password"`
 	PublicShareMustHavePassword    bool                              `mapstructure:"public_share_must_have_password"`
 	PasswordPolicy                 map[string]interface{}            `mapstructure:"password_policy"`
+	EnablePublicSharing            bool                              `mapstructure:"enable_public_sharing"`
 }
 
 type passwordPolicy struct {
@@ -212,6 +213,12 @@ func (s *service) CreatePublicShare(ctx context.Context, req *link.CreatePublicS
 	}
 
 	isInternalLink := grants.PermissionsEqual(req.GetGrant().GetPermissions().GetPermissions(), &provider.ResourcePermissions{})
+
+	if !isInternalLink && !s.conf.EnablePublicSharing {
+		return &link.CreatePublicShareResponse{
+			Status: status.NewPermissionDenied(ctx, nil, "public sharing is disabled"),
+		}, nil
+	}
 
 	sRes, err := gatewayClient.Stat(ctx, &provider.StatRequest{Ref: &provider.Reference{ResourceId: req.GetResourceInfo().GetId()}})
 	if err != nil {

--- a/internal/grpc/services/publicshareprovider/publicshareprovider_test.go
+++ b/internal/grpc/services/publicshareprovider/publicshareprovider_test.go
@@ -146,6 +146,7 @@ var _ = Describe("PublicShareProvider", func() {
 			"allowed_paths_for_shares":           []string{"/NewFolder"},
 			"writeable_share_must_have_password": false,
 			"public_share_must_have_password":    true,
+			"enable_public_sharing":              true,
 			"password_policy": map[string]interface{}{
 				"min_digits":               1,
 				"min_characters":           8,

--- a/internal/grpc/services/usershareprovider/usershareprovider.go
+++ b/internal/grpc/services/usershareprovider/usershareprovider.go
@@ -65,6 +65,7 @@ type config struct {
 	Drivers               map[string]map[string]interface{} `mapstructure:"drivers"`
 	GatewayAddr           string                            `mapstructure:"gateway_addr"`
 	AllowedPathsForShares []string                          `mapstructure:"allowed_paths_for_shares"`
+	EnableUserSharing     bool                              `mapstructure:"enable_user_sharing"`
 }
 
 func (c *config) init() {
@@ -73,10 +74,15 @@ func (c *config) init() {
 	}
 }
 
+func defaultConfig() *config {
+	return &config{EnableUserSharing: true}
+}
+
 type service struct {
 	sm                    share.Manager
 	gatewaySelector       pool.Selectable[gateway.GatewayAPIClient]
 	allowedPathsForShares []*regexp.Regexp
+	enableUserSharing     bool
 }
 
 func getShareManager(c *config) (share.Manager, error) {
@@ -100,7 +106,7 @@ func (s *service) Register(ss *grpc.Server) {
 }
 
 func parseConfig(m map[string]interface{}) (*config, error) {
-	c := &config{}
+	c := defaultConfig()
 	if err := mapstructure.Decode(m, c); err != nil {
 		err = errors.Wrap(err, "error decoding conf")
 		return nil, err
@@ -137,15 +143,16 @@ func NewDefault(m map[string]interface{}, ss *grpc.Server, _ *zerolog.Logger) (r
 		return nil, err
 	}
 
-	return New(gatewaySelector, sm, allowedPathsForShares), nil
+	return New(gatewaySelector, sm, allowedPathsForShares, c.EnableUserSharing), nil
 }
 
 // New creates a new user share provider svc
-func New(gatewaySelector pool.Selectable[gateway.GatewayAPIClient], sm share.Manager, allowedPathsForShares []*regexp.Regexp) rgrpc.Service {
+func New(gatewaySelector pool.Selectable[gateway.GatewayAPIClient], sm share.Manager, allowedPathsForShares []*regexp.Regexp, enableUserSharing bool) rgrpc.Service {
 	service := &service{
 		sm:                    sm,
 		gatewaySelector:       gatewaySelector,
 		allowedPathsForShares: allowedPathsForShares,
+		enableUserSharing:     enableUserSharing,
 	}
 
 	return service
@@ -171,6 +178,12 @@ func (s *service) CreateShare(ctx context.Context, req *collaboration.CreateShar
 	if HasGrantPermissions(req.GetGrant().GetPermissions().GetPermissions()) {
 		return &collaboration.CreateShareResponse{
 			Status: status.NewInvalidArg(ctx, "resharing not supported"),
+		}, nil
+	}
+
+	if !s.enableUserSharing {
+		return &collaboration.CreateShareResponse{
+			Status: status.NewPermissionDenied(ctx, nil, "direct sharing is disabled"),
 		}, nil
 	}
 

--- a/internal/grpc/services/usershareprovider/usershareprovider.go
+++ b/internal/grpc/services/usershareprovider/usershareprovider.go
@@ -74,10 +74,6 @@ func (c *config) init() {
 	}
 }
 
-func defaultConfig() *config {
-	return &config{EnableUserSharing: true}
-}
-
 type service struct {
 	sm                    share.Manager
 	gatewaySelector       pool.Selectable[gateway.GatewayAPIClient]
@@ -106,7 +102,7 @@ func (s *service) Register(ss *grpc.Server) {
 }
 
 func parseConfig(m map[string]interface{}) (*config, error) {
-	c := defaultConfig()
+	c := &config{}
 	if err := mapstructure.Decode(m, c); err != nil {
 		err = errors.Wrap(err, "error decoding conf")
 		return nil, err

--- a/internal/grpc/services/usershareprovider/usershareprovider_test.go
+++ b/internal/grpc/services/usershareprovider/usershareprovider_test.go
@@ -115,7 +115,7 @@ var _ = Describe("user share provider service", func() {
 		}
 		manager.On("GetShare", mock.Anything, mock.Anything).Return(getShareResponse, nil)
 
-		rgrpcService := usershareprovider.New(gatewaySelector, manager, []*regexp.Regexp{})
+		rgrpcService := usershareprovider.New(gatewaySelector, manager, []*regexp.Regexp{}, true)
 
 		provider = rgrpcService.(collaborationpb.CollaborationAPIServer)
 		Expect(provider).ToNot(BeNil())
@@ -367,7 +367,7 @@ var _ = Describe("user share provider service", func() {
 		)
 		Context("resharing is not allowed", func() {
 			JustBeforeEach(func() {
-				rgrpcService := usershareprovider.New(gatewaySelector, manager, []*regexp.Regexp{})
+				rgrpcService := usershareprovider.New(gatewaySelector, manager, []*regexp.Regexp{}, true)
 
 				provider = rgrpcService.(collaborationpb.CollaborationAPIServer)
 				Expect(provider).ToNot(BeNil())

--- a/internal/http/services/owncloud/ocs/config/config.go
+++ b/internal/http/services/owncloud/ocs/config/config.go
@@ -49,6 +49,7 @@ type Config struct {
 	Notifications                         map[string]interface{}            `mapstructure:"notifications"`
 	IncludeOCMSharees                     bool                              `mapstructure:"include_ocm_sharees"`
 	ShowEmailInResults                    bool                              `mapstructure:"show_email_in_results"`
+	EnableUserSharing                     bool                              `mapstructure:"enable_user_sharing"`
 }
 
 // Init sets sane defaults

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/sharees/sharees.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/sharees/sharees.go
@@ -41,6 +41,7 @@ type Handler struct {
 	additionalInfoAttribute string
 	includeOCMSharees       bool
 	showUserEmailInResults  bool
+	enableUserSharing       bool
 }
 
 // Init initializes this and any contained handlers
@@ -49,6 +50,7 @@ func (h *Handler) Init(c *config.Config) {
 	h.additionalInfoAttribute = c.AdditionalInfoAttribute
 	h.includeOCMSharees = c.IncludeOCMSharees
 	h.showUserEmailInResults = c.ShowEmailInResults
+	h.enableUserSharing = c.EnableUserSharing
 }
 
 // FindSharees implements the /apps/files_sharing/api/v1/sharees endpoint
@@ -58,6 +60,20 @@ func (h *Handler) FindSharees(w http.ResponseWriter, r *http.Request) {
 
 	if term == "" {
 		response.WriteOCSError(w, r, response.MetaBadRequest.StatusCode, "search must not be empty", nil)
+		return
+	}
+
+	if !h.enableUserSharing {
+		response.WriteOCSSuccess(w, r, &conversions.ShareeData{
+			Exact: &conversions.ExactMatchesData{
+				Users:   []*conversions.MatchData{},
+				Groups:  []*conversions.MatchData{},
+				Remotes: []*conversions.MatchData{},
+			},
+			Users:   []*conversions.MatchData{},
+			Groups:  []*conversions.MatchData{},
+			Remotes: []*conversions.MatchData{},
+		})
 		return
 	}
 

--- a/internal/http/services/owncloud/ocs/handlers/cloud/capabilities/capabilities.go
+++ b/internal/http/services/owncloud/ocs/handlers/cloud/capabilities/capabilities.go
@@ -141,7 +141,6 @@ func (h *Handler) Init(c *config.Config) {
 	}
 
 	// h.c.Capabilities.FilesSharing.IsPublic.Enabled is boolean
-	h.c.Capabilities.FilesSharing.Public.Enabled = true
 
 	if h.c.Capabilities.FilesSharing.Public.Password == nil {
 		h.c.Capabilities.FilesSharing.Public.Password = &ocs.CapabilitiesFilesSharingPublicPassword{}

--- a/internal/http/services/owncloud/ocs/ocs.go
+++ b/internal/http/services/owncloud/ocs/ocs.go
@@ -49,7 +49,7 @@ type svc struct {
 
 // New initializes the service
 func New(m map[string]interface{}, log *zerolog.Logger) (global.Service, error) {
-	conf := &config.Config{EnableUserSharing: true}
+	conf := &config.Config{}
 	if err := mapstructure.Decode(m, conf); err != nil {
 		return nil, err
 	}

--- a/internal/http/services/owncloud/ocs/ocs.go
+++ b/internal/http/services/owncloud/ocs/ocs.go
@@ -49,7 +49,7 @@ type svc struct {
 
 // New initializes the service
 func New(m map[string]interface{}, log *zerolog.Logger) (global.Service, error) {
-	conf := &config.Config{}
+	conf := &config.Config{EnableUserSharing: true}
 	if err := mapstructure.Decode(m, conf); err != nil {
 		return nil, err
 	}

--- a/pkg/owncloud/ocs/capabilities.go
+++ b/pkg/owncloud/ocs/capabilities.go
@@ -283,6 +283,7 @@ type CapabilitiesFilesSharingPublicExpireDate struct {
 
 // CapabilitiesFilesSharingUser TODO document
 type CapabilitiesFilesSharingUser struct {
+	Enabled        ocsBool                                   `json:"enabled" xml:"enabled"`
 	SendMail       ocsBool                                   `json:"send_mail" xml:"send_mail" mapstructure:"send_mail"`
 	ProfilePicture ocsBool                                   `json:"profile_picture" xml:"profile_picture" mapstructure:"profile_picture"`
 	Settings       []*CapabilitiesUserSettings               `json:"settings" xml:"settings" mapstructure:"settings"`

--- a/tests/oc-integration-tests/drone/frontend-global.toml
+++ b/tests/oc-integration-tests/drone/frontend-global.toml
@@ -54,6 +54,7 @@ webdav_namespace = "/"
 machine_auth_apikey = "change-me-please"
 
 [http.services.ocs]
+enable_user_sharing = true
 
 [http.services.ocs.capabilities.capabilities.core.status]
 version = "10.0.11.5"

--- a/tests/oc-integration-tests/drone/frontend.toml
+++ b/tests/oc-integration-tests/drone/frontend.toml
@@ -55,6 +55,7 @@ allow_depth_infinity = true
 
 [http.services.ocs]
 machine_auth_apikey = "change-me-please"
+enable_user_sharing = true
 
 [http.services.ocs.capabilities.capabilities.core.status]
 version = "10.0.11.5"

--- a/tests/oc-integration-tests/drone/shares.toml
+++ b/tests/oc-integration-tests/drone/shares.toml
@@ -9,12 +9,16 @@ address = "0.0.0.0:17000"
 
 [grpc.services.usershareprovider]
 driver = "memory"
+enable_user_sharing = true
 
 [grpc.services.authprovider]
 auth_manager = "publicshares"
 
 [grpc.services.authprovider.auth_managers.publicshares]
 gateway_addr = "localhost:19000"
+
+[grpc.services.publicshareprovider]
+enable_public_sharing = true
 
 [grpc.services.publicshareprovider.drivers.json]
 file = "/drone/src/tmp/reva/publicshares.json"

--- a/tests/oc-integration-tests/local-mesh/frontend-global.toml
+++ b/tests/oc-integration-tests/local-mesh/frontend-global.toml
@@ -48,6 +48,7 @@ webdav_namespace = "/"
 machine_auth_apikey = "change-me-please"
 
 [http.services.ocs]
+enable_user_sharing = true
 
 [http.services.ocs.capabilities.capabilities.core.status]
 version = "10.0.11.5"

--- a/tests/oc-integration-tests/local-mesh/frontend.toml
+++ b/tests/oc-integration-tests/local-mesh/frontend.toml
@@ -50,6 +50,7 @@ machine_auth_apikey = "change-me-please"
 
 # serve /ocs which contains the sharing and user provisioning api of owncloud classic
 [http.services.ocs]
+enable_user_sharing = true
 
 [http.services.ocs.capabilities.capabilities.core.status]
 version = "10.0.11.5"

--- a/tests/oc-integration-tests/local-mesh/shares.toml
+++ b/tests/oc-integration-tests/local-mesh/shares.toml
@@ -9,12 +9,16 @@ address = "0.0.0.0:37000"
 
 [grpc.services.usershareprovider]
 driver = "memory"
+enable_user_sharing = true
 
 [grpc.services.authprovider]
 auth_manager = "publicshares"
 
 [grpc.services.authprovider.auth_managers.publicshares]
 gateway_addr = "0.0.0.0:39000"
+
+[grpc.services.publicshareprovider]
+enable_public_sharing = true
 
 [grpc.services.publicshareprovider.drivers.json]
 file = "/var/tmp/reva/publicshares.json"

--- a/tests/oc-integration-tests/local/combined.toml
+++ b/tests/oc-integration-tests/local/combined.toml
@@ -87,6 +87,7 @@ usershareprovidersvc = "0.0.0.0:19000"
 
 [grpc.services.usershareprovider]
 driver = "memory"
+enable_user_sharing = true
 
 
 [http]
@@ -129,6 +130,7 @@ machine_auth_apikey = "change-me-please"
 
 [http.services.ocs]
 machine_auth_apikey = "change-me-please"
+enable_user_sharing = true
 
 [http.services.ocs.capabilities.capabilities.core.status]
 version = "10.0.11.5"

--- a/tests/oc-integration-tests/local/frontend-global.toml
+++ b/tests/oc-integration-tests/local/frontend-global.toml
@@ -55,6 +55,7 @@ webdav_namespace = "/"
 machine_auth_apikey = "change-me-please"
 
 [http.services.ocs]
+enable_user_sharing = true
 
 [http.services.ocs.capabilities.capabilities.core.status]
 version = "10.0.11.5"

--- a/tests/oc-integration-tests/local/frontend.toml
+++ b/tests/oc-integration-tests/local/frontend.toml
@@ -63,6 +63,7 @@ allow_depth_infinity = true
 # serve /ocs which contains the sharing and user provisioning api of owncloud classic
 [http.services.ocs]
 machine_auth_apikey = "change-me-please"
+enable_user_sharing = true
 
 [http.services.ocs.capabilities.capabilities.core.status]
 version = "10.0.11.5"

--- a/tests/oc-integration-tests/local/shares.toml
+++ b/tests/oc-integration-tests/local/shares.toml
@@ -19,12 +19,16 @@ enabled = true
 
 [grpc.services.usershareprovider]
 driver = "memory"
+enable_user_sharing = true
 
 [grpc.services.authprovider]
 auth_manager = "publicshares"
 
 [grpc.services.authprovider.auth_managers.publicshares]
 gateway_addr = "0.0.0.0:19000"
+
+[grpc.services.publicshareprovider]
+enable_public_sharing = true
 
 [grpc.services.publicshareprovider.drivers.json]
 file = "/tmp/reva/publicshares.json"


### PR DESCRIPTION
Adds an `enable_user_sharing` config option to the `ocs`, `usershareprovider` and `ocmshareprovider` services. Defaults to `true`.
  
When set to `false`:
  - `usershareprovider.CreateShare` and `ocmshareprovider.CreateOCMShare` reject
    requests to share a resource with a user, group, or federated (remote) user.
    Public link sharing is not affected.
  - The legacy `/apps/files_sharing/api/v1/sharees` search endpoint returns an
    empty result set instead of searching users/groups.
  - The `files_sharing.user.enabled` capability is set to `false`, so clients
    can hide the corresponding UI.
  
  This is consumed by a corresponding oCIS change that wires the new option to
  an `OCIS_ENABLE_USER_SHARING` config toggle.