### PR TITLE
feat: OCISDEV-1059 rollback upload

### DIFF
--- a/pkg/ocm/storage/received/ocm.go
+++ b/pkg/ocm/storage/received/ocm.go
@@ -663,3 +663,7 @@ func (d *driver) DeleteStorageSpace(ctx context.Context, req *provider.DeleteSto
 func (d *driver) PrepareUpload(_ context.Context, _ *provider.Reference, _ string, info storage.UploadInfo) (*storage.PrepareUploadResult, error) {
 	return &storage.PrepareUploadResult{VersionCreated: info.NodeExisted}, nil
 }
+
+func (d *driver) RollbackUpload(_ context.Context, _ *provider.Reference, _ string, _ bool, _ int64) error {
+	return nil
+}

--- a/pkg/storage/fs/cephfs/upload.go
+++ b/pkg/storage/fs/cephfs/upload.go
@@ -159,6 +159,10 @@ func (fs *cephfs) PrepareUpload(_ context.Context, _ *provider.Reference, _ stri
 	return &storage.PrepareUploadResult{VersionCreated: info.NodeExisted}, nil
 }
 
+func (fs *cephfs) RollbackUpload(_ context.Context, _ *provider.Reference, _ string, _ bool, _ int64) error {
+	return nil
+}
+
 // UseIn tells the tus upload middleware which extensions it supports.
 func (fs *cephfs) UseIn(composer *tusd.StoreComposer) {
 	composer.UseCore(fs)

--- a/pkg/storage/fs/hello/unimplemented.go
+++ b/pkg/storage/fs/hello/unimplemented.go
@@ -98,6 +98,10 @@ func (fs *hellofs) PrepareUpload(_ context.Context, _ *provider.Reference, _ str
 	return &storage.PrepareUploadResult{VersionCreated: info.NodeExisted}, nil
 }
 
+func (fs *hellofs) RollbackUpload(_ context.Context, _ *provider.Reference, _ string, _ bool, _ int64) error {
+	return nil
+}
+
 // grants
 
 // DenyGrant marks a resource as denied for a recipient

--- a/pkg/storage/fs/kiteworks/kiteworks.go
+++ b/pkg/storage/fs/kiteworks/kiteworks.go
@@ -279,6 +279,10 @@ func (d *Driver) PrepareUpload(_ context.Context, _ *provider.Reference, _ strin
 	return &storage.PrepareUploadResult{VersionCreated: info.NodeExisted}, nil
 }
 
+func (d *Driver) RollbackUpload(_ context.Context, _ *provider.Reference, _ string, _ bool, _ int64) error {
+	return nil
+}
+
 func (d *Driver) RestoreRevision(_ context.Context, _ *provider.Reference, _ string) (*storage.RestoreRevisionResult, error) {
 	return nil, errtypes.NotSupported("kiteworks: read-only driver")
 }

--- a/pkg/storage/fs/nextcloud/nextcloud.go
+++ b/pkg/storage/fs/nextcloud/nextcloud.go
@@ -423,6 +423,10 @@ func (nc *StorageDriver) PrepareUpload(_ context.Context, _ *provider.Reference,
 	return &storage.PrepareUploadResult{VersionCreated: info.NodeExisted}, nil
 }
 
+func (nc *StorageDriver) RollbackUpload(_ context.Context, _ *provider.Reference, _ string, _ bool, _ int64) error {
+	return nil
+}
+
 // Upload as defined in the storage.FS interface
 func (nc *StorageDriver) Upload(ctx context.Context, req storage.UploadRequest, _ storage.UploadFinishedFunc) (*provider.ResourceInfo, error) {
 	err := nc.doUpload(ctx, req.Ref.Path, req.Body)

--- a/pkg/storage/fs/owncloudsql/upload.go
+++ b/pkg/storage/fs/owncloudsql/upload.go
@@ -181,6 +181,10 @@ func (fs *owncloudsqlfs) PrepareUpload(_ context.Context, _ *provider.Reference,
 	return &storage.PrepareUploadResult{VersionCreated: info.NodeExisted}, nil
 }
 
+func (fs *owncloudsqlfs) RollbackUpload(_ context.Context, _ *provider.Reference, _ string, _ bool, _ int64) error {
+	return nil
+}
+
 // UseIn tells the tus upload middleware which extensions it supports.
 func (fs *owncloudsqlfs) UseIn(composer *tusd.StoreComposer) {
 	composer.UseCore(fs)

--- a/pkg/storage/fs/s3/upload.go
+++ b/pkg/storage/fs/s3/upload.go
@@ -85,3 +85,7 @@ func (fs *s3FS) CommitUpload(_ context.Context, _ *provider.Reference, _ string,
 func (fs *s3FS) PrepareUpload(_ context.Context, _ *provider.Reference, _ string, info storage.UploadInfo) (*storage.PrepareUploadResult, error) {
 	return &storage.PrepareUploadResult{VersionCreated: info.NodeExisted}, nil
 }
+
+func (fs *s3FS) RollbackUpload(_ context.Context, _ *provider.Reference, _ string, _ bool, _ int64) error {
+	return nil
+}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -149,6 +149,8 @@ type FS interface {
 	// It is the inverse of PrepareUpload: restores previous metadata and reverts the optimistic
 	// size propagation. The caller (coordinator) is responsible for unmarking the processing flag
 	// and deleting the upload session files. Drivers that performed no work in PrepareUpload may return nil.
+	// nodeExisted indicates whether the target node had a prior version; drivers that have nothing
+	// to undo for new nodes may no-op when nodeExisted is false.
 	RollbackUpload(ctx context.Context, ref *provider.Reference, sessionID string, nodeExisted bool, sizeDiff int64) error
 
 	// Revisions

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -87,6 +87,7 @@ type UploadInfo struct {
 
 type PrepareUploadResult struct {
 	VersionCreated bool
+	SizeDiff       int64
 }
 
 // FS is the interface to implement access to the storage.
@@ -144,6 +145,11 @@ type FS interface {
 	// Implementations may lock the target node, snapshot the previous version, write new metadata,
 	// and propagate size changes. Drivers that do not require any of these steps may return immediately.
 	PrepareUpload(ctx context.Context, ref *provider.Reference, sessionID string, info UploadInfo) (*PrepareUploadResult, error)
+	// RollbackUpload reverts node state after a failed or aborted postprocessing run.
+	// It is the inverse of PrepareUpload: restores previous metadata and reverts the optimistic
+	// size propagation. The caller (coordinator) is responsible for unmarking the processing flag
+	// and deleting the upload session files. Drivers that performed no work in PrepareUpload may return nil.
+	RollbackUpload(ctx context.Context, ref *provider.Reference, sessionID string, nodeExisted bool, sizeDiff int64) error
 
 	// Revisions
 

--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -473,7 +473,7 @@ func (fs *Decomposedfs) processEvent(evCtx context.Context, event events.Event, 
 			return
 		}
 
-		if err := n.RevertCurrentRevision(ctx); err != nil {
+		if err := n.RevertCurrentRevision(ctx, true); err != nil {
 			sublog.Error().Err(err).Msg("Failed to revert revision")
 			return
 		}

--- a/pkg/storage/utils/decomposedfs/node/node.go
+++ b/pkg/storage/utils/decomposedfs/node/node.go
@@ -1400,7 +1400,7 @@ func (n *Node) SetDTime(ctx context.Context, t *time.Time) (err error) {
 }
 
 // RevertCurrentRevision reverts an upload by either deleting the node or restoring the latest version
-func (n *Node) RevertCurrentRevision(ctx context.Context) error {
+func (n *Node) RevertCurrentRevision(ctx context.Context, unmarkProcessing bool) error {
 	versionPath, err := n.getLatestRevision(ctx)
 	if err != nil {
 		return err
@@ -1431,11 +1431,12 @@ func (n *Node) RevertCurrentRevision(ctx context.Context) error {
 		return err
 	}
 
-	// we just reverted an upload - remove processing flag if set
-	if uploadid, err := n.ProcessingID(ctx); err == nil {
-		if err := n.UnmarkProcessing(ctx, uploadid); err != nil {
-			appctx.GetLogger(ctx).Info().Str("path", n.InternalPath()).Err(err).Msg("unmarking processing failed")
-			return err
+	if unmarkProcessing {
+		if uploadid, err := n.ProcessingID(ctx); err == nil {
+			if err := n.UnmarkProcessing(ctx, uploadid); err != nil {
+				appctx.GetLogger(ctx).Info().Str("path", n.InternalPath()).Err(err).Msg("unmarking processing failed")
+				return err
+			}
 		}
 	}
 	return nil

--- a/pkg/storage/utils/decomposedfs/rollback_upload_test.go
+++ b/pkg/storage/utils/decomposedfs/rollback_upload_test.go
@@ -1,0 +1,126 @@
+package decomposedfs_test
+
+import (
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/owncloud/reva/v2/pkg/storage"
+	"github.com/owncloud/reva/v2/pkg/storage/utils/decomposedfs/metadata/prefixes"
+	helpers "github.com/owncloud/reva/v2/pkg/storage/utils/decomposedfs/testhelpers"
+	"github.com/stretchr/testify/mock"
+)
+
+var _ = Describe("RollbackUpload", func() {
+	var (
+		env *helpers.TestEnv
+		ref *provider.Reference
+	)
+
+	JustBeforeEach(func() {
+		var err error
+		env, err = helpers.NewTestEnv(nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).
+			Return(&provider.ResourcePermissions{
+				InitiateFileUpload: true,
+				Stat:               true,
+				ListFileVersions:   true,
+			}, nil)
+
+		ref = &provider.Reference{
+			ResourceId: env.SpaceRootRes,
+			Path:       "/dir1/rollback-target.txt",
+		}
+	})
+
+	AfterEach(func() {
+		if env != nil {
+			env.Cleanup()
+		}
+	})
+
+	Context("versioning enabled, existing node, session owns node", func() {
+		It("restores previous version, removes version file, reverts size propagation", func() {
+			_, err := env.Fs.TouchFile(env.Ctx, ref, false, "")
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = env.Fs.PrepareUpload(env.Ctx, ref, "session-init", storage.UploadInfo{
+				NodeExisted: false,
+				Size:        10,
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			parentInfoBefore, err := env.Fs.GetMD(env.Ctx, &provider.Reference{ResourceId: env.SpaceRootRes, Path: "/dir1"}, []string{}, []string{})
+			Expect(err).ToNot(HaveOccurred())
+			sizeBefore := parentInfoBefore.Size
+
+			result, err := env.Fs.PrepareUpload(env.Ctx, ref, "session-overwrite", storage.UploadInfo{
+				NodeExisted: true,
+				Size:        30,
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.VersionCreated).To(BeTrue())
+			Expect(result.SizeDiff).To(Equal(int64(20))) // 30 - 10
+
+			revsBefore, err := env.Fs.ListRevisions(env.Ctx, ref)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(revsBefore).To(HaveLen(1))
+
+			Expect(env.Fs.MarkProcessing(env.Ctx, ref, true, "session-overwrite")).To(Succeed())
+			Expect(env.Fs.RollbackUpload(env.Ctx, ref, "session-overwrite", true, result.SizeDiff)).To(Succeed())
+
+			revsAfter, err := env.Fs.ListRevisions(env.Ctx, ref)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(revsAfter).To(BeEmpty())
+
+			n, err := env.Lookup.NodeFromResource(env.Ctx, ref)
+			Expect(err).ToNot(HaveOccurred())
+			blobID, err := n.Xattr(env.Ctx, prefixes.BlobIDAttr)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(blobID)).To(Equal("session-init"))
+
+			parentInfoAfter, err := env.Fs.GetMD(env.Ctx, &provider.Reference{ResourceId: env.SpaceRootRes, Path: "/dir1"}, []string{}, []string{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(parentInfoAfter.Size).To(Equal(sizeBefore))
+		})
+	})
+
+	Context("session guard: another session owns the node", func() {
+		It("is a no-op and does not touch the node", func() {
+			_, err := env.Fs.TouchFile(env.Ctx, ref, false, "")
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = env.Fs.PrepareUpload(env.Ctx, ref, "session-a", storage.UploadInfo{
+				NodeExisted: false,
+				Size:        10,
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = env.Fs.PrepareUpload(env.Ctx, ref, "session-b", storage.UploadInfo{
+				NodeExisted: true,
+				Size:        20,
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(env.Fs.MarkProcessing(env.Ctx, ref, true, "session-b")).To(Succeed())
+			Expect(env.Fs.RollbackUpload(env.Ctx, ref, "session-a", true, 10)).To(Succeed())
+
+			n, err := env.Lookup.NodeFromResource(env.Ctx, ref)
+			Expect(err).ToNot(HaveOccurred())
+			blobID, err := n.Xattr(env.Ctx, prefixes.BlobIDAttr)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(blobID)).To(Equal("session-b"))
+		})
+	})
+
+	Context("new node (NodeExists=false)", func() {
+		It("returns nil without error", func() {
+			missingRef := &provider.Reference{
+				ResourceId: env.SpaceRootRes,
+				Path:       "/dir1/does-not-exist.txt",
+			}
+			Expect(env.Fs.RollbackUpload(env.Ctx, missingRef, "any-session-id", false, 0)).To(Succeed())
+		})
+	})
+})

--- a/pkg/storage/utils/decomposedfs/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload.go
@@ -630,7 +630,7 @@ func (fs *Decomposedfs) PrepareUpload(ctx context.Context, ref *provider.Referen
 func (fs *Decomposedfs) RollbackUpload(ctx context.Context, ref *provider.Reference, sessionID string, nodeExisted bool, sizeDiff int64) error {
 	n, err := fs.lu.NodeFromResource(ctx, ref)
 	if err != nil {
-		return errtypes.InternalError("RollbackUpload: node lookup failed")
+		return fmt.Errorf("RollbackUpload: node lookup failed: %w", err)
 	}
 	if !n.Exists {
 		return nil // new node; coordinator calls Delete separately
@@ -642,8 +642,7 @@ func (fs *Decomposedfs) RollbackUpload(ctx context.Context, ref *provider.Refere
 
 	curProcessingID, err := n.ProcessingID(ctx)
 	if err != nil {
-		appctx.GetLogger(ctx).Warn().Err(err).Str("sessionID", sessionID).Msg("RollbackUpload: could not read processing ID, skipping")
-		return nil
+		return fmt.Errorf("RollbackUpload: could not read processing ID: %w", err)
 	}
 	if curProcessingID != sessionID {
 		return nil
@@ -653,11 +652,10 @@ func (fs *Decomposedfs) RollbackUpload(ctx context.Context, ref *provider.Refere
 		if err := n.RevertCurrentRevision(ctx, false); err != nil {
 			return err
 		}
-	}
-
-	if sizeDiff != 0 {
-		if err := fs.tp.Propagate(ctx, n, -sizeDiff); err != nil {
-			appctx.GetLogger(ctx).Error().Err(err).Msg("RollbackUpload: could not revert propagate")
+		if sizeDiff != 0 {
+			if err := fs.tp.Propagate(ctx, n, -sizeDiff); err != nil {
+				appctx.GetLogger(ctx).Error().Err(err).Msg("RollbackUpload: could not revert propagate")
+			}
 		}
 	}
 

--- a/pkg/storage/utils/decomposedfs/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload.go
@@ -621,7 +621,43 @@ func (fs *Decomposedfs) PrepareUpload(ctx context.Context, ref *provider.Referen
 	}
 	committed = true
 
-	return &storage.PrepareUploadResult{VersionCreated: versionCreated}, nil
+	return &storage.PrepareUploadResult{VersionCreated: versionCreated, SizeDiff: sizeDiff}, nil
+}
+
+// RollbackUpload reverts the node state written by PrepareUpload after a failed or aborted
+// postprocessing run. It restores the previous revision (or purges the node if versioning is
+// disabled and no prior version exists) and reverts the optimistic size propagation.
+func (fs *Decomposedfs) RollbackUpload(ctx context.Context, ref *provider.Reference, sessionID string, nodeExisted bool, sizeDiff int64) error {
+	n, err := fs.lu.NodeFromResource(ctx, ref)
+	if err != nil {
+		return errtypes.InternalError("RollbackUpload: node lookup failed")
+	}
+	if !n.Exists {
+		return nil // new node; coordinator calls Delete separately
+	}
+	n.SpaceRoot, err = node.ReadNode(ctx, fs.lu, n.SpaceID, n.SpaceID, false, nil, false)
+	if err != nil {
+		return err
+	}
+
+	curProcessingID, err := n.ProcessingID(ctx)
+	if err != nil || curProcessingID != sessionID {
+		return nil
+	}
+
+	if nodeExisted {
+		if err := n.RevertCurrentRevision(ctx, false); err != nil {
+			return err
+		}
+	}
+
+	if sizeDiff != 0 {
+		if err := fs.tp.Propagate(ctx, n, -sizeDiff); err != nil {
+			appctx.GetLogger(ctx).Error().Err(err).Msg("RollbackUpload: could not revert propagate")
+		}
+	}
+
+	return nil
 }
 
 func validateChecksums(ctx context.Context, lu node.PathLookup, n *node.Node, versionPath string) error {

--- a/pkg/storage/utils/decomposedfs/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload.go
@@ -641,7 +641,11 @@ func (fs *Decomposedfs) RollbackUpload(ctx context.Context, ref *provider.Refere
 	}
 
 	curProcessingID, err := n.ProcessingID(ctx)
-	if err != nil || curProcessingID != sessionID {
+	if err != nil {
+		appctx.GetLogger(ctx).Warn().Err(err).Str("sessionID", sessionID).Msg("RollbackUpload: could not read processing ID, skipping")
+		return nil
+	}
+	if curProcessingID != sessionID {
 		return nil
 	}
 

--- a/pkg/storage/utils/decomposedfs/upload/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload/upload.go
@@ -355,7 +355,7 @@ func (session *OcisSession) Cleanup(revertNodeMetadata, cleanBin, cleanInfo, unm
 
 		curUpload, err := n.ProcessingID(ctx)
 		if err == nil && curUpload == session.ID() {
-			if err := n.RevertCurrentRevision(ctx); err != nil {
+			if err := n.RevertCurrentRevision(ctx, true); err != nil {
 				appctx.GetLogger(ctx).Error().Err(err).Str("nodepath", n.InternalPath()).Msg("reverting node metadata failed")
 				return
 			}

--- a/pkg/storage/utils/eosfs/upload.go
+++ b/pkg/storage/utils/eosfs/upload.go
@@ -110,3 +110,7 @@ func (fs *eosfs) CommitUpload(_ context.Context, _ *provider.Reference, _ string
 func (fs *eosfs) PrepareUpload(_ context.Context, _ *provider.Reference, _ string, info storage.UploadInfo) (*storage.PrepareUploadResult, error) {
 	return &storage.PrepareUploadResult{VersionCreated: info.NodeExisted}, nil
 }
+
+func (fs *eosfs) RollbackUpload(_ context.Context, _ *provider.Reference, _ string, _ bool, _ int64) error {
+	return nil
+}

--- a/pkg/storage/utils/localfs/upload.go
+++ b/pkg/storage/utils/localfs/upload.go
@@ -163,6 +163,10 @@ func (fs *localfs) PrepareUpload(_ context.Context, _ *provider.Reference, _ str
 	return &storage.PrepareUploadResult{VersionCreated: info.NodeExisted}, nil
 }
 
+func (fs *localfs) RollbackUpload(_ context.Context, _ *provider.Reference, _ string, _ bool, _ int64) error {
+	return nil
+}
+
 // UseIn tells the tus upload middleware which extensions it supports.
 func (fs *localfs) UseIn(composer *tusd.StoreComposer) {
 	composer.UseCore(fs)

--- a/pkg/storage/utils/middleware/middleware.go
+++ b/pkg/storage/utils/middleware/middleware.go
@@ -442,6 +442,10 @@ func (f *FS) PrepareUpload(ctx context.Context, ref *provider.Reference, session
 	return res, err
 }
 
+func (f *FS) RollbackUpload(ctx context.Context, ref *provider.Reference, sessionID string, nodeExisted bool, sizeDiff int64) error {
+	return f.next.RollbackUpload(ctx, ref, sessionID, nodeExisted, sizeDiff)
+}
+
 func (f *FS) Download(ctx context.Context, ref *provider.Reference, openReaderFunc func(md *provider.ResourceInfo) bool) (*provider.ResourceInfo, io.ReadCloser, error) {
 	var (
 		err     error


### PR DESCRIPTION
Mirrors the behavior in decomposedfs postprocessing loop when postprocessing failed. This MR is a prerequisite to move the postprocessingloop into the cooridinator. 

Additional changes:
- Add sizeDiff to the return value of PrepareUpload. This value is necessary so the size propagation can be reverted. 
- Make the `UnmarkProcessing` call in `RevertCurrentRevision` method optional. `RollbackUpload` should not call `UnmarkProcessing`, because 1) coordinator calls `MarkProcessing(false)` itself and 2) `UnmarkProcessing` is changing metric values, which also should only happen in coordinator.

Notes: 
- There is a bug that when versioning is disabled and a node got overwritten, this method is deleting the file instead of reverting the changes. This bug is preexisting and is not fixed in this MR. It's not straightforward to fix, because at the time of reverting, we don't have the information about the overwritten file anymore. Could be solved in the future by e.g. storing the old overwritten metadata in the session. Out of scope for this MR