### PR TITLE
feat(ldap): [OCISDEV-1031] add opt-in LDAP connection pool

### DIFF
--- a/changelog/unreleased/enhancement-ldap-connection-pool.md
+++ b/changelog/unreleased/enhancement-ldap-connection-pool.md
@@ -1,0 +1,10 @@
+Enhancement: Add an opt-in LDAP connection pool
+
+Added `GetLDAPClientWithPool`, a bounded pool of authenticated LDAP
+connections, as a drop-in alternative to the existing single, long-lived
+reconnecting connection. It is disabled by default and can be enabled per
+backend via `pool_enabled` (plus `pool_size` and `pool_checkout_timeout`) on
+the auth, user and group LDAP managers, so concurrent requests no longer
+serialize on a single socket.
+
+https://github.com/owncloud/reva/pull/679

--- a/changelog/unreleased/enhancement-ldap-pool-password-modify.md
+++ b/changelog/unreleased/enhancement-ldap-pool-password-modify.md
@@ -1,0 +1,9 @@
+Enhancement: Implement PasswordModify and ModifyWithResult on the LDAP clients
+
+`ConnWithReconnect` and `ConnPool` (`pkg/utils/ldap`) previously stubbed out
+`PasswordModify` and `ModifyWithResult` with a "not implemented" error. Both
+are now implemented (with the same retry-on-network-error behaviour as the
+other operations), so callers that rely on the LDAP Password Modify Extended
+Operation or on `ModifyWithResult` no longer break when using either client.
+
+https://github.com/owncloud/reva/pull/679

--- a/changelog/unreleased/fix-ldap-ca-cert-trust-scope.md
+++ b/changelog/unreleased/fix-ldap-ca-cert-trust-scope.md
@@ -1,0 +1,12 @@
+Bugfix: Restore pinned-CA-only trust and PEM validation for LDAP TLS
+
+`tlsConfigFromLDAPConn`'s CA-cert branch built its `RootCAs` pool from
+`x509.SystemCertPool()` plus the configured CA, so callers configuring a CA cert
+ended up trusting every system-level CA as well, not just the pinned one — a
+trust-scope widening versus the pre-pool behavior. It also ignored
+`AppendCertsFromPEM`'s return value, so a malformed or empty CA file would
+silently fall back to an unrestricted trust store instead of failing
+initialization. Use `x509.NewCertPool()` (pinned CA only) and fail
+`tlsConfigFromLDAPConn` when the PEM contains no valid certificates.
+
+https://github.com/owncloud/reva/pull/679

--- a/changelog/unreleased/fix-ldap-tls-min-version.md
+++ b/changelog/unreleased/fix-ldap-tls-min-version.md
@@ -1,0 +1,9 @@
+Bugfix: Restore TLS 1.2 floor for LDAP connections
+
+`tlsConfigFromLDAPConn` (shared by `GetLDAPClientWithReconnect`, `GetLDAPClientWithPool` and
+`GetLDAPClientForAuth`) built its `*tls.Config` without a `MinVersion`, allowing the LDAP client
+to negotiate down to whatever the Go runtime's default minimum TLS version is. Set
+`MinVersion: tls.VersionTLS12` on both the insecure and CA-cert paths to match the floor the
+callers previously enforced individually.
+
+https://github.com/owncloud/reva/pull/679

--- a/pkg/auth/manager/ldap/ldap.go
+++ b/pkg/auth/manager/ldap/ldap.go
@@ -78,7 +78,7 @@ func New(m map[string]interface{}) (auth.Manager, error) {
 	if err != nil {
 		return nil, err
 	}
-	manager.ldapClient, err = utils.GetLDAPClientWithReconnect(&manager.c.LDAPConn)
+	manager.ldapClient, err = utils.GetLDAPClientFromConfig(&manager.c.LDAPConn)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/group/manager/ldap/ldap.go
+++ b/pkg/group/manager/ldap/ldap.go
@@ -74,7 +74,7 @@ func New(m map[string]interface{}) (group.Manager, error) {
 		return nil, err
 	}
 
-	mgr.ldapClient, err = utils.GetLDAPClientWithReconnect(&mgr.c.LDAPConn)
+	mgr.ldapClient, err = utils.GetLDAPClientFromConfig(&mgr.c.LDAPConn)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/user/manager/ldap/ldap.go
+++ b/pkg/user/manager/ldap/ldap.go
@@ -73,7 +73,7 @@ func New(m map[string]interface{}) (user.Manager, error) {
 		return nil, err
 	}
 
-	mgr.ldapClient, err = utils.GetLDAPClientWithReconnect(&mgr.c.LDAPConn)
+	mgr.ldapClient, err = utils.GetLDAPClientFromConfig(&mgr.c.LDAPConn)
 	return mgr, err
 }
 

--- a/pkg/user/manager/ldap/ldap_test.go
+++ b/pkg/user/manager/ldap/ldap_test.go
@@ -65,4 +65,11 @@ func TestUserManager(t *testing.T) {
 	if err != nil {
 		t.Fatal(err.Error())
 	}
+
+	// New must not dial anything eagerly, so pool_enabled must also succeed without a
+	// reachable LDAP server.
+	_, err = New(map[string]interface{}{"pool_enabled": true})
+	if err != nil {
+		t.Fatal(err.Error())
+	}
 }

--- a/pkg/utils/ldap/config.go
+++ b/pkg/utils/ldap/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	RetryBaseDelay time.Duration
 	RetryMaxDelay  time.Duration
 
+
 	// PoolSize caps the number of concurrently open connections in the pool. Only used by
 	// NewLDAPPool; NewLDAPWithReconnect ignores it. Defaults to defaultPoolSize (5) when <= 0.
 	PoolSize int


### PR DESCRIPTION
## Summary
- Forward-port of the LDAP connection pooling work from #658, #665, #672, #674 (originally merged to `stable-8.0`) to `stable-8.1`.
- Adds an opt-in bounded LDAP connection pool (`pkg/utils/ldap/pool.go`) as a drop-in alternative to the existing single reconnecting connection, plus `PasswordModify`/`ModifyWithResult` support on both clients, and two TLS hardening fixes found during review of the original PRs (TLS 1.2 floor, pinned-CA-only trust).
- Disabled by default, fully backwards compatible.

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/utils/ldap/... ./pkg/auth/manager/ldap/... ./pkg/user/manager/ldap/... ./pkg/group/manager/ldap/...`