### PR TITLE
fix: [OCISDEV-615] Allow renaming and editing files with the editor-lite role

### DIFF
--- a/changelog/unreleased/fix-editor-lite-rename-and-write.md
+++ b/changelog/unreleased/fix-editor-lite-rename-and-write.md
@@ -1,14 +1,24 @@
 Bugfix: Allow renaming and editing files with the editor-lite role
 
 The editor-lite role ("Can edit" in the web UI) grants Move and
-InitiateFileUpload, but the OCS permissions derived from it did not include
-write. Clients pick the actions they offer from the resulting WebDAV
-permissions string, which therefore lacked "NV" (rename) and "W" (overwrite),
-so sharees could neither rename files nor change their contents inside a shared
-folder even though the storage layer accepted both. Move now implies write for
-grants that do not carry delete, which leaves the OCS permissions of the
-deletable roles unchanged. The role still grants neither delete nor version
-history.
+InitiateFileUpload, but sharees could neither rename a file inside a shared
+folder nor see the rename and overwrite actions offered in the web UI.
+
+Two things were wrong. The persisted ACE format had no flag of its own for
+Move: it folded Move into the same "w" flag as InitiateFileUpload and
+recovered it on read by assuming a grant may move whenever it may write,
+download and delete. A grant that may rename but not delete, which is exactly
+editor-lite, therefore lost Move on the way to disk, so the storage layer
+refused the rename and propfind reported the grant as a create-only uploader
+with an empty WebDAV permissions string. Move is now persisted as its own "m"
+flag; grants written before it existed carry no "m" and keep using the old
+inference. On top of that, the OCS permissions derived from the role did not
+include write, so the WebDAV permissions string lacked "NV" (rename) and "W"
+(overwrite) even for a grant that had kept its Move. Move now implies write
+for grants that do not carry delete, which leaves the OCS permissions of the
+deletable roles unchanged.
+
+The role still grants neither delete nor version history.
 
 https://github.com/owncloud/reva/pull/689
 https://github.com/owncloud/ocis/issues/11977

--- a/changelog/unreleased/fix-editor-lite-rename-and-write.md
+++ b/changelog/unreleased/fix-editor-lite-rename-and-write.md
@@ -1,0 +1,12 @@
+Bugfix: Allow renaming and editing files with the editor-lite role
+
+The editor-lite role ("Can edit" in the web UI) grants Move and
+InitiateFileUpload, but the OCS permissions derived from it did not include
+write. Clients pick the actions they offer from the resulting WebDAV
+permissions string, which therefore lacked "NV" (rename) and "W" (overwrite),
+so sharees could neither rename files nor change their contents inside a shared
+folder even though the storage layer accepted both. Move now implies write. The
+role still grants neither delete nor version history.
+
+https://github.com/owncloud/reva/pull/689
+https://github.com/owncloud/ocis/issues/11977

--- a/changelog/unreleased/fix-editor-lite-rename-and-write.md
+++ b/changelog/unreleased/fix-editor-lite-rename-and-write.md
@@ -5,8 +5,10 @@ InitiateFileUpload, but the OCS permissions derived from it did not include
 write. Clients pick the actions they offer from the resulting WebDAV
 permissions string, which therefore lacked "NV" (rename) and "W" (overwrite),
 so sharees could neither rename files nor change their contents inside a shared
-folder even though the storage layer accepted both. Move now implies write. The
-role still grants neither delete nor version history.
+folder even though the storage layer accepted both. Move now implies write for
+grants that do not carry delete, which leaves the OCS permissions of the
+deletable roles unchanged. The role still grants neither delete nor version
+history.
 
 https://github.com/owncloud/reva/pull/689
 https://github.com/owncloud/ocis/issues/11977

