### PR TITLE
fix: same-name rename is a no-op on the id based dav route

### DIFF
--- a/changelog/unreleased/bugfix-rename-resource-to-same-name.md
+++ b/changelog/unreleased/bugfix-rename-resource-to-same-name.md
@@ -7,8 +7,11 @@ destroy the resource. The handler now compares the stat'ed resource ids of
 source and destination and, when they are equal, returns a silent no-op
 (`204 No Content`) before the overwrite and delete logic runs, consistently for
 all clients. This also catches id based dav paths where source and destination
-references differ but resolve to the same resource. Users without the move
+references differ but resolve to the same resource; there the same name check
+runs before the recursion detection, which would otherwise report the resource
+as a child of itself and fail with `409 Conflict`. Users without the move
 permission still receive a `403 Forbidden`.
 
 https://github.com/owncloud/reva/pull/708
+https://github.com/owncloud/reva/pull/713
 https://github.com/owncloud/ocis/issues/1976

--- a/internal/http/services/owncloud/ocdav/move.go
+++ b/internal/http/services/owncloud/ocdav/move.go
@@ -148,59 +148,6 @@ func (s *svc) handleMove(ctx context.Context, w http.ResponseWriter, r *http.Req
 		errors.HandleWebdavError(&log, w, b, err)
 		return
 	}
