### PR TITLE
fix: check against memberUid instead of posixGroup

### DIFF
--- a/pkg/utils/ldap/identity.go
+++ b/pkg/utils/ldap/identity.go
@@ -23,9 +23,9 @@ import (
 	"strings"
 
 	identityUser "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
-	"github.com/owncloud/reva/v2/pkg/errtypes"
 	"github.com/go-ldap/ldap/v3"
 	"github.com/google/uuid"
+	"github.com/owncloud/reva/v2/pkg/errtypes"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 )
@@ -329,8 +329,8 @@ func (i *Identity) IsLDAPUserInDisabledGroup(log *zerolog.Logger, lc ldap.Client
 func (i *Identity) GetLDAPUserGroups(log *zerolog.Logger, lc ldap.Client, userEntry *ldap.Entry) ([]string, error) {
 	var memberValue string
 
-	if strings.ToLower(i.Group.Objectclass) == "posixgroup" {
-		// posixGroup usually means that the member attribute just contains the username
+	if strings.ToLower(i.Group.Schema.Member) == "memberuid" {
+		// memberUid means that the member attribute just contains the username
 		memberValue = userEntry.GetEqualFoldAttributeValue(i.User.Schema.Username)
 	} else {
 		// In all other case we assume the member Attribute to contain full LDAP DNs
@@ -467,7 +467,7 @@ func (i *Identity) GetLDAPGroupMembers(log *zerolog.Logger, lc ldap.Client, grou
 	for _, member := range members {
 		var e *ldap.Entry
 		var err error
-		if strings.ToLower(i.Group.Objectclass) == "posixgroup" {
+		if strings.ToLower(i.Group.Schema.Member) == "memberuid" {
 			e, err = i.GetLDAPUserByAttribute(log, lc, "username", member)
 		} else {
 			e, err = i.GetLDAPUserByDN(log, lc, member)


### PR DESCRIPTION
posixGroup might be set up as an auxiliary class, and the oCIS configuration might target a structural class such as groupOfNames. This means that the memberUid attribute might appear in groups configured with groupsOfNames, not just with posixGroup.
We'll look for usernames if the group membership is configured as "memberUid" in oCIS regardless of the specific object class for groups.

-------

**NOTE**: In LDAP is possible to configure groups containing "member" and "memberUid" attributes at the same time, both of them targeting different users. However, oCIS is currently expecting only one group membership attribute.
In this scenario, it's expected that only the users in the configured oCIS' group membership attribute (either "member" or "memberUid") are shown, while the rest of users are ignored.