### PR TITLE
fix(ldap): restore TLS 1.2 floor for LDAP connections

### DIFF
--- a/changelog/unreleased/fix-ldap-tls-min-version.md
+++ b/changelog/unreleased/fix-ldap-tls-min-version.md
@@ -1,0 +1,9 @@
+Bugfix: Restore TLS 1.2 floor for LDAP connections
+
+`tlsConfigFromLDAPConn` (shared by `GetLDAPClientWithReconnect`, `GetLDAPClientWithPool` and
+`GetLDAPClientForAuth`) built its `*tls.Config` without a `MinVersion`, allowing the LDAP client
+to negotiate down to whatever the Go runtime's default minimum TLS version is. Set
+`MinVersion: tls.VersionTLS12` on both the insecure and CA-cert paths to match the floor the
+callers previously enforced individually.
+
+https://github.com/owncloud/reva/pull/658

--- a/pkg/utils/ldap.go
+++ b/pkg/utils/ldap.go
@@ -54,6 +54,7 @@ func tlsConfigFromLDAPConn(c *LDAPConn) (*tls.Config, error) {
 	if c.Insecure {
 		logger.New().Warn().Msg("SSL Certificate verification is disabled. This is strongly discouraged for production environments.")
 		return &tls.Config{
+			MinVersion: tls.VersionTLS12,
 			//nolint:gosec // We need the ability to run with "insecure" (dev/testing)
 			InsecureSkipVerify: true,
 		}, nil
@@ -66,7 +67,8 @@ func tlsConfigFromLDAPConn(c *LDAPConn) (*tls.Config, error) {
 		rpool, _ := x509.SystemCertPool()
 		rpool.AppendCertsFromPEM(pemBytes)
 		return &tls.Config{
-			RootCAs: rpool,
+			MinVersion: tls.VersionTLS12,
+			RootCAs:    rpool,
 		}, nil
 	}
 	return nil, nil


### PR DESCRIPTION
## Description
\`tlsConfigFromLDAPConn\` (shared by \`GetLDAPClientWithReconnect\`, \`GetLDAPClientWithPool\` and \`GetLDAPClientForAuth\`, introduced in #658) built its \`*tls.Config\` without a \`MinVersion\` — the insecure branch set only \`InsecureSkipVerify\`, and the CA-cert branch set only \`RootCAs\`. This lets the LDAP client negotiate down to whatever the Go runtime's default minimum TLS version is.

Before #658, callers (oCIS graph service, and previously the auth-basic/users/groups managers) built their own \`tls.Config\` with \`MinVersion: tls.VersionTLS12\` set explicitly. This PR restores that floor inside the shared helper so all callers get it back consistently.

Flagged during review of owncloud/ocis#12660 (which unified oCIS graph's LDAP client onto this helper, surfacing the regression).

## Motivation and Context
Minor security regression: without an explicit floor, TLS 1.0/1.1 could be negotiated on affected connections.

## How Has This Been Tested?
\`go build ./pkg/utils/...\` passes.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)