### PR TITLE
fix: answer a denied TUS upload with 403, not 500

### DIFF
--- a/pkg/upload/tus_adapter.go
+++ b/pkg/upload/tus_adapter.go
@@ -55,6 +55,8 @@ func (u *tusAdapter) FinishUpload(ctx context.Context) error {
 		return tusd.NewError("ERR_BAD_REQUEST", err.Error(), http.StatusBadRequest)
 	case errtypes.ChecksumMismatch:
 		return tusd.NewError("ERR_CHECKSUM_MISMATCH", err.Error(), errtypes.StatusChecksumMismatch)
+	case errtypes.IsPermissionDenied:
+		return tusd.NewError("ERR_PERMISSION_DENIED", err.Error(), http.StatusForbidden)
 	default:
 		return err
 	}

--- a/pkg/upload/tus_adapter_test.go
+++ b/pkg/upload/tus_adapter_test.go
@@ -126,6 +126,7 @@ var _ = Describe("tusAdapter", func() {
 			Entry("locked", errtypes.Locked("lock-1"), "ERR_LOCKED", http.StatusLocked),
 			Entry("bad request", errtypes.BadRequest("invalid mtime"), "ERR_BAD_REQUEST", http.StatusBadRequest),
 			Entry("checksum mismatch", errtypes.ChecksumMismatch("sha1"), "ERR_CHECKSUM_MISMATCH", errtypes.StatusChecksumMismatch),
+			Entry("permission denied", errtypes.PermissionDenied("share was revoked"), "ERR_PERMISSION_DENIED", http.StatusForbidden),
 		)
 
 		It("passes an unmapped error through for tusd to answer with a 500", func() {


### PR DESCRIPTION
A revoked share mid-upload made the TUS client see a 500.

`TouchFile` refuses an upload the user may not perform. When the caller can still
stat the node it returns `PermissionDenied` (`decomposedfs.go:858`) rather than
`NotFound` — the case when a share is revoked while the transfer is in flight: the
sharee can read the file but no longer write it.

`finishUpload` propagates that error unchanged, and `FinishUpload`'s switch had no
case for it, so tusd fell through to the bare 500 it uses for error types it does not
recognise. The client saw a server fault for what is a permission answer, and retried
an upload that can never succeed.

The PUT path has always mapped it (`simple.go:146`). This maps it in the TUS adapter
too, using the interface form the rest of the repo uses for this error
(`download.go:272`, `spaces.go:459`) so a driver returning its own `PermissionDenied`
type is caught as well.

One Entry added to the existing `DescribeTable`; 234 specs pass. Reverting only the
two-line fix fails exactly that Entry, so the test is not vacuous.

Reported by @mklos-kw on #714, fix as proposed there.

No changelog — one goes in at the end of the coordinator stack, not per PR.
