### PR TITLE
feat: route PUT and TUS through the upload coordinator

### DIFF
--- a/pkg/upload/coordinator.go
+++ b/pkg/upload/coordinator.go
@@ -69,8 +69,6 @@ func (c *coordinator) InitiateUpload(ctx context.Context, ref *provider.Referenc
 		return nil, err
 	}
 
-	// TODO: main wraps this in the posix usermapper's base scope (upload.go:316),
-	// which is not reachable from a driver-agnostic package.
 	if err := session.TouchBin(); err != nil {
 		return nil, fmt.Errorf("coordinator: could not create bin file: %w", err)
 	}
@@ -108,7 +106,8 @@ func (c *coordinator) populateSession(ctx context.Context, session Session, t *u
 		session.SetStorageValue("NodeId", t.nodeID)
 		session.SetStorageValue("NodeExists", "true")
 	} else {
-		// A new file has no id yet, so mint a placeholder TouchFile replaces.
+		// A new file has no id yet, and an empty one would resolve to the space root
+		// (lookup.go:191), so mint a placeholder TouchFile replaces.
 		session.SetStorageValue("NodeId", uuid.New().String())
 	}
 
@@ -129,9 +128,6 @@ func (c *coordinator) populateSession(ctx context.Context, session Session, t *u
 	session.SetMetadata("initiatorid", initiatorID)
 
 	session.SetSize(uploadLength)
-
-	// TODO: main also copies CtxKeySpaceGID for posix uid/gid scoping
-	// (upload.go:188), which lives in the decomposedfs package.
 
 	return c.applyRequestMetadata(session, metadata)
 }
@@ -673,8 +669,7 @@ func (c *coordinator) describeExisting(ctx context.Context, ref *provider.Refere
 	t.spaceID = existing.GetId().GetSpaceId()
 	t.parentID = existing.GetParentId().GetOpaqueId()
 	t.name = existing.GetName()
-	// TODO: no manager fallback, so this stays nil on project drives.
-	t.spaceOwner = existing.GetOwner()
+	t.spaceOwner = c.spaceOwnerOrManager(ctx, existing.GetOwner(), t.spaceID)
 
 	// GetMD returns only the basename for id-based refs, so ask for the full path.
 	relPath := existing.GetPath()
@@ -691,6 +686,36 @@ func (c *coordinator) describeExisting(ctx context.Context, ref *provider.Refere
 	}
 	if metadata["if-none-match"] == "*" {
 		return errtypes.Aborted(fmt.Sprintf("parent %s already has a child %s, id %s", t.parentID, t.name, t.nodeID))
+	}
+	return nil
+}
+
+// spaceOwnerOrManager resolves the space owner, falling back to a manager.
+func (c *coordinator) spaceOwnerOrManager(ctx context.Context, owner *user.UserId, spaceID string) *user.UserId {
+	// A space with no personal owner stores a SPACE_OWNER placeholder (spaces.go:145).
+	if owner != nil && owner.GetType() != user.UserType_USER_TYPE_SPACE_OWNER {
+		return owner
+	}
+
+	grants, err := c.fs.ListGrants(ctx, &provider.Reference{ResourceId: &provider.ResourceId{
+		SpaceId:  spaceID,
+		OpaqueId: spaceID,
+	}})
+	if err != nil {
+		return nil
+	}
+
+	// Grants come back in map order, so several managers resolve to an arbitrary one.
+	for _, g := range grants {
+		// Group grants carry no user id.
+		uid := g.GetGrantee().GetUserId()
+		if uid == nil {
+			continue
+		}
+		p := g.GetPermissions()
+		if p.GetStat() && p.GetListContainer() && p.GetInitiateFileDownload() {
+			return uid
+		}
 	}
 	return nil
 }

