### PR TITLE
fix: renaming a resource to its current name is a no-op

### DIFF
--- a/changelog/unreleased/bugfix-rename-resource-to-same-name.md
+++ b/changelog/unreleased/bugfix-rename-resource-to-same-name.md
@@ -1,0 +1,14 @@
+Bugfix: Rename a resource to its current name is a no-op
+
+Renaming a resource to the name it already has failed with an opaque error.
+The MOVE handler ran the overwrite check and deleted the existing tree before
+noticing that source and destination pointed at the same resource, which could
+destroy the resource. The handler now compares the stat'ed resource ids of
+source and destination and, when they are equal, returns a silent no-op
+(`204 No Content`) before the overwrite and delete logic runs, consistently for
+all clients. This also catches id based dav paths where source and destination
+references differ but resolve to the same resource. Users without the move
+permission still receive a `403 Forbidden`.
+
+https://github.com/owncloud/reva/pull/708
+https://github.com/owncloud/ocis/issues/1976

--- a/internal/http/services/owncloud/ocdav/move.go
+++ b/internal/http/services/owncloud/ocdav/move.go
@@ -245,6 +245,25 @@ func (s *svc) handleMove(ctx context.Context, w http.ResponseWriter, r *http.Req
 		return
 	}
 
+	if dstStatRes.Status.Code == rpc.Code_CODE_OK && srcStatRes.GetInfo().GetId() != nil &&
+		utils.ResourceIDEqual(srcStatRes.GetInfo().GetId(), dstStatRes.GetInfo().GetId()) {
+		// a user without move permission must not be told the rename succeeded
+		if !srcStatRes.GetInfo().GetPermissionSet().GetMove() {
+			w.WriteHeader(http.StatusForbidden)
+			b, err := errors.Marshal(http.StatusForbidden, "permission denied", "", "")
+			errors.HandleWebdavError(&log, w, b, err)
+			return
+		}
+		log.Debug().Msg("move: source and destination are the same resource, nothing to do")
+		info := dstStatRes.GetInfo()
+		w.Header().Set(net.HeaderContentType, info.GetMimeType())
+		w.Header().Set(net.HeaderETag, info.GetEtag())
+		w.Header().Set(net.HeaderOCFileID, storagespace.FormatResourceID(info.GetId()))
+		w.Header().Set(net.HeaderOCETag, info.GetEtag())
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
 	successCode := http.StatusCreated // 201 if new resource was created, see https://tools.ietf.org/html/rfc4918#section-9.9.4
 	if dstStatRes.Status.Code == rpc.Code_CODE_OK {
 		successCode = http.StatusNoContent // 204 if target already existed, see https://tools.ietf.org/html/rfc4918#section-9.9.4

--- a/internal/http/services/owncloud/ocdav/ocdav_blackbox_test.go
+++ b/internal/http/services/owncloud/ocdav/ocdav_blackbox_test.go
@@ -645,7 +645,7 @@ var _ = Describe("ocdav", func() {
 				It("the source and the destination exist", func() {
 
 					mockPathStat(mReq.Source.Path, status.NewOK(ctx), &cs3storageprovider.ResourceInfo{Id: mReq.Source.ResourceId})
-					mockPathStat(mReq.Destination.Path, status.NewOK(ctx), &cs3storageprovider.ResourceInfo{Id: mReq.Destination.ResourceId})
+					mockPathStat(mReq.Destination.Path, status.NewOK(ctx), &cs3storageprovider.ResourceInfo{Id: &cs3storageprovider.ResourceId{StorageId: "provider-1", SpaceId: "userspace", OpaqueId: "newfile"}})
 
 					client.On("Delete", mock.Anything, mock.MatchedBy(func(req *cs3storageprovider.DeleteRequest) bool {
 						return utils.ResourceEqual(req.Ref, mReq.Destination)
@@ -661,6 +661,51 @@ var _ = Describe("ocdav", func() {
 
 					handler.Handler().ServeHTTP(rr, req)
 					Expect(rr).To(HaveHTTPStatus(http.StatusNoContent))
+				})
+			})
+
+			When("renaming a resource to its current name", func() {
+				// see https://github.com/owncloud/ocis/issues/1976: source and destination
+				// stat to the same resource id, the move must be a silent no-op.
+				sameID := &cs3storageprovider.ResourceId{StorageId: "provider-1", SpaceId: "userspace", OpaqueId: "sameid"}
+
+				It("succeeds as a no-op with move permission and does not move or delete", func() {
+					mockPathStat(mReq.Source.Path, status.NewOK(ctx), &cs3storageprovider.ResourceInfo{
+						Id:            sameID,
+						PermissionSet: &cs3storageprovider.ResourcePermissions{Move: true},
+					})
+					mockPathStat(mReq.Destination.Path, status.NewOK(ctx), &cs3storageprovider.ResourceInfo{
+						Id:       sameID,
+						MimeType: "text/plain",
+						Etag:     `"deadbeef"`,
+					})
+
+					handler.Handler().ServeHTTP(rr, req)
+
+					Expect(rr).To(HaveHTTPStatus(http.StatusNoContent))
+					// the resource must not be touched
+					client.AssertNotCalled(GinkgoT(), "Move", mock.Anything, mock.Anything)
+					client.AssertNotCalled(GinkgoT(), "Delete", mock.Anything, mock.Anything)
+					// the response headers describe the untouched destination resource
+					Expect(rr.Header().Get(net.HeaderETag)).To(Equal(`"deadbeef"`))
+					Expect(rr.Header().Get(net.HeaderOCETag)).To(Equal(`"deadbeef"`))
+					Expect(rr.Header().Get(net.HeaderOCFileID)).ToNot(BeEmpty())
+				})
+
+				It("returns forbidden without move permission and does not move or delete", func() {
+					mockPathStat(mReq.Source.Path, status.NewOK(ctx), &cs3storageprovider.ResourceInfo{
+						Id:            sameID,
+						PermissionSet: &cs3storageprovider.ResourcePermissions{Move: false},
+					})
+					mockPathStat(mReq.Destination.Path, status.NewOK(ctx), &cs3storageprovider.ResourceInfo{
+						Id: sameID,
+					})
+
+					handler.Handler().ServeHTTP(rr, req)
+
+					Expect(rr).To(HaveHTTPStatus(http.StatusForbidden))
+					client.AssertNotCalled(GinkgoT(), "Move", mock.Anything, mock.Anything)
+					client.AssertNotCalled(GinkgoT(), "Delete", mock.Anything, mock.Anything)
 				})
 			})
 
@@ -709,7 +754,7 @@ var _ = Describe("ocdav", func() {
 				It("error when deleting an existing tree", func() {
 
 					mockPathStat(mReq.Source.Path, status.NewOK(ctx), &cs3storageprovider.ResourceInfo{Id: mReq.Source.ResourceId, Path: "./file"})
-					mockPathStat(mReq.Destination.Path, status.NewOK(ctx), &cs3storageprovider.ResourceInfo{Id: mReq.Destination.ResourceId, Path: "./newfile"})
+					mockPathStat(mReq.Destination.Path, status.NewOK(ctx), &cs3storageprovider.ResourceInfo{Id: &cs3storageprovider.ResourceId{StorageId: "provider-1", SpaceId: "userspace", OpaqueId: "newfile"}, Path: "./newfile"})
 
 					client.On("Delete", mock.Anything, mock.MatchedBy(func(req *cs3storageprovider.DeleteRequest) bool {
 						return utils.ResourceEqual(req.Ref, mReq.Destination)
@@ -731,7 +776,7 @@ var _ = Describe("ocdav", func() {
 				It("error when Delete returns unexpected code", func() {
 
 					mockPathStat(mReq.Source.Path, status.NewOK(ctx), &cs3storageprovider.ResourceInfo{Id: mReq.Source.ResourceId, Path: "./file"})
-					mockPathStat(mReq.Destination.Path, status.NewOK(ctx), &cs3storageprovider.ResourceInfo{Id: mReq.Destination.ResourceId, Path: "./newfile"})
+					mockPathStat(mReq.Destination.Path, status.NewOK(ctx), &cs3storageprovider.ResourceInfo{Id: &cs3storageprovider.ResourceId{StorageId: "provider-1", SpaceId: "userspace", OpaqueId: "newfile"}, Path: "./newfile"})
 
 					client.On("Delete", mock.Anything, mock.MatchedBy(func(req *cs3storageprovider.DeleteRequest) bool {
 						return utils.ResourceEqual(req.Ref, mReq.Destination)
@@ -890,7 +935,7 @@ var _ = Describe("ocdav", func() {
 
 			When("the gateway returns error when moving file", func() {
 				It("error when the source is a file and the destination is a folder", func() {
-					mockPathStat(mReq.Source.Path, status.NewOK(ctx), &cs3storageprovider.ResourceInfo{Id: mReq.Source.ResourceId})
+					mockPathStat(mReq.Source.Path, status.NewOK(ctx), &cs3storageprovider.ResourceInfo{Id: &cs3storageprovider.ResourceId{StorageId: "provider-1", SpaceId: "userspace", OpaqueId: "srcfile"}})
 
 					mockStat(mockReference("userspace", ""), status.NewOK(ctx), &cs3storageprovider.ResourceInfo{
 						Id: mReq.Destination.ResourceId, Path: mReq.Destination.Path,
@@ -990,7 +1035,7 @@ var _ = Describe("ocdav", func() {
 				})).Return(&cs3storageprovider.StatResponse{
 					Status: status.NewOK(ctx),
 					Info: &cs3storageprovider.ResourceInfo{
-						Id:       mReq.Source.ResourceId,
+						Id:       &cs3storageprovider.ResourceId{StorageId: "provider-1", OpaqueId: "dstStat", SpaceId: "userspace"},
 						ParentId: &cs3storageprovider.ResourceId{StorageId: "provider-1", OpaqueId: "dstId", SpaceId: "userspace"},
 						Name:     dstFileName,
 					},


### PR DESCRIPTION
Renaming a resource to the name it already has failed with an opaque error.

`handleMove` ran the overwrite check and the `client.Delete` "delete existing tree" call before noticing that source and destination pointed at the same resource, so a same-name rename could destroy the resource. Depending on the `Overwrite` header the request surfaced either a bare `412` with an empty body (what web sends, `Overwrite: F`) or a `403`/`404` from the decomposedfs `Move` (see owncloud/ocis#1976).

## Change

`handleMove` now compares the **stat'ed** resource ids of source and destination and, when they are equal, returns `204 No Content` as a silent no-op — placed **before** the overwrite/412 check and the delete call, which is the safety-critical property. Comparing the stat'ed infos rather than the raw references also catches id based DAV paths, where the two references differ but resolve to the same resource.

Permissions are still respected: a user without `PermissionSet.Move` receives `403 Forbidden` rather than being told the rename succeeded.

Because all rename clients funnel through `handleMove` (`handlePathMove` and `handleSpacesMove` both delegate to it), the single guard makes the behaviour consistent across clients.

## Tests

Two new cases in `ocdav_blackbox_test.go` covering the same-name no-op and the no-permission `403`. Six pre-existing MOVE tests were adjusted: they reused a single `ResourceId` for both source and destination, which is unrealistic and would now trip the new guard, so they were given distinct ids.

`go build ./...`, `go vet` and `go test ./internal/http/services/owncloud/ocdav/ -count=1` all pass.