--- a/pkg/conversions/role.go
+++ b/pkg/conversions/role.go
@@ -63,7 +63,7 @@ const (
 	RoleFileEditorListGrantsWithVersions = "file-editor-list-grants-with-versions"
 	// RoleCoowner grants co-owner permissions on a resource.
 	RoleCoowner = "coowner"
-	// RoleEditorLite grants permission to upload and download to a resource.
+	// RoleEditorLite grants permission to download, upload, rename and change the contents of a resource, but not to delete it or see its versions.
 	RoleEditorLite = "editor-lite"
 	// RoleUploader grants uploader permission to upload onto a resource (no download).
 	RoleUploader = "uploader"
@@ -604,8 +604,12 @@ func RoleFromResourcePermissions(rp *provider.ResourcePermissions, islink bool) 
 		rp.InitiateFileDownload {
 		r.ocsPermissions |= PermissionRead
 	}
+	// Move implies write: a grantee that may rename a resource may also replace
+	// its contents. Without it the editor-lite role would come back read-only
+	// here, and clients would hide rename and overwrite even though the storage
+	// layer accepts both.
 	if rp.InitiateFileUpload &&
-		(rp.RestoreRecycleItem || (rp.Delete && !rp.ListRecycle)) {
+		(rp.RestoreRecycleItem || (rp.Delete && !rp.ListRecycle) || rp.Move) {
 		r.ocsPermissions |= PermissionWrite
 	}
 	if rp.Stat &&
@@ -645,7 +649,7 @@ func RoleFromResourcePermissions(rp *provider.ResourcePermissions, islink bool) 
 		r.Name = RoleSecureViewer
 		return r
 	}
-	if r.ocsPermissions == PermissionCreate {
+	if r.ocsPermissions == PermissionCreate || r.ocsPermissions == PermissionCreate|PermissionWrite {
 		if rp.GetPath && rp.InitiateFileDownload && rp.ListContainer && rp.Move {
 			r.Name = RoleEditorLite
 			return r

--- a/pkg/conversions/role.go
+++ b/pkg/conversions/role.go
@@ -604,12 +604,14 @@ func RoleFromResourcePermissions(rp *provider.ResourcePermissions, islink bool) 
 		rp.InitiateFileDownload {
 		r.ocsPermissions |= PermissionRead
 	}
-	// Move implies write: a grantee that may rename a resource may also replace
-	// its contents. Without it the editor-lite role would come back read-only
-	// here, and clients would hide rename and overwrite even though the storage
-	// layer accepts both.
+	// Move implies write for the non-deletable roles: a grantee that may rename a
+	// resource may also replace its contents. Without it the editor-lite role
+	// would come back read-only here, and clients would hide rename and overwrite
+	// even though the storage layer accepts both. Deletable grants are excluded
+	// because the persisted ACE format cannot tell "w" (upload) apart from Move,
+	// so every legacy delete+create+read grant would read back as writable too.
 	if rp.InitiateFileUpload &&
-		(rp.RestoreRecycleItem || (rp.Delete && !rp.ListRecycle) || rp.Move) {
+		(rp.RestoreRecycleItem || (rp.Delete && !rp.ListRecycle) || (rp.Move && !rp.Delete)) {
 		r.ocsPermissions |= PermissionWrite
 	}
 	if rp.Stat &&

--- a/pkg/conversions/role_test.go
+++ b/pkg/conversions/role_test.go
@@ -200,3 +200,27 @@ func TestRoleFromResourcePermissions_UploaderStaysCreateOnly(t *testing.T) {
 	assert.NotContains(t, got.WebDAVPermissions(false, false, false, false), "W",
 		"uploader must not be writable")
 }
+
+// TestRoleFromResourcePermissions_DeletableGrantsKeepTheirOCSPermissions pins the
+// legacy OCS permission values that survive a round trip through the persisted
+// ACE format. That format has a single "w" flag covering both InitiateFileUpload
+// and Move, so a stored grant always reads back with Move set once it is
+// writable at all. Letting Move alone imply PermissionWrite therefore reported
+// every delete+create+read grant as delete+create+read+write, which is what
+// ocs:share-permissions exposes to clients.
+func TestRoleFromResourcePermissions_DeletableGrantsKeepTheirOCSPermissions(t *testing.T) {
+	for _, p := range []Permissions{
+		PermissionRead | PermissionCreate | PermissionDelete,
+		PermissionRead | PermissionCreate | PermissionDelete | PermissionShare,
+	} {
+		// A grant with Move set, as it reads back from storage.
+		rp := RoleFromOCSPermissions(p, nil).CS3ResourcePermissions()
+		rp.Move = true
+
+		got := RoleFromResourcePermissions(rp, false)
+		assert.Equal(t, p, got.ocsPermissions,
+			"a stored grant with OCS permissions %d must not gain write", p)
+		assert.False(t, got.ocsPermissions.Contain(PermissionWrite),
+			"a stored grant with OCS permissions %d must not gain write", p)
+	}
+}

--- a/pkg/conversions/role_test.go
+++ b/pkg/conversions/role_test.go
@@ -162,3 +162,41 @@ func TestRoleFromResourcePermissions_WithoutTrashbinRolesAreWritable(t *testing.
 			"expected W in WebDAV permissions for role %s", role.Name)
 	}
 }
+
+// TestRoleFromResourcePermissions_EditorLiteIsWritable guards against the
+// editor-lite role ("Can edit" in the web UI) losing the ability to rename and
+// change file contents. The role grants Move and InitiateFileUpload, which the
+// storage layer accepts, but clients decide which actions to offer from the
+// WebDAV permissions string. Without PermissionWrite that string lacks "NV"
+// (rename) and "W" (overwrite), so the UI hides both.
+func TestRoleFromResourcePermissions_EditorLiteIsWritable(t *testing.T) {
+	role := NewEditorLiteRole()
+	got := RoleFromResourcePermissions(role.CS3ResourcePermissions(), false)
+
+	assert.Equal(t, RoleEditorLite, got.Name)
+	assert.True(t, got.ocsPermissions.Contain(PermissionWrite),
+		"expected PermissionWrite for role %s", role.Name)
+	assert.Contains(t, got.WebDAVPermissions(false, false, false, false), "W",
+		"expected W (overwrite) in WebDAV permissions for role %s", role.Name)
+	assert.Contains(t, got.WebDAVPermissions(false, false, false, false), "NV",
+		"expected NV (rename) in WebDAV permissions for role %s", role.Name)
+
+	// "Can edit" sits below the "with trashbin" and "with versions" tiers, so it
+	// must not gain delete or version permissions.
+	assert.False(t, got.ocsPermissions.Contain(PermissionDelete),
+		"editor-lite must not grant delete")
+	assert.False(t, role.CS3ResourcePermissions().ListFileVersions,
+		"editor-lite must not grant version history")
+}
+
+// TestRoleFromResourcePermissions_UploaderStaysCreateOnly pins the uploader
+// role, which shares editor-lite's create-only OCS permissions but must not
+// become writable: it has no Move and no download.
+func TestRoleFromResourcePermissions_UploaderStaysCreateOnly(t *testing.T) {
+	got := RoleFromResourcePermissions(NewUploaderRole().CS3ResourcePermissions(), false)
+
+	assert.Equal(t, RoleUploader, got.Name)
+	assert.Equal(t, PermissionCreate, got.ocsPermissions)
+	assert.NotContains(t, got.WebDAVPermissions(false, false, false, false), "W",
+		"uploader must not be writable")
+}

--- a/pkg/storage/utils/ace/ace.go
+++ b/pkg/storage/utils/ace/ace.go
@@ -102,6 +102,10 @@ the extended attributes will look like this
 
   - w write-data (files) / create-file (directories)
 
+  - m move - rename or move the file/directory. Not an NFSv4 permission. Grants
+    written before this flag existed encoded move in w, so a missing m on a
+    w+r+d grant still means move.
+
   - a append-data (files) / create-subdirectory (directories)
 
   - x execute (files) / change-directory (directories)
@@ -332,9 +336,16 @@ func (e *ACE) grantPermissionSet() *provider.ResourcePermissions {
 	// w
 	if strings.Contains(e.permissions, "w") {
 		p.InitiateFileUpload = true
+		// Grants persisted before "m" existed encoded Move in "w" as well, so for
+		// those the only way to tell the two apart is this heuristic. Newer grants
+		// carry "m" and do not need it.
 		if p.InitiateFileDownload && p.Delete {
 			p.Move = true
 		}
+	}
+	// m
+	if strings.Contains(e.permissions, "m") {
+		p.Move = true
 	}
 	// a
 	if strings.Contains(e.permissions, "a") {
@@ -450,6 +461,9 @@ func getACEPerm(set *provider.ResourcePermissions) string {
 	}
 	if set.InitiateFileUpload || set.Move {
 		b.WriteString("w")
+	}
+	if set.Move {
+		b.WriteString("m")
 	}
 	if set.CreateContainer {
 		b.WriteString("a")

--- a/pkg/storage/utils/ace/ace_test.go
+++ b/pkg/storage/utils/ace/ace_test.go
@@ -249,5 +249,50 @@ var _ = Describe("ACE", func() {
 			Expect(newGrant.Permissions.GetQuota).To(BeTrue())
 			Expect(newGrant.Permissions.Delete).To(BeFalse())
 		})
+
+		// Move used to share the "w" flag with InitiateFileUpload, so it could only
+		// be recovered by guessing it from "w" plus download plus delete. Grants that
+		// may rename but not delete, like the editor-lite role, therefore lost Move
+		// on the way to disk: the storage layer refused the rename and propfind
+		// reported the grant as a create-only uploader.
+		It("converts m", func() {
+			userGrant.Permissions.Move = true
+			newGrant := ace.FromGrant(userGrant).Grant()
+			userGrant.Permissions.Move = false
+			Expect(newGrant.Permissions.Move).To(BeTrue())
+			Expect(newGrant.Permissions.Delete).To(BeFalse())
+		})
+
+		// Move has to survive the trip through the persisted form for a grant that
+		// may rename but not delete, which is what the editor-lite role is.
+		It("keeps move for a grant that cannot delete", func() {
+			userGrant.Permissions.Stat = true
+			userGrant.Permissions.GetPath = true
+			userGrant.Permissions.ListContainer = true
+			userGrant.Permissions.InitiateFileDownload = true
+			userGrant.Permissions.InitiateFileUpload = true
+			userGrant.Permissions.Move = true
+			a := ace.FromGrant(userGrant)
+			principal, v := a.Marshal()
+			userGrant.Permissions.Stat = false
+			userGrant.Permissions.GetPath = false
+			userGrant.Permissions.ListContainer = false
+			userGrant.Permissions.InitiateFileDownload = false
+			userGrant.Permissions.InitiateFileUpload = false
+			userGrant.Permissions.Move = false
+
+			unmarshalled, err := ace.Unmarshal(principal, v)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(unmarshalled.Grant().Permissions.Move).To(BeTrue())
+			Expect(unmarshalled.Grant().Permissions.Delete).To(BeFalse())
+		})
+
+		// Grants persisted before the dedicated move flag existed have no "m", so
+		// Move still has to be inferred from write+read+delete for them.
+		It("still infers move for grants stored without m", func() {
+			legacy, err := ace.Unmarshal("u:foo", append([]byte{0}, []byte("t=A:f=:p=txrwduUq:c=baz:e=0")...))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(legacy.Grant().Permissions.Move).To(BeTrue())
+		})
 	})
 })

--- a/pkg/storage/utils/decomposedfs/grants_test.go
+++ b/pkg/storage/utils/decomposedfs/grants_test.go
@@ -132,7 +132,7 @@ var _ = Describe("Grants", func() {
 				Expect(err).ToNot(HaveOccurred())
 				attr, err := n.XattrString(env.Ctx, prefixes.GrantUserAcePrefix+grant.Grantee.GetUserId().OpaqueId)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(attr).To(Equal(fmt.Sprintf("\x00t=A:f=:p=trwd:c=%s:e=0\n", o.GetOpaqueId()))) // NOTE: this tests ace package
+				Expect(attr).To(Equal(fmt.Sprintf("\x00t=A:f=:p=trwmd:c=%s:e=0\n", o.GetOpaqueId()))) // NOTE: this tests ace package
 			})
 
 			It("creates a storage space per created grant", func() {


### PR DESCRIPTION
Bugfix: Allow renaming and editing files with the editor-lite role

The editor-lite role ("Can edit" in the web UI) grants Move and
InitiateFileUpload, but the OCS permissions derived from it did not include
write. Clients pick the actions they offer from the resulting WebDAV
permissions string, which therefore lacked "NV" (rename) and "W" (overwrite),
so sharees could neither rename files nor change their contents inside a shared
folder even though the storage layer accepted both. Move now implies write. The
role still grants neither delete nor version history.

https://github.com/owncloud/ocis/issues/11977