### PR TITLE
fix(ldap): restore pinned-CA-only trust for LDAP TLS

### DIFF
--- a/changelog/unreleased/fix-ldap-ca-cert-trust-scope.md
+++ b/changelog/unreleased/fix-ldap-ca-cert-trust-scope.md
@@ -1,0 +1,12 @@
+Bugfix: Restore pinned-CA-only trust and PEM validation for LDAP TLS
+
+`tlsConfigFromLDAPConn`'s CA-cert branch built its `RootCAs` pool from
+`x509.SystemCertPool()` plus the configured CA, so callers configuring a CA cert
+ended up trusting every system-level CA as well, not just the pinned one — a
+trust-scope widening versus the pre-pool behavior. It also ignored
+`AppendCertsFromPEM`'s return value, so a malformed or empty CA file would
+silently fall back to an unrestricted trust store instead of failing
+initialization. Use `x509.NewCertPool()` (pinned CA only) and fail
+`tlsConfigFromLDAPConn` when the PEM contains no valid certificates.
+
+https://github.com/owncloud/reva/pull/658

--- a/pkg/utils/ldap.go
+++ b/pkg/utils/ldap.go
@@ -64,8 +64,10 @@ func tlsConfigFromLDAPConn(c *LDAPConn) (*tls.Config, error) {
 		if err != nil {
 			return nil, errors.Wrapf(err, "Error reading LDAP CA Cert '%s.'", c.CACert)
 		}
-		rpool, _ := x509.SystemCertPool()
-		rpool.AppendCertsFromPEM(pemBytes)
+		rpool := x509.NewCertPool()
+		if !rpool.AppendCertsFromPEM(pemBytes) {
+			return nil, errors.Errorf("Error adding LDAP CA Cert '%s': no valid certificates found", c.CACert)
+		}
 		return &tls.Config{
 			MinVersion: tls.VersionTLS12,
 			RootCAs:    rpool,


### PR DESCRIPTION
## Description
Follow-up to #672. \`tlsConfigFromLDAPConn\`'s CA-cert branch built its \`RootCAs\` pool from \`x509.SystemCertPool()\` plus the configured CA cert. Before this helper was introduced in #658, the graph service's own TLS setup used \`x509.NewCertPool()\` — trusting only the pinned CA. So configuring \`CACert\` now also trusts every system-level CA, a real widening of trust scope.

It also ignored \`AppendCertsFromPEM\`'s boolean return value. The graph service's old code checked it and failed initialization ("Adding CA cert failed") on a malformed/empty PEM; the helper silently proceeds with the system trust store instead.

This PR:
- Switches back to \`x509.NewCertPool()\` (pinned-CA-only trust).
- Checks \`AppendCertsFromPEM\`'s return value and fails \`tlsConfigFromLDAPConn\` when the PEM contains no valid certificates.

As a side effect this also removes the swallowed \`x509.SystemCertPool()\` error path (`rpool, _ := ...`), since we no longer call it here.

Flagged during review of owncloud/ocis#12660.

## Motivation and Context
Security regression: LDAP TLS connections configured with a CA cert should trust only that CA, not the full system trust store, and a malformed CA cert should fail loudly rather than silently widen trust.

## How Has This Been Tested?
\`go build ./pkg/utils/...\` passes.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)