-	isChild, err := s.referenceIsChildOf(ctx, s.gatewaySelector, dst, src)
-	if err != nil {
-		switch err.(type) {
-		case errtypes.IsNotFound:
-			w.WriteHeader(http.StatusNotFound)
-		case errtypes.IsNotSupported:
-			log.Error().Err(err).Msg("can not detect recursive move operation. missing machine auth configuration?")
-			w.WriteHeader(http.StatusForbidden)
-		default:
-			log.Error().Err(err).Msg("error while trying to detect recursive move operation")
-			w.WriteHeader(http.StatusInternalServerError)
-		}
-		return
-	}
-	if isChild {
-		w.WriteHeader(http.StatusConflict)
-		b, err := errors.Marshal(http.StatusBadRequest, "can not move a folder into one of its children", "", "")
-		errors.HandleWebdavError(&log, w, b, err)
-		return
-	}
-
-	isParent, err := s.referenceIsChildOf(ctx, s.gatewaySelector, src, dst)
-	if err != nil {
-		switch err.(type) {
-		case errtypes.IsNotFound:
-			isParent = false
-		case errtypes.IsNotSupported:
-			log.Error().Err(err).Msg("can not detect recursive move operation. missing machine auth configuration?")
-			w.WriteHeader(http.StatusForbidden)
-			return
-		default:
-			log.Error().Err(err).Msg("error while trying to detect recursive move operation")
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-	}
-	if isParent {
-		w.WriteHeader(http.StatusConflict)
-		b, err := errors.Marshal(http.StatusBadRequest, "can not move a folder into its parent", "", "")
-		errors.HandleWebdavError(&log, w, b, err)
-		return
-
-	}
-
-	oh := r.Header.Get(net.HeaderOverwrite)
-	log.Debug().Str("overwrite", oh).Msg("move")
-
-	overwrite, err := net.ParseOverwrite(oh)
-	if err != nil {
-		w.WriteHeader(http.StatusBadRequest)
-		return
-	}
-
 	client, err := s.gatewaySelector.Next()
 	if err != nil {
 		log.Error().Err(err).Msg("error selecting next client")
@@ -261,6 +208,59 @@ func (s *svc) handleMove(ctx context.Context, w http.ResponseWriter, r *http.Req
 		w.Header().Set(net.HeaderOCFileID, storagespace.FormatResourceID(info.GetId()))
 		w.Header().Set(net.HeaderOCETag, info.GetEtag())
 		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	isChild, err := s.referenceIsChildOf(ctx, s.gatewaySelector, dst, src)
+	if err != nil {
+		switch err.(type) {
+		case errtypes.IsNotFound:
+			w.WriteHeader(http.StatusNotFound)
+		case errtypes.IsNotSupported:
+			log.Error().Err(err).Msg("can not detect recursive move operation. missing machine auth configuration?")
+			w.WriteHeader(http.StatusForbidden)
+		default:
+			log.Error().Err(err).Msg("error while trying to detect recursive move operation")
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+		return
+	}
+	if isChild {
+		w.WriteHeader(http.StatusConflict)
+		b, err := errors.Marshal(http.StatusBadRequest, "can not move a folder into one of its children", "", "")
+		errors.HandleWebdavError(&log, w, b, err)
+		return
+	}
+
+	isParent, err := s.referenceIsChildOf(ctx, s.gatewaySelector, src, dst)
+	if err != nil {
+		switch err.(type) {
+		case errtypes.IsNotFound:
+			isParent = false
+		case errtypes.IsNotSupported:
+			log.Error().Err(err).Msg("can not detect recursive move operation. missing machine auth configuration?")
+			w.WriteHeader(http.StatusForbidden)
+			return
+		default:
+			log.Error().Err(err).Msg("error while trying to detect recursive move operation")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	}
+	if isParent {
+		w.WriteHeader(http.StatusConflict)
+		b, err := errors.Marshal(http.StatusBadRequest, "can not move a folder into its parent", "", "")
+		errors.HandleWebdavError(&log, w, b, err)
+		return
+
+	}
+
+	oh := r.Header.Get(net.HeaderOverwrite)
+	log.Debug().Str("overwrite", oh).Msg("move")
+
+	overwrite, err := net.ParseOverwrite(oh)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 

--- a/internal/http/services/owncloud/ocdav/ocdav_blackbox_test.go
+++ b/internal/http/services/owncloud/ocdav/ocdav_blackbox_test.go
@@ -1111,6 +1111,74 @@ var _ = Describe("ocdav", func() {
 			})
 		})
 
+		Describe("MOVE a resource to the name it already has", func() {
+			// see https://github.com/owncloud/ocis/issues/1976. The id based dav route
+			// addresses the source by its own id and the destination relative to the
+			// parent, so the two references carry different resource ids even though they
+			// resolve to the same path. The recursion detection sees a path that is a
+			// prefix of itself, so the same name check has to run before it.
+			sameID := &cs3storageprovider.ResourceId{StorageId: "provider-1", SpaceId: "userspace", OpaqueId: "fileId"}
+
+			var srcRef, dstRef *cs3storageprovider.Reference
+
+			BeforeEach(func() {
+				srcRef = mockReference("fileId", ".")
+				// the space id form of the destination carries no opaque id
+				dstRef = mockReference("", "./textfile.txt")
+
+				rr = httptest.NewRecorder()
+				req, err = http.NewRequest("MOVE", basePath+"/provider-1$userspace!fileId", strings.NewReader(""))
+				Expect(err).ToNot(HaveOccurred())
+				req = req.WithContext(ctx)
+				req.Header.Set(net.HeaderDestination, basePath+"/provider-1$userspace/textfile.txt")
+				req.Header.Set("Overwrite", "T")
+
+				// both references resolve to the same path
+				client.On("GetPath", mock.Anything, mock.Anything).Return(func(ctx context.Context, req *cs3storageprovider.GetPathRequest, _ ...grpc.CallOption) (*cs3storageprovider.GetPathResponse, error) {
+					switch req.ResourceId.OpaqueId {
+					case "fileId":
+						return &cs3storageprovider.GetPathResponse{Status: status.NewOK(ctx), Path: "/textfile.txt"}, nil
+					default:
+						return &cs3storageprovider.GetPathResponse{Status: status.NewOK(ctx), Path: "/"}, nil
+					}
+				})
+			})
+
+			It("succeeds as a no-op with move permission and does not move or delete", func() {
+				mockStatOK(srcRef, &cs3storageprovider.ResourceInfo{
+					Id:            sameID,
+					PermissionSet: &cs3storageprovider.ResourcePermissions{Move: true},
+				})
+				mockStatOK(dstRef, &cs3storageprovider.ResourceInfo{
+					Id:       sameID,
+					MimeType: "text/plain",
+					Etag:     `"deadbeef"`,
+				})
+
+				handler.Handler().ServeHTTP(rr, req)
+
+				Expect(rr).To(HaveHTTPStatus(http.StatusNoContent))
+				client.AssertNotCalled(GinkgoT(), "Move", mock.Anything, mock.Anything)
+				client.AssertNotCalled(GinkgoT(), "Delete", mock.Anything, mock.Anything)
+				Expect(rr.Header().Get(net.HeaderETag)).To(Equal(`"deadbeef"`))
+				Expect(rr.Header().Get(net.HeaderOCETag)).To(Equal(`"deadbeef"`))
+			})
+
+			It("returns forbidden without move permission and does not move or delete", func() {
+				mockStatOK(srcRef, &cs3storageprovider.ResourceInfo{
+					Id:            sameID,
+					PermissionSet: &cs3storageprovider.ResourcePermissions{Move: false},
+				})
+				mockStatOK(dstRef, &cs3storageprovider.ResourceInfo{Id: sameID})
+
+				handler.Handler().ServeHTTP(rr, req)
+
+				Expect(rr).To(HaveHTTPStatus(http.StatusForbidden))
+				client.AssertNotCalled(GinkgoT(), "Move", mock.Anything, mock.Anything)
+				client.AssertNotCalled(GinkgoT(), "Delete", mock.Anything, mock.Anything)
+			})
+		})
+
 	})
 	Context("at the /dav/public-files endpoint", func() {
 


### PR DESCRIPTION
Follow-up to #708. That PR made a same-name rename a silent no-op, but the guard was only
reached on the path based dav route. Addressing the resource by its id still returned
`409 Conflict`.

## Why the guard was skipped

`referenceIsChildOf` branches on how the two `Reference`s are anchored, and the trailing `/`
lands differently per branch:

| Branch | Comparison | Same-name result |
|---|---|---|
| same anchor — path based route | `HasPrefix(child.Path, parent.Path+"/")` — slash on **parent only** | `false` |
| different anchors — id based route | `HasPrefix(cp, pp)` — slash on **both** | `true` → 409 |
| shares (`sspReferenceIsChildOf`) | resolved anchors only, relative `Path` ignored | `false` |

On the id based route the source is `{fileId, "."}` and the destination is
`{spaceRoot, "./textfile.txt"}`. Different anchors send it down the `GetPath` branch, both
sides resolve to `/textfile.txt/`, the two strings are byte-identical, and every string is a
prefix of itself — so `isChild` fires and returns `409` before the same-name guard runs.
(`isParent` would also be true, but is never evaluated.) This is also why the sharee
scenario already passed: the shares branch ignores the relative path, so the collision
never arises.

## The change

The client selection, the source and destination `Stat` calls and the same-name guard move
above the `isChild`/`isParent` checks. The guard could not move on its own — it reads
`srcStatRes`/`dstStatRes`, so the `Stat` calls travel with it.

No logic changed: `move.go` is **53 insertions / 53 deletions**, pure relocation.

Reordering is safe because **a move onto the resource itself is never recursive**. The guard
compares the stat'ed resource ids (`StatResponse.Info.Id`), not the reference anchors, so it
is indifferent to how the client addressed the resource — which is exactly what
`referenceIsChildOf` is sensitive to.

## Testing

- Two new specs in `ocdav_blackbox_test.go` under
  `Describe("MOVE a resource to the name it already has")` in the `/dav/spaces` context,
  covering the `204` no-op and the `403` for a user without move permission. Written
  test-first: both failed with `409 can not move a folder into one of its children` — the
  exact production symptom — and pass after the reorder.
- The ocis `moveByFileId.feature` acceptance suite: the three real by-id failures
  (`@issue-1976`) now pass.
- Verified live over HTTP against a running ocis stack: by-id MOVE `409` → `204` with correct
  `etag`/`oc-etag`/`oc-fileid`, and a follow-up `GET` returned the original content — the file
  is intact and keeps its fileid. That last check matters, since the original report was that
  this path could destroy the resource.

## Changelog

Folded into the existing `bugfix-rename-resource-to-same-name.md` rather than shipping a
second entry. Both are in the same unreleased cycle and describe one user-visible behaviour,
and that entry already claimed the id based route was covered — a claim that only becomes
true with this change.

Fixes owncloud/ocis#1976