### PR TITLE
fix: do not collide vault and non-vault share mountpoints

### DIFF
--- a/changelog/unreleased/fix-vault-share-mountpoint-collision.md
+++ b/changelog/unreleased/fix-vault-share-mountpoint-collision.md
@@ -1,0 +1,12 @@
+Bugfix: Do not collide vault and non-vault share mountpoints
+
+Received shares mounted from the Vault storage and received shares mounted
+from regular drives were treated as one flat namespace when computing a
+unique mountpoint name. Sharing a resource with the same name once from a
+regular drive and once from the Vault caused the second one to get a
+spurious ` (1)` suffix, even though the two shares are rendered in
+completely separate, segregated lists and never actually collide.
+Mountpoint name collisions are now only checked against other shares within
+the same vault/non-vault group.
+
+https://github.com/owncloud/reva/pull/691

--- a/internal/grpc/services/usershareprovider/usershareprovider.go
+++ b/internal/grpc/services/usershareprovider/usershareprovider.go
@@ -661,6 +661,7 @@ func getMountpointAndUnmountedShares(ctx context.Context, receivedShares []*coll
 	mount := base
 	existingMountpoint := ""
 	mountedShares := make([]string, 0, len(receivedShares))
+	newShareInVault := id.GetStorageId() == utils.VaultStorageProviderID
 	var pathExists bool
 	var err error
 
@@ -684,6 +685,14 @@ func getMountpointAndUnmountedShares(ctx context.Context, receivedShares []*coll
 		if resourceIDEqual && s.State != collaboration.ShareState_SHARE_STATE_ACCEPTED {
 			// a share to the resource already exists but is not mounted, collect the unmounted share
 			unmountedShares = append(unmountedShares, s)
+		}
+
+		// vault and non-vault shares are rendered in separate, segregated lists (see
+		// pkg/storage/registry/spaces/spaces.go), so name collisions must only be checked
+		// against mountpoints within the same list, not across both.
+		existingShareInVault := s.GetShare().GetResourceId().GetStorageId() == utils.VaultStorageProviderID
+		if existingShareInVault != newShareInVault {
+			continue
 		}
 
 		if s.State == collaboration.ShareState_SHARE_STATE_ACCEPTED {

--- a/internal/grpc/services/usershareprovider/usershareprovider_test.go
+++ b/internal/grpc/services/usershareprovider/usershareprovider_test.go
@@ -600,6 +600,7 @@ var _ = Describe("helpers", func() {
 				})
 
 			statCallCount := 0
+			newShareInVault := args.withResourceId.GetStorageId() == utils.VaultStorageProviderID
 
 			for _, s := range args.listReceivedSharesResponse.GetShares() {
 				if s.GetState() != collaborationpb.ShareState_SHARE_STATE_ACCEPTED {
@@ -609,6 +610,12 @@ var _ = Describe("helpers", func() {
 				// add one for every accepted share where the resource id matches
 				if utils.ResourceIDEqual(s.GetShare().GetResourceId(), args.withResourceId) {
 					statCallCount++
+				}
+
+				// mountpoints are only compared within the same vault/non-vault segregation group
+				existingShareInVault := s.GetShare().GetResourceId().GetStorageId() == utils.VaultStorageProviderID
+				if existingShareInVault != newShareInVault {
+					continue
 				}
 
 				// add one for every accepted share where the mountpoint patch matches
@@ -707,6 +714,36 @@ var _ = Describe("helpers", func() {
 					},
 				},
 				expectedName: "some name (1)",
+			},
+		),
+		Entry(
+			"does not enumerate the name if a same-named mounted share only collides across the vault/non-vault boundary",
+			GetMountpointAndUnmountedSharesArgs{
+				withName: "some name",
+				withResourceId: &providerpb.ResourceId{
+					StorageId: "1",
+					OpaqueId:  "2",
+					SpaceId:   "3",
+				},
+				listReceivedSharesResponse: &collaborationpb.ListReceivedSharesResponse{
+					Status: status.NewOK(context.Background()),
+					Shares: []*collaborationpb.ReceivedShare{
+						{
+							State: collaborationpb.ShareState_SHARE_STATE_ACCEPTED,
+							MountPoint: &providerpb.Reference{
+								Path: "some name",
+							},
+							Share: &collaborationpb.Share{
+								ResourceId: &providerpb.ResourceId{
+									StorageId: utils.VaultStorageProviderID,
+									OpaqueId:  "20",
+									SpaceId:   "30",
+								},
+							},
+						},
+					},
+				},
+				expectedName: "some name",
 			},
 		),
 	)


### PR DESCRIPTION
Received shares from the Vault storage and regular drives were treated as one flat namespace when computing a unique mountpoint name, so sharing a resource with the same name from both caused a spurious (1) suffix even though the two are rendered in separate, segregated lists.

fixes: https://kiteworks.atlassian.net/browse/OCISDEV-1165