### PR TITLE
feat: [OCISDEV-1031] implement PasswordModify and ModifyWithResult on LDAP clients

### DIFF
--- a/changelog/unreleased/enhancement-ldap-pool-password-modify.md
+++ b/changelog/unreleased/enhancement-ldap-pool-password-modify.md
@@ -1,0 +1,9 @@
+Enhancement: Implement PasswordModify and ModifyWithResult on the LDAP clients
+
+`ConnWithReconnect` and `ConnPool` (`pkg/utils/ldap`) previously stubbed out
+`PasswordModify` and `ModifyWithResult` with a "not implemented" error. Both
+are now implemented (with the same retry-on-network-error behaviour as the
+other operations), so callers that rely on the LDAP Password Modify Extended
+Operation or on `ModifyWithResult` no longer break when using either client.
+
+https://github.com/owncloud/reva/pull/665

--- a/pkg/utils/ldap/pool.go
+++ b/pkg/utils/ldap/pool.go
@@ -303,7 +303,13 @@ func (p *ConnPool) Unbind() error {
 
 // ModifyWithResult implements the ldap.Client interface
 func (p *ConnPool) ModifyWithResult(m *ldap.ModifyRequest) (*ldap.ModifyResult, error) {
-	return nil, ldap.NewError(ldap.LDAPResultNotSupported, fmt.Errorf("not implemented"))
+	var res *ldap.ModifyResult
+	err := p.do(func(conn ldap.Client) error {
+		var err error
+		res, err = conn.ModifyWithResult(m)
+		return err
+	})
+	return res, err
 }
 
 // Compare implements the ldap.Client interface
@@ -312,8 +318,14 @@ func (p *ConnPool) Compare(dn, attribute, value string) (bool, error) {
 }
 
 // PasswordModify implements the ldap.Client interface
-func (p *ConnPool) PasswordModify(*ldap.PasswordModifyRequest) (*ldap.PasswordModifyResult, error) {
-	return nil, ldap.NewError(ldap.LDAPResultNotSupported, fmt.Errorf("not implemented"))
+func (p *ConnPool) PasswordModify(m *ldap.PasswordModifyRequest) (*ldap.PasswordModifyResult, error) {
+	var res *ldap.PasswordModifyResult
+	err := p.do(func(conn ldap.Client) error {
+		var err error
+		res, err = conn.PasswordModify(m)
+		return err
+	})
+	return res, err
 }
 
 // SearchWithPaging implements the ldap.Client interface

--- a/pkg/utils/ldap/pool_test.go
+++ b/pkg/utils/ldap/pool_test.go
@@ -46,10 +46,16 @@ func (f *fakeConn) Close() error {
 }
 
 func (f *fakeConn) PasswordModify(req *ldap.PasswordModifyRequest) (*ldap.PasswordModifyResult, error) {
+	if f.passwordModifyFunc == nil {
+		return nil, errors.New("fakeConn: passwordModifyFunc not set")
+	}
 	return f.passwordModifyFunc(req)
 }
 
 func (f *fakeConn) ModifyWithResult(req *ldap.ModifyRequest) (*ldap.ModifyResult, error) {
+	if f.modifyWithResultFunc == nil {
+		return nil, errors.New("fakeConn: modifyWithResultFunc not set")
+	}
 	return f.modifyWithResultFunc(req)
 }
 
@@ -270,6 +276,69 @@ func TestConnPoolModifyWithResult(t *testing.T) {
 	}
 	if gotReq != req {
 		t.Fatalf("expected the request to be forwarded to the underlying connection")
+	}
+}
+
+func TestConnPoolPasswordModifyRetriesOnceOnNetworkError(t *testing.T) {
+	p, dialCount := newTestPool(2, time.Second)
+
+	var calls int
+	p.dial = func(Config) (ldap.Client, error) {
+		atomic.AddInt32(dialCount, 1)
+		return &fakeConn{
+			passwordModifyFunc: func(req *ldap.PasswordModifyRequest) (*ldap.PasswordModifyResult, error) {
+				calls++
+				if calls == 1 {
+					return nil, ldap.NewError(ldap.ErrorNetwork, errors.New("boom"))
+				}
+				return &ldap.PasswordModifyResult{GeneratedPassword: "generated"}, nil
+			},
+		}, nil
+	}
+
+	req := ldap.NewPasswordModifyRequest("uid=test", "old", "new")
+	res, err := p.PasswordModify(req)
+	if err != nil {
+		t.Fatalf("expected PasswordModify to succeed after one retry, got %v", err)
+	}
+	if res.GeneratedPassword != "generated" {
+		t.Fatalf("expected the result to be forwarded from the retried connection, got %q", res.GeneratedPassword)
+	}
+	if calls != 2 {
+		t.Fatalf("expected passwordModifyFunc to be called twice (initial + 1 retry), got %d", calls)
+	}
+	if got := atomic.LoadInt32(dialCount); got != 2 {
+		t.Fatalf("expected a redial for the retry attempt, got %d dials", got)
+	}
+}
+
+func TestConnPoolModifyWithResultRetriesOnceOnNetworkError(t *testing.T) {
+	p, dialCount := newTestPool(2, time.Second)
+
+	var calls int
+	p.dial = func(Config) (ldap.Client, error) {
+		atomic.AddInt32(dialCount, 1)
+		return &fakeConn{
+			modifyWithResultFunc: func(req *ldap.ModifyRequest) (*ldap.ModifyResult, error) {
+				calls++
+				if calls == 1 {
+					return nil, ldap.NewError(ldap.ErrorNetwork, errors.New("boom"))
+				}
+				return &ldap.ModifyResult{}, nil
+			},
+		}, nil
+	}
+
+	req := ldap.NewModifyRequest("uid=test", nil)
+	_, err := p.ModifyWithResult(req)
+	if err != nil {
+		t.Fatalf("expected ModifyWithResult to succeed after one retry, got %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("expected modifyWithResultFunc to be called twice (initial + 1 retry), got %d", calls)
+	}
+	if got := atomic.LoadInt32(dialCount); got != 2 {
+		t.Fatalf("expected a redial for the retry attempt, got %d dials", got)
 	}
 }
 

--- a/pkg/utils/ldap/pool_test.go
+++ b/pkg/utils/ldap/pool_test.go
@@ -29,16 +29,28 @@ import (
 )
 
 // fakeConn is a minimal ldap.Client double used to test pool bookkeeping without a real LDAP
-// server. It embeds a nil ldap.Client so it satisfies the interface; only Close is overridden,
-// which is the only method the pool itself calls on connections it manages.
+// server. It embeds a nil ldap.Client so it satisfies the interface; only Close is overridden by
+// default (the only method the pool itself calls on connections it manages), with
+// passwordModifyFunc/modifyWithResultFunc as optional overrides for tests exercising those methods.
 type fakeConn struct {
 	ldap.Client
 	closed bool
+
+	passwordModifyFunc   func(*ldap.PasswordModifyRequest) (*ldap.PasswordModifyResult, error)
+	modifyWithResultFunc func(*ldap.ModifyRequest) (*ldap.ModifyResult, error)
 }
 
 func (f *fakeConn) Close() error {
 	f.closed = true
 	return nil
+}
+
+func (f *fakeConn) PasswordModify(req *ldap.PasswordModifyRequest) (*ldap.PasswordModifyResult, error) {
+	return f.passwordModifyFunc(req)
+}
+
+func (f *fakeConn) ModifyWithResult(req *ldap.ModifyRequest) (*ldap.ModifyResult, error) {
+	return f.modifyWithResultFunc(req)
 }
 
 // newTestPool returns a pool with a fake, network-free dial function and a counter of how many
@@ -207,6 +219,57 @@ func TestConnPoolCloseDrainsIdleAndRejectsCheckout(t *testing.T) {
 	}
 	if _, err := p.checkout(); !errors.Is(err, errPoolClosed) {
 		t.Fatalf("expected errPoolClosed, got %v", err)
+	}
+}
+
+func TestConnPoolPasswordModify(t *testing.T) {
+	p, dialCount := newTestPool(2, time.Second)
+
+	var gotReq *ldap.PasswordModifyRequest
+	p.dial = func(Config) (ldap.Client, error) {
+		atomic.AddInt32(dialCount, 1)
+		return &fakeConn{
+			passwordModifyFunc: func(req *ldap.PasswordModifyRequest) (*ldap.PasswordModifyResult, error) {
+				gotReq = req
+				return &ldap.PasswordModifyResult{GeneratedPassword: "generated"}, nil
+			},
+		}, nil
+	}
+
+	req := ldap.NewPasswordModifyRequest("uid=test", "old", "new")
+	res, err := p.PasswordModify(req)
+	if err != nil {
+		t.Fatalf("PasswordModify failed: %v", err)
+	}
+	if gotReq != req {
+		t.Fatalf("expected the request to be forwarded to the underlying connection")
+	}
+	if res.GeneratedPassword != "generated" {
+		t.Fatalf("expected the result to be forwarded from the underlying connection, got %q", res.GeneratedPassword)
+	}
+}
+
+func TestConnPoolModifyWithResult(t *testing.T) {
+	p, dialCount := newTestPool(2, time.Second)
+
+	var gotReq *ldap.ModifyRequest
+	p.dial = func(Config) (ldap.Client, error) {
+		atomic.AddInt32(dialCount, 1)
+		return &fakeConn{
+			modifyWithResultFunc: func(req *ldap.ModifyRequest) (*ldap.ModifyResult, error) {
+				gotReq = req
+				return &ldap.ModifyResult{}, nil
+			},
+		}, nil
+	}
+
+	req := ldap.NewModifyRequest("uid=test", nil)
+	_, err := p.ModifyWithResult(req)
+	if err != nil {
+		t.Fatalf("ModifyWithResult failed: %v", err)
+	}
+	if gotReq != req {
+		t.Fatalf("expected the request to be forwarded to the underlying connection")
 	}
 }
 

--- a/pkg/utils/ldap/reconnect.go
+++ b/pkg/utils/ldap/reconnect.go
@@ -286,7 +286,15 @@ func (c *ConnWithReconnect) ExternalBind() error {
 
 // ModifyWithResult implements the ldap.Client interface
 func (c *ConnWithReconnect) ModifyWithResult(m *ldap.ModifyRequest) (*ldap.ModifyResult, error) {
-	return nil, ldap.NewError(ldap.LDAPResultNotSupported, fmt.Errorf("not implemented"))
+	var err error
+	var res *ldap.ModifyResult
+
+	retryErr := c.retry(func(c ldap.Client) error {
+		res, err = c.ModifyWithResult(m)
+		return err
+	})
+
+	return res, retryErr
 }
 
 // Compare implements the ldap.Client interface
@@ -295,8 +303,16 @@ func (c *ConnWithReconnect) Compare(dn, attribute, value string) (bool, error) {
 }
 
 // PasswordModify implements the ldap.Client interface
-func (c *ConnWithReconnect) PasswordModify(*ldap.PasswordModifyRequest) (*ldap.PasswordModifyResult, error) {
-	return nil, ldap.NewError(ldap.LDAPResultNotSupported, fmt.Errorf("not implemented"))
+func (c *ConnWithReconnect) PasswordModify(m *ldap.PasswordModifyRequest) (*ldap.PasswordModifyResult, error) {
+	var err error
+	var res *ldap.PasswordModifyResult
+
+	retryErr := c.retry(func(c ldap.Client) error {
+		res, err = c.PasswordModify(m)
+		return err
+	})
+
+	return res, retryErr
 }
 
 // SearchWithPaging implements the ldap.Client interface


### PR DESCRIPTION
`ConnWithReconnect` and `ConnPool` (`pkg/utils/ldap`) stubbed out `PasswordModify` and `ModifyWithResult` with a "not implemented" error, copied over from the existing set of unimplemented `ldap.Client` methods. This implements both on each client via their existing retry helpers (`retry` on `ConnWithReconnect`, `do` on `ConnPool`), mirroring the retry-on-network-error behaviour already used by `Search`/`Add`/`Modify`/etc.

This is a prerequisite for unifying oCIS's graph service onto this package's LDAP client: graph's own hand-rolled reconnect implementation fully implements both methods (and actually calls `PasswordModify` behind `GRAPH_LDAP_SERVER_USE_PASSWORD_MODIFY_EXOP`), so swapping it onto `ConnWithReconnect`/`ConnPool` as-is would silently break that path.

Follow-up to #658 ([OCISDEV-1031](https://kiteworks.atlassian.net/browse/OCISDEV-1031)).