--- a/pkg/upload/coordinator.go
+++ b/pkg/upload/coordinator.go
@@ -1,0 +1,333 @@
+package upload
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	user "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	tusd "github.com/tus/tusd/v2/pkg/handler"
+
+	"github.com/owncloud/reva/v2/pkg/appctx"
+	ctxpkg "github.com/owncloud/reva/v2/pkg/ctx"
+	"github.com/owncloud/reva/v2/pkg/errtypes"
+	"github.com/owncloud/reva/v2/pkg/events"
+	"github.com/owncloud/reva/v2/pkg/storage"
+	"github.com/owncloud/reva/v2/pkg/storage/utils/chunking"
+	"github.com/owncloud/reva/v2/pkg/utils"
+)
+
+// Coordinator owns the upload lifecycle: initiation, data transfer and listing.
+type Coordinator interface {
+	// InitiateUpload returns the protocols and ids that bytes can be appended to.
+	InitiateUpload(ctx context.Context, ref *provider.Reference, uploadLength int64, metadata map[string]string) (map[string]string, error)
+	// GetUpload returns the session with the given id as a tusd upload.
+	GetUpload(ctx context.Context, id string) (tusd.Upload, error)
+	// UseIn registers the coordinator as the tusd data store.
+	UseIn(composer *tusd.StoreComposer)
+	// ListUploadSessions returns the upload sessions matching the given filter.
+	ListUploadSessions(ctx context.Context, filter storage.UploadSessionFilter) ([]storage.UploadSession, error)
+	// Upload writes the whole body of a non-resumable (PUT) upload and finishes it.
+	Upload(ctx context.Context, req storage.UploadRequest, uff storage.UploadFinishedFunc) (*provider.ResourceInfo, error)
+}
+
+// coordinator is the concrete implementation of Coordinator.
+type coordinator struct {
+	fs           storage.FS
+	store        SessionStore
+	chunkHandler *chunking.ChunkHandler
+	pub          events.Publisher
+	// async defers the commit to postprocessing. Only StartPostprocessing sets it.
+	async bool
+}
+
+// NewCoordinator constructs a coordinator backed by the given driver and store.
+func NewCoordinator(fs storage.FS, store SessionStore, chunkFolder string, pub events.Publisher) *coordinator {
+	c := &coordinator{fs: fs, store: store, pub: pub}
+	if chunkFolder != "" {
+		c.chunkHandler = chunking.NewChunkHandler(chunkFolder)
+	}
+	return c
+}
+
+// uploadTarget is what an upload needs to know about its destination
+type uploadTarget struct {
+	// exists distinguishes an overwrite from a new file.
+	exists bool
+	// chunkName is set for legacy chunking-v1 uploads only.
+	chunkName string
+
+	nodeID     string
+	spaceID    string
+	parentID   string
+	dir        string
+	name       string
+	spaceOwner *user.UserId
+}
+
+// resolveTarget locates the file an upload writes to, and rejects an upload that
+// may not proceed.
+func (c *coordinator) resolveTarget(ctx context.Context, ref *provider.Reference, uploadLength int64, metadata map[string]string) (*uploadTarget, error) {
+	t := &uploadTarget{}
+	if chunking.IsChunked(ref.GetPath()) { // check legacy chunking v1
+		var err error
+		ref, t.chunkName, err = rewriteChunkedRef(ref)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// TODO: GetMD reports a file hidden by a deny-grant as NotFound, so the upload
+	// fails late with 409 instead of 403. Needs a permission-free resolve.
+	existing, err := c.fs.GetMD(ctx, ref, []string{}, []string{})
+	switch err.(type) {
+	case nil:
+		t.exists = true
+	case errtypes.IsNotFound:
+		t.exists = false
+	default:
+		return nil, err
+	}
+
+	if err := c.checkQuota(ctx, ref, uploadLength, existing); err != nil {
+		return nil, err
+	}
+
+	if t.exists {
+		if err := c.describeExisting(ctx, ref, existing, metadata, t); err != nil {
+			return nil, err
+		}
+	} else if err := c.describeNew(ctx, ref, t); err != nil {
+		return nil, err
+	}
+
+	if t.name == "" {
+		return nil, errtypes.BadRequest("coordinator: missing filename in ref")
+	}
+	if t.dir == "" {
+		return nil, errtypes.BadRequest("coordinator: could not determine upload directory")
+	}
+	return t, nil
+}
+
+// checkQuota rejects an upload that would not fit in the space, counting only
+// the bytes it adds.
+func (c *coordinator) checkQuota(ctx context.Context, ref *provider.Reference, uploadLength int64, existing *provider.ResourceInfo) error {
+	if uploadLength < 0 {
+		return nil
+	}
+	spaceRef := &provider.Reference{ResourceId: &provider.ResourceId{
+		StorageId: ref.GetResourceId().GetStorageId(),
+		SpaceId:   ref.GetResourceId().GetSpaceId(),
+	}}
+	_, _, remaining, err := c.fs.GetQuota(ctx, spaceRef)
+	if err != nil {
+		return nil
+	}
+
+	netRequired := uint64(uploadLength)
+	if existingSize := existing.GetSize(); existingSize < netRequired {
+		netRequired -= existingSize
+	} else {
+		netRequired = 0
+	}
+	if remaining < netRequired {
+		return errtypes.InsufficientStorage("quota exceeded")
+	}
+	return nil
+}
+
+// describeExisting fills in the target from the file being overwritten.
+func (c *coordinator) describeExisting(ctx context.Context, ref *provider.Reference, existing *provider.ResourceInfo, metadata map[string]string, t *uploadTarget) error {
+	if !existing.GetPermissionSet().GetInitiateFileUpload() {
+		return errtypes.PermissionDenied(ref.GetPath())
+	}
+	if existing.GetType() == provider.ResourceType_RESOURCE_TYPE_CONTAINER {
+		return errtypes.PreconditionFailed("resource is not a file")
+	}
+
+	t.nodeID = existing.GetId().GetOpaqueId()
+	t.spaceID = existing.GetId().GetSpaceId()
+	t.parentID = existing.GetParentId().GetOpaqueId()
+	t.name = existing.GetName()
+	// TODO: no manager fallback, so this stays nil on project drives.
+	t.spaceOwner = existing.GetOwner()
+
+	// GetMD returns only the basename for id-based refs, so ask for the full path.
+	relPath := existing.GetPath()
+	if utils.IsRelativeReference(ref) {
+		if full, err := c.fs.GetPathByID(ctx, existing.GetId()); err == nil {
+			relPath = full
+		}
+	}
+	t.dir = filepath.Dir(relPath)
+
+	// Lock before precondition, the order main checks them in (upload.go:293-302).
+	if err := c.checkLock(ctx, ref); err != nil {
+		return err
+	}
+	if metadata["if-none-match"] == "*" {
+		return errtypes.Aborted(fmt.Sprintf("parent %s already has a child %s, id %s", t.parentID, t.name, t.nodeID))
+	}
+	return nil
+}
+
+// checkLock rejects an upload that conflicts with a lock held on the file.
+func (c *coordinator) checkLock(ctx context.Context, ref *provider.Reference) error {
+	// An unlocked file and a driver without locks both error, so only a lock we
+	// actually read counts as one.
+	diskLock, err := c.fs.GetLock(ctx, ref)
+	if err != nil {
+		diskLock = nil
+	}
+	contextLockID, _ := ctxpkg.ContextGetLockID(ctx)
+
+	switch {
+	case diskLock == nil && contextLockID != "":
+		return errtypes.Aborted("not locked")
+	case diskLock == nil:
+		return nil
+	case contextLockID == "":
+		return errtypes.Locked(diskLock.LockId)
+	case contextLockID != diskLock.LockId:
+		return errtypes.Aborted("mismatching lock")
+	}
+	return nil
+}
+
+// describeNew fills in the target for a file that does not exist yet, from its
+// parent directory.
+func (c *coordinator) describeNew(ctx context.Context, ref *provider.Reference, t *uploadTarget) error {
+	t.spaceID = ref.GetResourceId().GetSpaceId()
+	t.dir = filepath.Dir(ref.GetPath())
+	t.name = filepath.Base(ref.GetPath())
+
+	parentRef := &provider.Reference{ResourceId: ref.GetResourceId(), Path: t.dir}
+	parentMD, err := c.fs.GetMD(ctx, parentRef, []string{}, []string{})
+	switch err.(type) {
+	case nil:
+	case errtypes.IsNotFound:
+		return c.missingParentError(ctx, ref, t.dir, err)
+	default:
+		return err
+	}
+
+	if !parentMD.GetPermissionSet().GetInitiateFileUpload() {
+		return errtypes.PermissionDenied(ref.GetPath())
+	}
+	t.parentID = parentMD.GetId().GetOpaqueId()
+	t.spaceID = parentMD.GetId().GetSpaceId()
+
+	// An id-based ref yields a relative dir ("."), so ask for the parent's full path.
+	if utils.IsRelativeReference(ref) {
+		if parentPath, pErr := c.fs.GetPathByID(ctx, parentMD.GetId()); pErr == nil {
+			t.dir = parentPath
+		}
+	}
+	return nil
+}
+
+// missingParentError tells a missing directory apart from one that is only
+// invisible to the caller: a visible ancestor means it is missing.
+func (c *coordinator) missingParentError(ctx context.Context, ref *provider.Reference, dir string, notFound error) error {
+	for ancestor := dir; ancestor != "." && ancestor != "/"; {
+		ancestor = filepath.Dir(ancestor)
+		ancestorRef := &provider.Reference{ResourceId: ref.GetResourceId(), Path: ancestor}
+		if _, err := c.fs.GetMD(ctx, ancestorRef, []string{}, []string{}); err == nil {
+			return errtypes.PreconditionFailed(notFound.Error())
+		}
+	}
+	return errtypes.PermissionDenied(ref.GetPath())
+}
+
+// rewriteChunkedRef turns a legacy chunking-v1 path into a reference to the real
+// target file, plus the chunk name.
+func rewriteChunkedRef(ref *provider.Reference) (*provider.Reference, string, error) {
+	ci, err := chunking.GetChunkBLOBInfo(ref.GetPath())
+	if err != nil {
+		return nil, "", errtypes.BadRequest(err.Error())
+	}
+	return &provider.Reference{ResourceId: ref.ResourceId, Path: ci.Path}, filepath.Base(ref.GetPath()), nil
+}
+
+// ListUploadSessions returns the upload sessions matching the given filter.
+func (c *coordinator) ListUploadSessions(ctx context.Context, filter storage.UploadSessionFilter) ([]storage.UploadSession, error) {
+	// Only the driver can resolve a session's node, so refuse rather than
+	// silently report every session as a match.
+	if filter.Orphaned != nil {
+		return nil, errtypes.NotSupported("coordinator: the orphaned filter is not supported")
+	}
+
+	var sessions []Session
+	if filter.ID != nil && *filter.ID != "" {
+		session, err := c.store.Get(ctx, *filter.ID)
+		if err != nil {
+			return nil, err
+		}
+		sessions = []Session{session}
+	} else {
+		var err error
+		sessions, err = c.store.List(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	filtered := []storage.UploadSession{}
+	now := time.Now()
+	for _, session := range sessions {
+		if filter.Processing != nil && *filter.Processing != session.IsProcessing() {
+			continue
+		}
+		if filter.Expired != nil {
+			if *filter.Expired {
+				if now.Before(session.Expires()) {
+					continue
+				}
+			} else {
+				if now.After(session.Expires()) {
+					continue
+				}
+			}
+		}
+		if filter.HasVirus != nil {
+			sr, _ := session.ScanData()
+			infected := sr != ""
+			if *filter.HasVirus != infected {
+				continue
+			}
+		}
+		filtered = append(filtered, session)
+	}
+	return filtered, nil
+}
+
+// uploadRef builds the reference upload events carry: the space root, plus the
+// file's path within it.
+func (c *coordinator) uploadRef(session Session) *provider.Reference {
+	return &provider.Reference{
+		ResourceId: &provider.ResourceId{
+			StorageId: session.ProviderID(),
+			SpaceId:   session.SpaceID(),
+			OpaqueId:  session.SpaceID(),
+		},
+		Path: utils.MakeRelativePath(filepath.Join(session.Dir(), session.Filename())),
+	}
+}
+
+// impersonatingUser returns the real actor behind a borrowed identity, which
+// public link and OCM auth record in the request user's opaque.
+func impersonatingUser(ctx context.Context) *user.User {
+	u, ok := ctxpkg.ContextGetUser(ctx)
+	if !ok || !utils.ExistsInOpaque(u.GetOpaque(), "impersonating-user") {
+		return nil
+	}
+	impersonating := &user.User{}
+	if err := utils.ReadJSONFromOpaque(u.GetOpaque(), "impersonating-user", impersonating); err != nil {
+		appctx.GetLogger(ctx).Error().Err(err).Msg("could not read impersonating user")
+		return nil
+	}
+	return impersonating
+}

--- a/pkg/upload/coordinator.go
+++ b/pkg/upload/coordinator.go
@@ -37,6 +37,8 @@ type Coordinator interface {
 	Upload(ctx context.Context, req storage.UploadRequest, uff storage.UploadFinishedFunc) (*provider.ResourceInfo, error)
 }
 
+var _ Coordinator = (*coordinator)(nil)
+
 // coordinator is the concrete implementation of Coordinator.
 type coordinator struct {
 	fs           storage.FS
@@ -177,6 +179,57 @@ func (c *coordinator) applyRequestMetadata(session Session, metadata map[string]
 		return errtypes.BadRequest("unsupported checksum algorithm: " + parts[0])
 	}
 	return nil
+}
+
+// Upload writes the whole body of a non-resumable (PUT) upload and finishes it.
+// req.Ref.Path carries the session id minted by InitiateUpload.
+func (c *coordinator) Upload(ctx context.Context, req storage.UploadRequest, uff storage.UploadFinishedFunc) (*provider.ResourceInfo, error) {
+	// The request path arrives rooted, while session ids are stored unrooted.
+	session, err := c.store.Get(ctx, strings.TrimPrefix(req.Ref.GetPath(), "/"))
+	if err != nil {
+		return nil, err
+	}
+
+	// Behind the data gateway the request carries a transfer token, not the user.
+	ctx = session.Context(ctx)
+
+	if chunk := session.Chunk(); chunk != "" { // legacy chunking v1
+		if c.chunkHandler == nil {
+			return nil, errtypes.NotSupported("coordinator: chunked uploads require a chunk folder")
+		}
+		assembled, assembledSize, done, aErr := c.chunkHandler.Assemble(chunk, req.Body)
+		if aErr != nil {
+			return nil, aErr
+		}
+		if !done {
+			// The bytes accumulate in the chunk folder, so this session holds nothing.
+			session.Cleanup(ctx, true, true)
+			return nil, errtypes.PartialContent(req.Ref.String())
+		}
+		defer assembled.Close()
+		// The declared length covers only the final chunk.
+		req.Body, req.Length = assembled, assembledSize
+		session.SetSize(assembledSize)
+	}
+
+	size, err := session.WriteChunk(ctx, 0, req.Body)
+	if err != nil {
+		return nil, err
+	}
+	if size != req.Length {
+		return nil, errtypes.PartialContent("coordinator: unexpected end of stream")
+	}
+
+	ri, err := c.finishUpload(ctx, session)
+	if err != nil {
+		return nil, err
+	}
+
+	if uff != nil {
+		executant := session.Executant()
+		uff(session.SpaceOwner(), &executant, c.uploadRef(session))
+	}
+	return ri, nil
 }
 
 // finishUpload creates the node, validates the staged bytes and commits them, or

--- a/pkg/upload/coordinator.go
+++ b/pkg/upload/coordinator.go
@@ -250,7 +250,8 @@ func (c *coordinator) finishUpload(ctx context.Context, session Session) (*provi
 		return nil, err
 	}
 
-	if c.async && session.Size() > 0 {
+	// Without a publisher there is nothing to hand the bytes to, so commit inline.
+	if c.async && c.pub != nil && session.Size() > 0 {
 		if err := c.publishBytesReceived(ctx, session); err != nil {
 			c.rollbackPrepared(ctx, session, session.SizeDiff())
 			return nil, err

--- a/pkg/upload/coordinator.go
+++ b/pkg/upload/coordinator.go
@@ -392,9 +392,7 @@ func (c *coordinator) rollbackMarked(ctx context.Context, session Session) {
 			appctx.GetLogger(ctx).Error().Err(err).Str("uploadid", session.ID()).Msg("could not roll back upload")
 		}
 	}
-	if err := c.fs.MarkProcessing(ctx, &ref, false, session.ID()); err != nil {
-		appctx.GetLogger(ctx).Error().Err(err).Str("uploadid", session.ID()).Msg("could not unmark processing")
-	}
+	c.unmarkProcessing(ctx, session, &ref)
 	metrics.UploadProcessing.Dec()
 	session.Cleanup(ctx, true, true)
 }
@@ -407,11 +405,24 @@ func (c *coordinator) rollbackPrepared(ctx context.Context, session Session, siz
 	if err := c.fs.RollbackUpload(ctx, &ref, session.ID(), session.NodeExists(), sizeDiff); err != nil {
 		appctx.GetLogger(ctx).Error().Err(err).Str("uploadid", session.ID()).Msg("could not roll back upload")
 	}
-	if err := c.fs.MarkProcessing(ctx, &ref, false, session.ID()); err != nil {
-		appctx.GetLogger(ctx).Error().Err(err).Str("uploadid", session.ID()).Msg("could not unmark processing")
-	}
+	c.unmarkProcessing(ctx, session, &ref)
 	metrics.UploadProcessing.Dec()
 	session.Cleanup(ctx, true, true)
+}
+
+// unmarkProcessing clears the processing flag, tolerating a node the rollback
+// already purged.
+func (c *coordinator) unmarkProcessing(ctx context.Context, session Session, ref *provider.Reference) {
+	err := c.fs.MarkProcessing(ctx, ref, false, session.ID())
+	log := appctx.GetLogger(ctx).With().Str("uploadid", session.ID()).Logger()
+	switch err.(type) {
+	case nil:
+	case errtypes.IsNotFound:
+		// RollbackUpload purged the node this upload created.
+		log.Debug().Err(err).Msg("could not unmark processing")
+	default:
+		log.Error().Err(err).Msg("could not unmark processing")
+	}
 }
 
 // uploadInfo collects what the driver needs to write the node metadata. The

--- a/pkg/upload/coordinator.go
+++ b/pkg/upload/coordinator.go
@@ -141,10 +141,6 @@ func (c *coordinator) applyRequestMetadata(session Session, metadata map[string]
 	}
 	session.SetMetadata("mtime", mtime)
 
-	if metadata == nil {
-		return nil
-	}
-
 	session.SetMetadata("providerID", metadata["providerID"])
 	if v, ok := metadata["expires"]; ok && v != "null" {
 		session.SetMetadata("expires", v)

--- a/pkg/upload/coordinator.go
+++ b/pkg/upload/coordinator.go
@@ -37,8 +37,6 @@ type Coordinator interface {
 	Upload(ctx context.Context, req storage.UploadRequest, uff storage.UploadFinishedFunc) (*provider.ResourceInfo, error)
 }
 
-var _ Coordinator = (*coordinator)(nil)
-
 // coordinator is the concrete implementation of Coordinator.
 type coordinator struct {
 	fs           storage.FS

--- a/pkg/upload/coordinator.go
+++ b/pkg/upload/coordinator.go
@@ -3,17 +3,21 @@ package upload
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	user "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	"github.com/google/uuid"
 	tusd "github.com/tus/tusd/v2/pkg/handler"
 
 	"github.com/owncloud/reva/v2/pkg/appctx"
 	ctxpkg "github.com/owncloud/reva/v2/pkg/ctx"
 	"github.com/owncloud/reva/v2/pkg/errtypes"
 	"github.com/owncloud/reva/v2/pkg/events"
+	"github.com/owncloud/reva/v2/pkg/rhttp/datatx/metrics"
 	"github.com/owncloud/reva/v2/pkg/storage"
 	"github.com/owncloud/reva/v2/pkg/storage/utils/chunking"
 	"github.com/owncloud/reva/v2/pkg/utils"
@@ -50,6 +54,471 @@ func NewCoordinator(fs storage.FS, store SessionStore, chunkFolder string, pub e
 		c.chunkHandler = chunking.NewChunkHandler(chunkFolder)
 	}
 	return c
+}
+
+// InitiateUpload resolves the target, then creates and persists the session that
+// bytes are appended to.
+func (c *coordinator) InitiateUpload(ctx context.Context, ref *provider.Reference, uploadLength int64, metadata map[string]string) (map[string]string, error) {
+	t, err := c.resolveTarget(ctx, ref, uploadLength, metadata)
+	if err != nil {
+		return nil, err
+	}
+
+	session := c.store.New(ctx)
+	if err := c.populateSession(ctx, session, t, uploadLength, metadata); err != nil {
+		return nil, err
+	}
+
+	// TODO: main wraps this in the posix usermapper's base scope (upload.go:316),
+	// which is not reachable from a driver-agnostic package.
+	if err := session.TouchBin(); err != nil {
+		return nil, fmt.Errorf("coordinator: could not create bin file: %w", err)
+	}
+	if err := session.Persist(ctx); err != nil {
+		session.Cleanup(ctx, true, true)
+		return nil, fmt.Errorf("coordinator: could not persist session: %w", err)
+	}
+
+	metrics.UploadSessionsInitiated.Inc()
+
+	// A zero-length upload has no bytes to append, so finish it here.
+	if uploadLength == 0 {
+		if _, err := c.finishUpload(ctx, session); err != nil {
+			return nil, err
+		}
+	}
+
+	return map[string]string{
+		"simple": session.ID(),
+		"tus":    session.ID(),
+	}, nil
+}
+
+// populateSession writes the resolved target and the request's metadata into a
+// new session.
+func (c *coordinator) populateSession(ctx context.Context, session Session, t *uploadTarget, uploadLength int64, metadata map[string]string) error {
+	session.SetMetadata("filename", t.name)
+	session.SetStorageValue("NodeName", t.name)
+	session.SetMetadata("dir", t.dir)
+	session.SetStorageValue("Dir", t.dir)
+	session.SetStorageValue("SpaceRoot", t.spaceID)
+	session.SetStorageValue("NodeParentId", t.parentID)
+
+	if t.exists {
+		session.SetStorageValue("NodeId", t.nodeID)
+		session.SetStorageValue("NodeExists", "true")
+	} else {
+		// A new file has no id yet, so mint a placeholder TouchFile replaces.
+		session.SetStorageValue("NodeId", uuid.New().String())
+	}
+
+	if t.spaceOwner != nil {
+		session.SetStorageValue("SpaceOwnerOrManager", t.spaceOwner.GetOpaqueId())
+		session.SetStorageValue("SpaceOwnerIdp", t.spaceOwner.GetIdp())
+		session.SetStorageValue("SpaceOwnerType", utils.UserTypeToString(t.spaceOwner.GetType()))
+	}
+	if t.chunkName != "" {
+		session.SetStorageValue("Chunk", t.chunkName)
+	}
+
+	// The ctx is gone by the time the bytes arrive, so record the actor now.
+	session.SetExecutant(ctxpkg.ContextMustGetUser(ctx))
+	lockID, _ := ctxpkg.ContextGetLockID(ctx)
+	session.SetMetadata("lockid", lockID)
+	initiatorID, _ := ctxpkg.ContextGetInitiator(ctx)
+	session.SetMetadata("initiatorid", initiatorID)
+
+	session.SetSize(uploadLength)
+
+	// TODO: main also copies CtxKeySpaceGID for posix uid/gid scoping
+	// (upload.go:188), which lives in the decomposedfs package.
+
+	return c.applyRequestMetadata(session, metadata)
+}
+
+// applyRequestMetadata stores the client's upload metadata, rejecting a malformed
+// checksum. Conditional headers are only recorded, and evaluated at finish.
+func (c *coordinator) applyRequestMetadata(session Session, metadata map[string]string) error {
+	mtime, ok := metadata["mtime"]
+	if !ok || mtime == "null" {
+		mtime = utils.TimeToOCMtime(time.Now())
+	}
+	session.SetMetadata("mtime", mtime)
+
+	if metadata == nil {
+		return nil
+	}
+
+	session.SetMetadata("providerID", metadata["providerID"])
+	if v, ok := metadata["expires"]; ok && v != "null" {
+		session.SetMetadata("expires", v)
+	}
+	if _, ok := metadata["sizedeferred"]; ok {
+		session.SetSizeIsDeferred(true)
+	}
+	for _, key := range []string{"if-match", "if-none-match", "if-unmodified-since"} {
+		if v := metadata[key]; v != "" {
+			session.SetMetadata(key, v)
+		}
+	}
+
+	checksum, ok := metadata["checksum"]
+	if !ok {
+		return nil
+	}
+	parts := strings.SplitN(checksum, " ", 2)
+	if len(parts) != 2 {
+		return errtypes.BadRequest("invalid checksum format. must be '[algorithm] [checksum]'")
+	}
+	switch parts[0] {
+	case "sha1", "md5", "adler32":
+		session.SetMetadata("checksum", checksum)
+	default:
+		return errtypes.BadRequest("unsupported checksum algorithm: " + parts[0])
+	}
+	return nil
+}
+
+// finishUpload creates the node, validates the staged bytes and commits them, or
+// hands them to postprocessing.
+func (c *coordinator) finishUpload(ctx context.Context, session Session) (*provider.ResourceInfo, error) {
+	if err := c.touchNode(ctx, session); err != nil {
+		return nil, err
+	}
+	if err := c.markProcessing(ctx, session); err != nil {
+		return nil, err
+	}
+	if err := verifyAndStoreChecksums(ctx, session); err != nil {
+		c.rollbackMarked(ctx, session)
+		return nil, err
+	}
+
+	metrics.UploadSessionsBytesReceived.Inc()
+
+	if err := c.prepare(ctx, session); err != nil {
+		return nil, err
+	}
+
+	if c.async && session.Size() > 0 {
+		if err := c.publishBytesReceived(ctx, session); err != nil {
+			c.rollbackPrepared(ctx, session, session.SizeDiff())
+			return nil, err
+		}
+		// The node stays flagged and the staged bytes are kept: postprocessing needs
+		// both to finish later.
+		return c.uploadedResourceInfo(ctx, session), nil
+	}
+
+	return c.finishSync(ctx, session)
+}
+
+// publishBytesReceived hands the staged upload to postprocessing, which downloads
+// the bytes from a signed URL to scan them before they are committed.
+func (c *coordinator) publishBytesReceived(ctx context.Context, session Session) error {
+	url, err := session.URL(ctx)
+	if err != nil {
+		return err
+	}
+
+	return events.Publish(ctx, c.pub, events.BytesReceived{
+		UploadID:      session.ID(),
+		URL:           url,
+		SpaceOwner:    session.SpaceOwner(),
+		ExecutingUser: session.ExecutantUser(),
+		ResourceID: &provider.ResourceId{
+			StorageId: session.ProviderID(),
+			SpaceId:   session.SpaceID(),
+			OpaqueId:  session.NodeID(),
+		},
+		Filename:          session.Filename(),
+		Filesize:          uint64(session.Size()),
+		ImpersonatingUser: impersonatingUser(ctx),
+	})
+}
+
+// touchNode creates the node a new file's upload writes to.
+func (c *coordinator) touchNode(ctx context.Context, session Session) error {
+	if session.NodeExists() {
+		return nil
+	}
+
+	// The node has no id yet, so address it as a named child of its parent.
+	pathRef := &provider.Reference{
+		ResourceId: &provider.ResourceId{
+			SpaceId:  session.SpaceID(),
+			OpaqueId: session.NodeParentID(),
+		},
+		Path: session.Filename(),
+	}
+	// MarkProcessing is the coordinator's own call, hence false here.
+	result, err := c.fs.TouchFile(ctx, pathRef, false, session.Metadata()["mtime"])
+	if err != nil {
+		session.Cleanup(ctx, true, true)
+		if _, ok := err.(errtypes.IsNotFound); ok {
+			// The parent went away, or the share was revoked, while bytes were in flight.
+			return errtypes.PreconditionFailed(err.Error())
+		}
+		return err
+	}
+
+	// Replaces the placeholder minted at initiate.
+	session.SetStorageValue("NodeId", result.ResourceID.GetOpaqueId())
+	session.SetStorageValue("SpaceRoot", result.SpaceID)
+	if result.SpaceOwner != nil {
+		session.SetStorageValue("SpaceOwnerOrManager", result.SpaceOwner.GetOpaqueId())
+		session.SetStorageValue("SpaceOwnerIdp", result.SpaceOwner.GetIdp())
+		session.SetStorageValue("SpaceOwnerType", utils.UserTypeToString(result.SpaceOwner.GetType()))
+	}
+	return nil
+}
+
+// markProcessing flags the node as being processed, so clients do not read it
+// before its bytes are committed.
+func (c *coordinator) markProcessing(ctx context.Context, session Session) error {
+	ref := session.Reference()
+	if err := c.fs.MarkProcessing(ctx, &ref, true, session.ID()); err != nil {
+		// Never marked, so there is nothing to unmark.
+		session.Cleanup(ctx, true, true)
+		c.deleteTouchedNode(ctx, session, &ref)
+		return err
+	}
+	metrics.UploadProcessing.Inc()
+
+	// The real node id from touchNode must reach the commit, which may run in
+	// another process.
+	if err := session.Persist(ctx); err != nil {
+		c.rollbackMarked(ctx, session)
+		return err
+	}
+	return nil
+}
+
+// deleteTouchedNode removes a node this upload created, for the one path where the
+// mark itself failed so RollbackUpload has no processing id to key off.
+func (c *coordinator) deleteTouchedNode(ctx context.Context, session Session, ref *provider.Reference) {
+	if session.NodeExists() {
+		return
+	}
+	// Delete is permission-gated, so an Uploader-only role may leave the empty file behind.
+	if _, err := c.fs.Delete(ctx, ref); err != nil {
+		appctx.GetLogger(ctx).Error().Err(err).Str("uploadid", session.ID()).Msg("could not delete node after failed upload")
+	}
+}
+
+// prepare has the driver write the node metadata and snapshot the previous
+// version, ahead of the commit that writes the bytes.
+func (c *coordinator) prepare(ctx context.Context, session Session) error {
+	ref := session.Reference()
+
+	info, err := uploadInfo(session)
+	if err != nil {
+		c.rollbackMarked(ctx, session)
+		return err
+	}
+
+	// A failed PrepareUpload has already undone its own writes.
+	prepared, err := c.fs.PrepareUpload(ctx, &ref, session.ID(), info)
+	if err != nil {
+		c.rollbackMarked(ctx, session)
+		return err
+	}
+
+	// Persisted, not just held: the commit may run in another process, which can
+	// only learn these by reading them back.
+	session.SetSizeDiff(prepared.SizeDiff)
+	session.SetVersionCreated(prepared.VersionCreated)
+	if err := session.Persist(ctx); err != nil {
+		c.rollbackPrepared(ctx, session, prepared.SizeDiff)
+		return err
+	}
+	return nil
+}
+
+// rollbackMarked undoes a finish that failed before PrepareUpload ran, so there is
+// no revision to revert and nothing was propagated.
+func (c *coordinator) rollbackMarked(ctx context.Context, session Session) {
+	ref := session.Reference()
+	if !session.NodeExists() {
+		// Before unmarking: RollbackUpload keys off the processing id.
+		if err := c.fs.RollbackUpload(ctx, &ref, session.ID(), false, 0); err != nil {
+			appctx.GetLogger(ctx).Error().Err(err).Str("uploadid", session.ID()).Msg("could not roll back upload")
+		}
+	}
+	if err := c.fs.MarkProcessing(ctx, &ref, false, session.ID()); err != nil {
+		appctx.GetLogger(ctx).Error().Err(err).Str("uploadid", session.ID()).Msg("could not unmark processing")
+	}
+	metrics.UploadProcessing.Dec()
+	session.Cleanup(ctx, true, true)
+}
+
+// rollbackPrepared undoes a finish that failed after PrepareUpload succeeded.
+func (c *coordinator) rollbackPrepared(ctx context.Context, session Session, sizeDiff int64) {
+	ref := session.Reference()
+	// Before unmarking: RollbackUpload keys off the processing id to confirm the
+	// node is still this upload's.
+	if err := c.fs.RollbackUpload(ctx, &ref, session.ID(), session.NodeExists(), sizeDiff); err != nil {
+		appctx.GetLogger(ctx).Error().Err(err).Str("uploadid", session.ID()).Msg("could not roll back upload")
+	}
+	if err := c.fs.MarkProcessing(ctx, &ref, false, session.ID()); err != nil {
+		appctx.GetLogger(ctx).Error().Err(err).Str("uploadid", session.ID()).Msg("could not unmark processing")
+	}
+	metrics.UploadProcessing.Dec()
+	session.Cleanup(ctx, true, true)
+}
+
+// uploadInfo collects what the driver needs to write the node metadata. The
+// preconditions are re-checked there, because the resource may have changed while
+// the bytes were being uploaded.
+func uploadInfo(session Session) (storage.UploadInfo, error) {
+	md := session.Metadata()
+	info := storage.UploadInfo{
+		NodeExisted: session.NodeExists(),
+		Size:        session.Size(),
+		Checksums:   session.Checksums(),
+		IfMatch:     md["if-match"],
+		IfNoneMatch: md["if-none-match"],
+	}
+	if v := md["mtime"]; v != "" {
+		mtime, err := utils.MTimeToTime(v)
+		if err != nil {
+			return info, errtypes.BadRequest("coordinator: invalid mtime: " + v)
+		}
+		info.MTime = mtime
+	}
+	if v := md["if-unmodified-since"]; v != "" {
+		ius, err := time.Parse(time.RFC3339Nano, v)
+		if err != nil {
+			return info, errtypes.BadRequest("coordinator: invalid if-unmodified-since: " + v)
+		}
+		info.IfUnmodifiedSince = ius
+	}
+	return info, nil
+}
+
+// verifyAndStoreChecksums hashes the staged bytes, checks them against the
+// checksum the client announced, and stores them for the commit.
+func verifyAndStoreChecksums(ctx context.Context, session Session) error {
+	sha1h, md5h, adler32h, err := calculateChecksums(ctx, session.BinPath())
+	if err != nil {
+		return err
+	}
+
+	// The announced checksum is not in Metadata(), so read the raw info.
+	info, err := session.GetInfo(ctx)
+	if err != nil {
+		return err
+	}
+	if checksum := info.MetaData["checksum"]; checksum != "" {
+		parts := strings.SplitN(checksum, " ", 2)
+		if len(parts) != 2 {
+			return errtypes.BadRequest("invalid checksum format. must be '[algorithm] [checksum]'")
+		}
+		var checkErr error
+		switch parts[0] {
+		case "sha1":
+			checkErr = checkHash(parts[1], sha1h)
+		case "md5":
+			checkErr = checkHash(parts[1], md5h)
+		case "adler32":
+			checkErr = checkHash(parts[1], adler32h)
+		default:
+			checkErr = errtypes.BadRequest("unsupported checksum algorithm: " + parts[0])
+		}
+		if checkErr != nil {
+			return checkErr
+		}
+	}
+
+	session.SetChecksums(sha1h.Sum(nil), md5h.Sum(nil), adler32h.Sum(nil))
+	return nil
+}
+
+// finishSync commits the staged bytes, then unmarks processing and cleans up.
+func (c *coordinator) finishSync(ctx context.Context, session Session) (*provider.ResourceInfo, error) {
+	ref := session.Reference()
+
+	f, err := os.Open(session.BinPath())
+	if err != nil {
+		c.rollbackPrepared(ctx, session, session.SizeDiff())
+		return nil, err
+	}
+	// The verdict rides along with the bytes, so a committed blob always carries
+	// the one it was cleared under. Empty on the inline path, which never scans.
+	scanResult, scanDate := session.ScanData()
+
+	// CommitUpload does not own the body; we opened it, so we close it.
+	err = c.fs.CommitUpload(ctx, &ref, session.ID(), storage.UploadSource{
+		Body:       f,
+		Length:     session.Size(),
+		ScanResult: scanResult,
+		ScanDate:   scanDate,
+	})
+	f.Close()
+	if err != nil {
+		c.rollbackPrepared(ctx, session, session.SizeDiff())
+		return nil, err
+	}
+
+	if err := c.fs.MarkProcessing(ctx, &ref, false, session.ID()); err != nil {
+		appctx.GetLogger(ctx).Error().Err(err).Str("uploadid", session.ID()).Msg("could not unmark processing")
+	}
+	metrics.UploadProcessing.Dec()
+	session.Cleanup(ctx, true, true)
+	metrics.UploadSessionsFinalized.Inc()
+
+	ri := c.uploadedResourceInfo(ctx, session)
+	c.publishUploadReady(ctx, session, ri)
+	return ri, nil
+}
+
+// uploadedResourceInfo describes the uploaded resource for the caller, which turns
+// it into PUT response headers.
+//
+// TODO: the fallback carries no etag, which a write-only share used to get.
+// Returning it through the seam is the proper fix.
+func (c *coordinator) uploadedResourceInfo(ctx context.Context, session Session) *provider.ResourceInfo {
+	ref := session.Reference()
+	// The driver owns the resulting etag and mtime, so read them back.
+	ri, err := c.fs.GetMD(ctx, &ref, nil, nil)
+	if err == nil {
+		// Drivers do not know their own mount id and the dataprovider does not stamp
+		// it, so an unstamped id would not resolve for the client.
+		if ri.GetId().GetStorageId() == "" {
+			ri.Id.StorageId = session.ProviderID()
+		}
+		return ri
+	}
+
+	// GetMD is permission-gated, so a write-only share cannot stat what it just
+	// uploaded. That must not fail the upload.
+	appctx.GetLogger(ctx).Debug().Err(err).Str("uploadid", session.ID()).Msg("could not stat uploaded resource")
+	fallback := &provider.ResourceInfo{Id: ref.GetResourceId(), Size: uint64(session.Size())}
+	if mtime, mErr := utils.MTimeToTime(session.Metadata()["mtime"]); mErr == nil {
+		fallback.Mtime = utils.TimeToTS(mtime)
+	}
+	return fallback
+}
+
+// publishUploadReady announces that the file is available. Consumers such as the
+// search indexer only listen for UploadReady, so without it they would never learn
+// about an upload the coordinator committed inline.
+func (c *coordinator) publishUploadReady(ctx context.Context, session Session, ri *provider.ResourceInfo) {
+	if c.pub == nil {
+		return
+	}
+	if err := events.Publish(ctx, c.pub, events.UploadReady{
+		UploadID:          session.ID(),
+		Filename:          session.Filename(),
+		SpaceOwner:        session.SpaceOwner(),
+		ExecutingUser:     session.ExecutantUser(),
+		FileRef:           c.uploadRef(session),
+		ResourceID:        ri.GetId(),
+		Timestamp:         utils.TSNow(),
+		IsVersion:         session.VersionCreated(),
+		ImpersonatingUser: impersonatingUser(ctx),
+	}); err != nil {
+		appctx.GetLogger(ctx).Error().Err(err).Str("uploadid", session.ID()).Msg("failed to publish UploadReady event")
+	}
 }
 
 // uploadTarget is what an upload needs to know about its destination

--- a/pkg/upload/tus_adapter.go
+++ b/pkg/upload/tus_adapter.go
@@ -9,6 +9,7 @@ import (
 
 	tusd "github.com/tus/tusd/v2/pkg/handler"
 
+	"github.com/owncloud/reva/v2/pkg/appctx"
 	"github.com/owncloud/reva/v2/pkg/errtypes"
 )
 
@@ -61,15 +62,19 @@ func (u *tusAdapter) FinishUpload(ctx context.Context) error {
 
 // Terminate discards an upload, so a cancelled one leaves nothing behind.
 func (u *tusAdapter) Terminate(ctx context.Context) error {
-	// Terminate can run before the node was created.
 	ref := u.session.Reference()
-	if ref.GetResourceId().GetOpaqueId() == "" {
-		u.session.Cleanup(ctx, true, true)
-		return nil
+
+	// Rollback rather than Delete, which is permission-gated. It is a no-op unless
+	// this upload still owns the node.
+	if err := u.coord.fs.RollbackUpload(ctx, &ref, u.session.ID(), u.session.NodeExists(), u.session.SizeDiff()); err != nil {
+		appctx.GetLogger(ctx).Error().Err(err).Str("uploadid", u.session.ID()).Msg("could not roll back terminated upload")
+	}
+	// A node that was never created cannot be unmarked, which is the normal case here.
+	if err := u.coord.fs.MarkProcessing(ctx, &ref, false, u.session.ID()); err != nil {
+		appctx.GetLogger(ctx).Debug().Err(err).Str("uploadid", u.session.ID()).Msg("could not unmark terminated upload")
 	}
 
-	// Rollback rather than Delete, which is permission-gated.
-	u.coord.rollbackMarked(ctx, u.session)
+	u.session.Cleanup(ctx, true, true)
 	return nil
 }
 

--- a/pkg/upload/tus_adapter.go
+++ b/pkg/upload/tus_adapter.go
@@ -1,0 +1,143 @@
+package upload
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	tusd "github.com/tus/tusd/v2/pkg/handler"
+
+	"github.com/owncloud/reva/v2/pkg/errtypes"
+)
+
+var errNotImplemented = tusd.NewError("ERR_NOT_IMPLEMENTED", "use InitiateUpload on the CS3 API to start a new upload", http.StatusNotImplemented)
+
+// tusAdapter adapts a single upload session to tusd's Upload interfaces.
+type tusAdapter struct {
+	session Session
+	coord   *coordinator
+}
+
+func (u *tusAdapter) GetInfo(ctx context.Context) (tusd.FileInfo, error) {
+	return u.session.GetInfo(ctx)
+}
+
+func (u *tusAdapter) GetReader(ctx context.Context) (io.ReadCloser, error) {
+	return u.session.GetReader(ctx)
+}
+
+func (u *tusAdapter) WriteChunk(ctx context.Context, offset int64, src io.Reader) (int64, error) {
+	return u.session.WriteChunk(ctx, offset, src)
+}
+
+// FinishUpload runs the coordinator's finish path once all bytes have arrived.
+func (u *tusAdapter) FinishUpload(ctx context.Context) error {
+	_, err := u.coord.finishUpload(u.session.Context(ctx), u.session)
+
+	// tusd answers an error type it does not recognise with a bare 500.
+	switch err.(type) {
+	case nil:
+		return nil
+	case errtypes.AlreadyExists:
+		return tusd.NewError("ERR_ALREADY_EXISTS", err.Error(), http.StatusConflict)
+	case errtypes.ResourceProcessing, errtypes.TooEarly:
+		return tusd.NewError("ERR_TOO_EARLY", err.Error(), http.StatusTooEarly)
+	case errtypes.Aborted:
+		return tusd.NewError("ERR_PRECONDITION_FAILED", err.Error(), http.StatusPreconditionFailed)
+	case errtypes.PreconditionFailed:
+		return tusd.NewError("ERR_PRECONDITION_FAILED", err.Error(), http.StatusMethodNotAllowed)
+	case errtypes.Locked:
+		return tusd.NewError("ERR_LOCKED", err.Error(), http.StatusLocked)
+	case errtypes.BadRequest:
+		return tusd.NewError("ERR_BAD_REQUEST", err.Error(), http.StatusBadRequest)
+	case errtypes.ChecksumMismatch:
+		return tusd.NewError("ERR_CHECKSUM_MISMATCH", err.Error(), errtypes.StatusChecksumMismatch)
+	default:
+		return err
+	}
+}
+
+// Terminate discards an upload, so a cancelled one leaves nothing behind.
+func (u *tusAdapter) Terminate(ctx context.Context) error {
+	// Terminate can run before the node was created.
+	ref := u.session.Reference()
+	if ref.GetResourceId().GetOpaqueId() == "" {
+		u.session.Cleanup(ctx, true, true)
+		return nil
+	}
+
+	// Rollback rather than Delete, which is permission-gated.
+	u.coord.rollbackMarked(ctx, u.session)
+	return nil
+}
+
+// DeclareLength records the total size for uploads initiated without one.
+func (u *tusAdapter) DeclareLength(ctx context.Context, length int64) error {
+	u.session.SetSize(length)
+	u.session.SetSizeIsDeferred(false)
+	return u.session.Persist(ctx)
+}
+
+// ConcatUploads appends the staged bytes of the partial uploads, in the order given.
+func (u *tusAdapter) ConcatUploads(ctx context.Context, partials []tusd.Upload) error {
+	file, err := os.OpenFile(u.session.BinPath(), os.O_WRONLY|os.O_APPEND, defaultFilePerm)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	for _, partial := range partials {
+		p, ok := partial.(*tusAdapter)
+		if !ok {
+			return fmt.Errorf("coordinator: unexpected partial upload type %T", partial)
+		}
+		src, err := p.session.GetReader(ctx)
+		if err != nil {
+			return err
+		}
+		_, copyErr := io.Copy(file, src)
+		src.Close()
+		if copyErr != nil {
+			return copyErr
+		}
+	}
+	return nil
+}
+
+// UseIn registers the coordinator as tusd's data store, in place of the driver's own.
+func (c *coordinator) UseIn(composer *tusd.StoreComposer) {
+	composer.UseCore(c)
+	composer.UseTerminater(c)
+	composer.UseConcater(c)
+	composer.UseLengthDeferrer(c)
+}
+
+// NewUpload is unsupported: uploads always start through the CS3 InitiateUpload call.
+func (c *coordinator) NewUpload(_ context.Context, _ tusd.FileInfo) (tusd.Upload, error) {
+	return nil, errNotImplemented
+}
+
+// GetUpload wraps the session with the given id for the TUS data path.
+func (c *coordinator) GetUpload(ctx context.Context, id string) (tusd.Upload, error) {
+	session, err := c.store.Get(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return &tusAdapter{session: session, coord: c}, nil
+}
+
+// The As* methods let tusd reach the extension interfaces on a plain tusd.Upload.
+
+func (c *coordinator) AsTerminatableUpload(up tusd.Upload) tusd.TerminatableUpload {
+	return up.(*tusAdapter)
+}
+
+func (c *coordinator) AsLengthDeclarableUpload(up tusd.Upload) tusd.LengthDeclarableUpload {
+	return up.(*tusAdapter)
+}
+
+func (c *coordinator) AsConcatableUpload(up tusd.Upload) tusd.ConcatableUpload {
+	return up.(*tusAdapter)
+}


### PR DESCRIPTION
Adds the driver-agnostic upload coordinator: `pkg/upload/coordinator.go` (886) and
`pkg/upload/tus_adapter.go` (148). Specs are in a separate PR against this branch, so this
diff stays readable; they should land together.

**Dormant.** Nothing outside `pkg/upload` imports the package yet — PR 7 wires it
into the dataprovider. Merging this cannot change runtime behaviour, which is why
the divergences below are safe to land and settle in review rather than block on.

## What it does

Three phases, because the HTTP context is gone by the time the bytes are committed:

1. `InitiateUpload` resolves the target, checks quota and locks, and persists a
   session.
2. Transport: `Upload` for PUT, `tusAdapter.WriteChunk` for TUS.
3. `finishUpload` touches the node, marks it processing, verifies checksums,
   prepares, then either commits inline or hands off to postprocessing.

The driver seam is 11 `storage.FS` methods: `GetMD`, `GetLock`, `GetQuota`,
`GetPathByID`, `ListGrants`, `TouchFile`, `MarkProcessing`, `PrepareUpload`,
`CommitUpload`, `RollbackUpload`, `Delete`.

## Cleanup, and why the orderings differ

Three paths, deliberately not collapsed into one:

| path | when | what it does |
|---|---|---|
| `deleteTouchedNode` | the mark itself failed | `Delete` — there is no processing id for `RollbackUpload` to key off |
| `rollbackMarked` | failed before `PrepareUpload` | `RollbackUpload` with `sizeDiff 0`, then unmark |
| `rollbackPrepared` | failed after `PrepareUpload` | `RollbackUpload` with the propagated `sizeDiff`, then unmark |

Both rollbacks call `RollbackUpload` **before** the unmark, because it keys off the
processing id (`decomposedfs/upload.go:664-670`). `deleteTouchedNode` runs only
**after** a failed mark, so the node is unflagged and `Delete`'s
processing-refusal (`decomposedfs.go:1121`) does not bite. The orderings are
opposite on purpose.

`tusAdapter.Terminate` duplicates ~8 lines rather than reuse `rollbackMarked`.
Sharing them was the original bug: `rollbackMarked` hardcodes `sizeDiff 0` and
decrements the processing gauge, both wrong for a cancelled transfer. A client
cancelling after `PrepareUpload` leaked the propagated size, and every cancelled
upload drove `reva_upload_processing` negative. The two callers have genuinely
different preconditions.

## Declared divergences from main

- **`checkQuota` proceeds when `GetQuota` errors** (`coordinator.go:650`). Main used
  `node.CheckQuota`, which propagates. The permissive form is deliberate — drivers
  without quota support must not be blocked — but it is a behaviour change, stated
  here rather than hidden.
- **`describeExisting` check order** and the **dropped `Persist`** between checksum
  verification and `prepare`.
- **`uploadRef` reuse in `uff`.**
- **Two TODOs** marking known gaps: the write-only-share etag fallback
  (`coordinator.go:532`) and deny-grant `NotFound` (`:606`), where `GetMD` reports a file
  hidden by a deny-grant as missing, so the upload fails late with 409 instead of 403.

## Inherited from main, not introduced

- **`sizedeferred` + `uploadLength == 0`.** A third-party copy sends
  `sizedeferred: true` and no `Upload-Length`, so the zero-length branch finishes it
  with no bytes. Main has the identical shape at `decomposedfs/upload.go:331-337`.
  Faithful parity — flagging it so it does not read as a porting mistake.
- **The zero-length path returns ids for an already-deleted session.** Same as main.
- **`chunking.GetChunkBLOBInfo`'s latent panic** is pre-existing and unreachable from
  here.

## Fixes made during self-review

- `Terminate` no longer decrements the processing gauge or passes `sizeDiff 0`, and
  logs the expected unmark failure at Debug rather than Error — it was Error on every
  cancelled upload.
- The async gate regained main's second condition: `c.async && c.pub != nil`. Main
  gates publish and commit on two independent conditions; collapsing them meant a
  deployment with async on but no publisher wired hit a nil-interface panic in the
  request path instead of committing inline.
- Dropped the `Coordinator` interface assertion — unneeded until PR 7, and the idiom
  appears nowhere else in the repo.

## Fixes from review

- the placeholder node id is documented rather than removed. An empty `OpaqueId` resolves to
  the space root (`lookup.go:191`) and `Terminate` can run before `TouchFile`, so rollback
  and unmark would target the root instead of missing. It only has to match nothing.
- the expected unmark failure after a rollback logs at Debug, not Error. `RollbackUpload`
  purges a node the upload created (`decomposedfs/upload.go:676`), so the unmark that follows
  correctly finds no node and returns `NotFound` (`:352`) — every failed upload of a new file
  was logging an error for the expected outcome. Demoted, not dropped. The unmark after a
  *successful* commit stays at Error, where a missing node is genuinely unexpected.
- dropped a dead nil-metadata guard.

## Tests

233 Ginkgo specs, on `OCISDEV-900-pr6b-specs` and opened against this branch.
`coordinator.go` and `tus_adapter.go` at 100% statement coverage, package at 99.5%; the three
uncovered statements are unreachable (NFS `ESTALE`, a `tusd.FileInfo` that cannot fail to
marshal, HMAC signing that cannot fail on a `[]byte` key). Verified by mutation testing rather
than coverage alone: ~33 injected bugs, all killed.

The specs cover the async fork, which had none before, and the `UploadProcessing` gauge, which
had none anywhere.

Re-verified against the three review fixes above: all 233 still pass. Coverage dips to 97.6%,
the whole gap being `spaceOwnerOrManager`'s grant fallback (untestable while `fakeFS` has no
`ListGrants`) and `unmarkProcessing`'s new `NotFound` branch.

## Not addressed here

`finishSync` destroys the session when the commit fails, which is right for a waiting client
but wrong for the async caller, which wants the upload parked for `RestartPostprocessing`.
It only gets that second caller in the postprocessing PR, which splits the commit path in two.

No changelog — one goes in at the end of the coordinator stack, not per PR.
