### PR TITLE
fix: [OCISDEV-1045] Show vault-shared mountpoints in the vault drive list

### DIFF
--- a/changelog/unreleased/fix-vault-shared-mountpoints.md
+++ b/changelog/unreleased/fix-vault-shared-mountpoints.md
@@ -1,0 +1,14 @@
+Bugfix: Show vault-shared mountpoints in the vault drive list
+
+Shares of vault resources are mountpoints hosted on the shares storage provider
+that grant into the vault storage provider. When listing spaces with the vault
+`storage_id`, the storage registry skipped the shares provider entirely, so the
+vault share mountpoint was missing from the vault drive list while still showing
+up in the regular drive list.
+
+The registry now also queries the shares provider when the vault storage id is
+requested and segregates share mountpoints by their `grantStorageID`, so a vault
+share only appears in the vault drive list and a regular share only in the
+regular one.
+
+https://github.com/owncloud/reva/pull/666

--- a/pkg/storage/registry/spaces/spaces.go
+++ b/pkg/storage/registry/spaces/spaces.go
@@ -364,8 +364,11 @@ func (r *registry) findProvidersForFilter(ctx context.Context, filters []*provid
 	currentUser := ctxpkg.ContextMustGetUser(ctx)
 	providerInfos := []*registrypb.ProviderInfo{}
 	for address, provider := range r.c.Providers {
-		// skip mismatching storageproviders
-		if storageId != "" && storageId != provider.ProviderID {
+		// skip mismatching storageproviders. The shares provider hosts the
+		// mountpoints of vault shares (they grant into the vault provider), so it
+		// must still be queried when the vault storage id is requested.
+		if storageId != "" && storageId != provider.ProviderID &&
+			!(storageId == utils.VaultStorageProviderID && provider.ProviderID == utils.ShareStorageProviderID) {
 			continue
 		}
 		// when a specific space type is requested we may skip this provider altogether if it is not configured for that type
@@ -403,6 +406,15 @@ func (r *registry) findProvidersForFilter(ctx context.Context, filters []*provid
 				// Filter out vault spaces if no storageId is provided
 				if storageId == "" && provider.ProviderID == utils.VaultStorageProviderID {
 					continue
+				}
+				// Shares of vault resources are mountpoints hosted on the shares
+				// provider that grant into the vault provider. Segregate them so
+				// they only appear in the matching (vault / non-vault) drive list.
+				if provider.ProviderID == utils.ShareStorageProviderID && space.SpaceType == "mountpoint" {
+					grantsIntoVault := utils.ReadPlainFromOpaque(space.Opaque, "grantStorageID") == utils.VaultStorageProviderID
+					if grantsIntoVault != (storageId == utils.VaultStorageProviderID) {
+						continue
+					}
 				}
 				spacePath, err = sc.SpacePath(currentUser, space)
 				if err != nil {

--- a/pkg/storage/registry/spaces/spaces_test.go
+++ b/pkg/storage/registry/spaces/spaces_test.go
@@ -26,6 +26,7 @@ import (
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	rpcv1beta1 "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	registrypb "github.com/cs3org/go-cs3apis/cs3/storage/registry/v1beta1"
 	ctxpkg "github.com/owncloud/reva/v2/pkg/ctx"
 	"github.com/owncloud/reva/v2/pkg/storage"
 	"github.com/owncloud/reva/v2/pkg/storage/registry/spaces"
@@ -471,6 +472,127 @@ var _ = Describe("Spaces", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(len(providers)).To(Equal(1))
 				Expect(providers[0].Address).To(Equal("com.owncloud.api.storage-users-vault"))
+			})
+		})
+	})
+
+	Context("with a shares provider serving vault and non-vault mountpoints", func() {
+		var sharesClient *mocks.StorageProviderClient
+
+		const (
+			regularStorageID = "provider-regular-id"
+			vaultStorageID   = "provider-vault-id"
+			sharesStorageID  = "provider-shares-id"
+		)
+
+		BeforeEach(func() {
+			utils.VaultStorageProviderID = vaultStorageID
+			utils.ShareStorageProviderID = sharesStorageID
+
+			sharesClient = &mocks.StorageProviderClient{}
+			sharesClient.On("ListStorageSpaces", mock.Anything, mock.Anything).Return(
+				func(_ context.Context, _ *provider.ListStorageSpacesRequest, _ ...grpc.CallOption) *provider.ListStorageSpacesResponse {
+					jailRoot := &provider.ResourceId{StorageId: sharesStorageID, SpaceId: sharesStorageID, OpaqueId: sharesStorageID}
+					virtualSpace := &provider.StorageSpace{
+						Id:        &provider.StorageSpaceId{OpaqueId: storagespace.FormatResourceID(jailRoot)},
+						Root:      jailRoot,
+						Name:      "Shares",
+						SpaceType: "virtual",
+					}
+					vaultMountpoint := &provider.StorageSpace{
+						Id:        &provider.StorageSpaceId{OpaqueId: sharesStorageID + "$" + sharesStorageID + "!vault-share"},
+						Root:      &provider.ResourceId{StorageId: sharesStorageID, SpaceId: sharesStorageID, OpaqueId: "vault-share"},
+						Name:      "Vault share",
+						SpaceType: "mountpoint",
+						Owner:     alice,
+						Opaque:    utils.AppendPlainToOpaque(nil, "grantStorageID", vaultStorageID),
+					}
+					regularMountpoint := &provider.StorageSpace{
+						Id:        &provider.StorageSpaceId{OpaqueId: sharesStorageID + "$" + sharesStorageID + "!regular-share"},
+						Root:      &provider.ResourceId{StorageId: sharesStorageID, SpaceId: sharesStorageID, OpaqueId: "regular-share"},
+						Name:      "Regular share",
+						SpaceType: "mountpoint",
+						Owner:     alice,
+						Opaque:    utils.AppendPlainToOpaque(nil, "grantStorageID", regularStorageID),
+					}
+					return &provider.ListStorageSpacesResponse{
+						Status:        &rpcv1beta1.Status{Code: rpcv1beta1.Code_CODE_OK},
+						StorageSpaces: []*provider.StorageSpace{virtualSpace, vaultMountpoint, regularMountpoint},
+					}
+				}, nil)
+
+			rules = map[string]interface{}{
+				"providers": map[string]interface{}{
+					"com.owncloud.api.storage-shares": map[string]interface{}{
+						"providerid": sharesStorageID,
+						"spaces": map[string]interface{}{
+							"virtual": map[string]interface{}{
+								"mount_point": "/users/{{.CurrentUser.Id.OpaqueId}}/Shares",
+							},
+							"grant": map[string]interface{}{
+								"mount_point": ".",
+							},
+							"mountpoint": map[string]interface{}{
+								"mount_point":   "/users/{{.CurrentUser.Id.OpaqueId}}/Shares",
+								"path_template": "/users/{{.CurrentUser.Id.OpaqueId}}/Shares/{{.Space.Name}}",
+							},
+						},
+					},
+					"com.owncloud.api.storage-users-vault": map[string]interface{}{
+						"providerid": vaultStorageID,
+						"spaces": map[string]interface{}{
+							"personal": map[string]interface{}{
+								"mount_point":   "/vault/users",
+								"path_template": "/vault/users/{{.Space.Owner.Id.OpaqueId}}",
+							},
+						},
+					},
+				},
+			}
+
+			getClientFunc = func(addr string) (spaces.StorageProviderClient, error) {
+				switch addr {
+				case "com.owncloud.api.storage-shares":
+					return sharesClient, nil
+				case "com.owncloud.api.storage-users-vault":
+					return fooClient, nil
+				}
+				return nil, fmt.Errorf("unexpected address %q", addr)
+			}
+		})
+
+		mountpointNames := func(providers []*registrypb.ProviderInfo) []string {
+			names := []string{}
+			for _, p := range providers {
+				if p.Opaque == nil || p.Opaque.Map["spaces"] == nil {
+					continue
+				}
+				sp := []*provider.StorageSpace{}
+				Expect(json.Unmarshal(p.Opaque.Map["spaces"].Value, &sp)).To(Succeed())
+				for _, s := range sp {
+					if s.SpaceType == "mountpoint" {
+						names = append(names, s.Name)
+					}
+				}
+			}
+			return names
+		}
+
+		Describe("ListProviders", func() {
+			It("excludes vault-shared mountpoints from the regular drive list", func() {
+				filters := map[string]string{"user_id": "alice"}
+
+				providers, err := handler.ListProviders(ctxAlice, filters)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(mountpointNames(providers)).To(ConsistOf("Regular share"))
+			})
+
+			It("includes vault-shared mountpoints when the vault storage_id is requested", func() {
+				filters := map[string]string{"user_id": "alice", "storage_id": vaultStorageID}
+
+				providers, err := handler.ListProviders(ctxAlice, filters)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(mountpointNames(providers)).To(ConsistOf("Vault share"))
 			})
 		})
 	})


### PR DESCRIPTION
Bugfix: Show vault-shared mountpoints in the vault drive list

Shares of vault resources are mountpoints hosted on the shares storage provider
that grant into the vault storage provider. When listing spaces with the vault
`storage_id`, the storage registry skipped the shares provider entirely, so the
vault share mountpoint was missing from the vault drive list while still showing
up in the regular drive list.

The registry now also queries the shares provider when the vault storage id is
requested and segregates share mountpoints by their `grantStorageID`, so a vault
share only appears in the vault drive list and a regular share only in the
regular one.