### PR TITLE
fix: allow space managers to remove shares created by other users

### DIFF
--- a/changelog/unreleased/bugfix-space-manager-remove-others-shares.md
+++ b/changelog/unreleased/bugfix-space-manager-remove-others-shares.md
@@ -1,0 +1,11 @@
+Bugfix: Allow space managers to remove shares created by other users
+
+Space managers with the `RemoveGrant` permission on a resource were unable to
+remove user shares created by other users. `Unshare` in the jsoncs3 share
+manager only permitted the share creator to remove a share, so removal attempts
+by other managers failed with a `NotFound` error, surfaced to callers as a
+generic HTTP 500. `Unshare` now also allows users who have the `RemoveGrant`
+permission on the shared resource to remove the share, matching the checks
+already performed in the `RemoveShare` gRPC handler and `GetShare`.
+
+https://github.com/owncloud/reva/pull/687

--- a/pkg/share/manager/jsoncs3/jsoncs3.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3.go
@@ -522,13 +522,35 @@ func (m *Manager) Unshare(ctx context.Context, ref *collaboration.ShareReference
 	if err != nil {
 		return err
 	}
-	// TODO allow manager to unshare shares in a space created by other users
-	if !share.IsCreatedByUser(s, user) {
+	// The requesting user is allowed to unshare if they created the share or
+	// if they have the RemoveGrant permission on the shared resource (e.g. a
+	// space manager removing a share created by another user).
+	if !share.IsCreatedByUser(s, user) && !m.userHasRemoveGrantPermission(ctx, s) {
 		// TODO why not permission denied?
 		return errtypes.NotFound(ref.String())
 	}
 
 	return m.removeShare(ctx, s, false)
+}
+
+// userHasRemoveGrantPermission checks whether the user in the context has the
+// RemoveGrant permission on the resource the given share points to. This allows
+// e.g. space managers to remove shares created by other users.
+func (m *Manager) userHasRemoveGrantPermission(ctx context.Context, s *collaboration.Share) bool {
+	req := &provider.StatRequest{
+		Ref: &provider.Reference{ResourceId: s.ResourceId},
+		FieldMask: &fieldmaskpb.FieldMask{
+			Paths: []string{"permissions"},
+		},
+	}
+	client, err := m.gatewaySelector.Next()
+	if err != nil {
+		return false
+	}
+	res, err := client.Stat(ctx, req)
+	return err == nil &&
+		res.Status.Code == rpcv1beta1.Code_CODE_OK &&
+		res.Info.PermissionSet.RemoveGrant
 }
 
 // UpdateShare updates the mode of the given share.

--- a/pkg/share/manager/jsoncs3/jsoncs3_test.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3_test.go
@@ -332,6 +332,40 @@ var _ = Describe("Jsoncs3", func() {
 				Expect(shares[0].Id).To(Equal(share.Id))
 			})
 		})
+
+		Describe("Unshare", func() {
+			It("removes a share created by another user when the manager has RemoveGrant permission", func() {
+				mockStat(
+					&provider.Reference{ResourceId: sharedResource.Id},
+					&providerv1beta1.ResourceInfo{PermissionSet: &providerv1beta1.ResourcePermissions{RemoveGrant: true}},
+				)
+
+				err := m.Unshare(managerCtx, &collaboration.ShareReference{
+					Spec: &collaboration.ShareReference_Id{
+						Id: &collaboration.ShareId{
+							OpaqueId: share.Id.OpaqueId,
+						},
+					},
+				})
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("does not remove a share created by another user when the manager lacks RemoveGrant permission", func() {
+				mockStat(
+					&provider.Reference{ResourceId: sharedResource.Id},
+					&providerv1beta1.ResourceInfo{PermissionSet: &providerv1beta1.ResourcePermissions{RemoveGrant: false}},
+				)
+
+				err := m.Unshare(managerCtx, &collaboration.ShareReference{
+					Spec: &collaboration.ShareReference_Id{
+						Id: &collaboration.ShareId{
+							OpaqueId: share.Id.OpaqueId,
+						},
+					},
+				})
+				Expect(err).To(HaveOccurred())
+			})
+		})
 	})
 
 	Context("with an existing share", func() {
@@ -467,6 +501,12 @@ var _ = Describe("Jsoncs3", func() {
 		})
 
 		Describe("UnShare", func() {
+			BeforeEach(func() {
+				mockStat(
+					&provider.Reference{ResourceId: sharedResource.Id},
+					&providerv1beta1.ResourceInfo{PermissionSet: &providerv1beta1.ResourcePermissions{RemoveGrant: false}},
+				)
+			})
 			It("does not remove shares of other users", func() {
 				err := m.Unshare(otherCtx, &collaboration.ShareReference{
 					Spec: &collaboration.ShareReference_Id{


### PR DESCRIPTION
Space managers with the RemoveGrant permission on a resource were unable to remove user shares created by other users. Unshare in the jsoncs3 share manager only permitted the share creator to remove a share, so removal attempts by other managers failed with a NotFound error, surfaced to callers as a generic HTTP 500.

Unshare now also allows users who have the RemoveGrant permission on the shared resource to remove the share, matching the checks already performed in the RemoveShare gRPC handler and GetShare.

fixes: https://kiteworks.atlassian.net/browse/OCISDEV-748